### PR TITLE
feat: add localStorage persistence to Zustand stores to prevent undefined state on refresh

### DIFF
--- a/store/useKanaKanjiStore.ts
+++ b/store/useKanaKanjiStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 export interface IKanjiObj {
   id: number;
@@ -32,74 +33,82 @@ interface IFormState {
   clearKanjiSets: () => void;
 }
 
-const useKanaKanjiStore = create<IFormState>(set => ({
-  // KANA
-  selectedGameModeKana: 'Pick',
-  kanaGroupIndices: [],
+const useKanaKanjiStore = create<IFormState>()(
+  persist(
+    (set) => ({
+      // KANA
+      selectedGameModeKana: 'Pick',
+      kanaGroupIndices: [],
 
-  setSelectedGameModeKana: gameMode => set({ selectedGameModeKana: gameMode }),
-  addKanaGroupIndex: kanaGroupIndex =>
-    set(state => ({
-      kanaGroupIndices: state.kanaGroupIndices.includes(kanaGroupIndex)
-        ? state.kanaGroupIndices.filter(index => index !== kanaGroupIndex) // Remove if present
-        : [...state.kanaGroupIndices, kanaGroupIndex] // Add if not present
-    })),
-  addKanaGroupIndices: kanaGroupIndices =>
-    set(state => ({
-      kanaGroupIndices: kanaGroupIndices.every(i =>
-        state.kanaGroupIndices.includes(i)
-      )
-        ? state.kanaGroupIndices.filter(i => !kanaGroupIndices.includes(i)) // Remove if present
-        : [...new Set([...state.kanaGroupIndices, ...kanaGroupIndices])]
-    })),
-
-  // KANJI
-  selectedGameModeKanji: 'Pick',
-  selectedKanjiObjs: [],
-  setSelectedGameModeKanji: gameMode =>
-    set({ selectedGameModeKanji: gameMode }),
-  addKanjiObj: kanjiObj =>
-    set(state => ({
-      selectedKanjiObjs: state.selectedKanjiObjs
-        .map(kanjiObj => kanjiObj.kanjiChar)
-        .includes(kanjiObj.kanjiChar)
-        ? state.selectedKanjiObjs.filter(
-            currentKanjiObj => currentKanjiObj.kanjiChar !== kanjiObj.kanjiChar
+      setSelectedGameModeKana: gameMode => set({ selectedGameModeKana: gameMode }),
+      addKanaGroupIndex: kanaGroupIndex =>
+        set(state => ({
+          kanaGroupIndices: state.kanaGroupIndices.includes(kanaGroupIndex)
+            ? state.kanaGroupIndices.filter(index => index !== kanaGroupIndex) // Remove if present
+            : [...state.kanaGroupIndices, kanaGroupIndex] // Add if not present
+        })),
+      addKanaGroupIndices: kanaGroupIndices =>
+        set(state => ({
+          kanaGroupIndices: kanaGroupIndices.every(i =>
+            state.kanaGroupIndices.includes(i)
           )
-        : [...state.selectedKanjiObjs, kanjiObj]
-    })),
-  addKanjiObjs: kanjiObjs =>
-    set(state => ({
-      selectedKanjiObjs: kanjiObjs.every(currentKanjiObj =>
-        state.selectedKanjiObjs
-          .map(currentKanjiObj => currentKanjiObj.kanjiChar)
-          .includes(currentKanjiObj.kanjiChar)
-      )
-        ? state.selectedKanjiObjs.filter(
-            currentKanjiObj =>
-              !kanjiObjs
-                .map(currentKanjiObj => currentKanjiObj.kanjiChar)
-                .includes(currentKanjiObj.kanjiChar)
+            ? state.kanaGroupIndices.filter(i => !kanaGroupIndices.includes(i)) // Remove if present
+            : [...new Set([...state.kanaGroupIndices, ...kanaGroupIndices])]
+        })),
+
+      // KANJI
+      selectedGameModeKanji: 'Pick',
+      selectedKanjiObjs: [],
+      setSelectedGameModeKanji: gameMode =>
+        set({ selectedGameModeKanji: gameMode }),
+      addKanjiObj: kanjiObj =>
+        set(state => ({
+          selectedKanjiObjs: state.selectedKanjiObjs
+            .map(kanjiObj => kanjiObj.kanjiChar)
+            .includes(kanjiObj.kanjiChar)
+            ? state.selectedKanjiObjs.filter(
+                currentKanjiObj => currentKanjiObj.kanjiChar !== kanjiObj.kanjiChar
+              )
+            : [...state.selectedKanjiObjs, kanjiObj]
+        })),
+      addKanjiObjs: kanjiObjs =>
+        set(state => ({
+          selectedKanjiObjs: kanjiObjs.every(currentKanjiObj =>
+            state.selectedKanjiObjs
+              .map(currentKanjiObj => currentKanjiObj.kanjiChar)
+              .includes(currentKanjiObj.kanjiChar)
           )
-        : [...new Set([...state.selectedKanjiObjs, ...kanjiObjs])]
-    })),
-  clearKanjiObjs: () => {
-    set(() => ({
-      selectedKanjiObjs: []
-    }));
-  },
+            ? state.selectedKanjiObjs.filter(
+                currentKanjiObj =>
+                  !kanjiObjs
+                    .map(currentKanjiObj => currentKanjiObj.kanjiChar)
+                    .includes(currentKanjiObj.kanjiChar)
+              )
+            : [...new Set([...state.selectedKanjiObjs, ...kanjiObjs])]
+        })),
+      clearKanjiObjs: () => {
+        set(() => ({
+          selectedKanjiObjs: []
+        }));
+      },
 
-  selectedKanjiCollection: 'n5',
-  setSelectedKanjiCollection: collection =>
-    set({ selectedKanjiCollection: collection }),
+      selectedKanjiCollection: 'n5',
+      setSelectedKanjiCollection: collection =>
+        set({ selectedKanjiCollection: collection }),
 
-  selectedKanjiSets: [],
-  setSelectedKanjiSets: sets => set({ selectedKanjiSets: sets }),
-  clearKanjiSets: () => {
-    set(() => ({
-      selectedKanjiSets: []
-    }));
-  }
-}));
+      selectedKanjiSets: [],
+      setSelectedKanjiSets: sets => set({ selectedKanjiSets: sets }),
+      clearKanjiSets: () => {
+        set(() => ({
+          selectedKanjiSets: []
+        }));
+      }
+    }),
+    {
+      name: 'kana-kanji-store',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);
 
 export default useKanaKanjiStore;

--- a/store/useVocabStore.ts
+++ b/store/useVocabStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 export interface IWordObj {
   word: string;
@@ -23,52 +24,60 @@ interface IFormState {
   clearVocabSets: () => void;
 }
 
-const useVocabStore = create<IFormState>(set => ({
-  selectedGameModeVocab: 'Pick',
-  selectedWordObjs: [],
-  setSelectedGameModeVocab: gameMode =>
-    set({ selectedGameModeVocab: gameMode }),
-  addWordObj: wordObj =>
-    set(state => ({
-      selectedWordObjs: state.selectedWordObjs
-        .map(wordObj => wordObj.word)
-        .includes(wordObj.word)
-        ? state.selectedWordObjs.filter(
-            currentWordObj => currentWordObj.word !== wordObj.word
+const useVocabStore = create<IFormState>()(
+  persist(
+    (set) => ({
+      selectedGameModeVocab: 'Pick',
+      selectedWordObjs: [],
+      setSelectedGameModeVocab: gameMode =>
+        set({ selectedGameModeVocab: gameMode }),
+      addWordObj: wordObj =>
+        set(state => ({
+          selectedWordObjs: state.selectedWordObjs
+            .map(wordObj => wordObj.word)
+            .includes(wordObj.word)
+            ? state.selectedWordObjs.filter(
+                currentWordObj => currentWordObj.word !== wordObj.word
+              )
+            : [...state.selectedWordObjs, wordObj]
+        })),
+      addWordObjs: wordObjs =>
+        set(state => ({
+          selectedWordObjs: wordObjs.every(currentWordObj =>
+            state.selectedWordObjs
+              .map(currentWordObj => currentWordObj.word)
+              .includes(currentWordObj.word)
           )
-        : [...state.selectedWordObjs, wordObj]
-    })),
-  addWordObjs: wordObjs =>
-    set(state => ({
-      selectedWordObjs: wordObjs.every(currentWordObj =>
-        state.selectedWordObjs
-          .map(currentWordObj => currentWordObj.word)
-          .includes(currentWordObj.word)
-      )
-        ? state.selectedWordObjs.filter(
-            currentWordObj =>
-              !wordObjs
-                .map(currentWordObj => currentWordObj.word)
-                .includes(currentWordObj.word)
-          )
-        : [...new Set([...state.selectedWordObjs, ...wordObjs])]
-    })),
-  clearWordObjs: () => {
-    set(() => ({
-      selectedWordObjs: []
-    }));
-  },
+            ? state.selectedWordObjs.filter(
+                currentWordObj =>
+                  !wordObjs
+                    .map(currentWordObj => currentWordObj.word)
+                    .includes(currentWordObj.word)
+              )
+            : [...new Set([...state.selectedWordObjs, ...wordObjs])]
+        })),
+      clearWordObjs: () => {
+        set(() => ({
+          selectedWordObjs: []
+        }));
+      },
 
-  selectedVocabCollection: 'n5',
-  setSelectedVocabCollection: collection =>
-    set({ selectedVocabCollection: collection }),
-  selectedVocabSets: [],
-  setSelectedVocabSets: sets => set({ selectedVocabSets: sets }),
-  clearVocabSets: () => {
-    set(() => ({
-      selectedVocabSets: []
-    }));
-  }
-}));
+      selectedVocabCollection: 'n5',
+      setSelectedVocabCollection: collection =>
+        set({ selectedVocabCollection: collection }),
+      selectedVocabSets: [],
+      setSelectedVocabSets: sets => set({ selectedVocabSets: sets }),
+      clearVocabSets: () => {
+        set(() => ({
+          selectedVocabSets: []
+        }));
+      }
+    }),
+    {
+      name: 'vocab-store',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);
 
 export default useVocabStore;


### PR DESCRIPTION
App state was lost when users refreshed the page.
User use to see error- Application error: a client-side exception has occurred while loading kanadojo.com (see the browser console for more information).
Poor user experience due to data not persisting between sessions

- Added Zustand `persist` middleware to `useVocabStore`  and `useKanaKanjiStore`
- Wrapped store with `createJSONStorage(() => localStorage)`
- State now automatically saves to and restores from localStorage
