### PR TITLE
Use more appropriate kanji labels for vocab and kanji tabs

### DIFF
--- a/components/MainMenu/index.tsx
+++ b/components/MainMenu/index.tsx
@@ -41,12 +41,12 @@ const MainMenu = () => {
     },
     {
       name_en: 'Vocabulary',
-      name_ja: '言',
+      name_ja: '語',
       href: '/vocabulary'
     },
     {
       name_en: 'Kanji',
-      name_ja: '出',
+      name_ja: '字',
       // name_ja: '間',
       href: '/kanji'
     }

--- a/components/reusable/Menu/Banner.tsx
+++ b/components/reusable/Menu/Banner.tsx
@@ -9,9 +9,9 @@ const Banner = () => {
     pathname === '/kana'
       ? 'Kana あ'
       : pathname === '/kanji'
-      ? 'Kanji 出'
+      ? 'Kanji 字'
       : pathname === '/vocabulary'
-      ? 'Vocabulary 言'
+      ? 'Vocabulary 語'
       : pathname === '/preferences'
       ? 'Preferences 設'
       : '';

--- a/components/reusable/Menu/Sidebar.tsx
+++ b/components/reusable/Menu/Sidebar.tsx
@@ -97,7 +97,7 @@ const Sidebar = () => {
         )}
         onClick={playClick}
       >
-        言<span className='max-lg:hidden'> Vocabulary</span>
+        語<span className='max-lg:hidden'> Vocabulary</span>
       </Link>
       <Link
         href='/kanji'
@@ -109,7 +109,7 @@ const Sidebar = () => {
         )}
         onClick={playClick}
       >
-        出<span className='max-lg:hidden'> Kanji</span>
+        字<span className='max-lg:hidden'> Kanji</span>
       </Link>
       <Link
         href='/preferences'


### PR DESCRIPTION
## Summary
- Changed Vocabulary label from 言 (say) to 語 (word) - the second character in 単語 (tango)
- Changed Kanji label from 出 (exit) to 字 (character) - the second character in 漢字 (kanji)
- These characters are more semantically appropriate for their respective navigation items
- Updated in all locations: Sidebar.tsx, Banner.tsx, and MainMenu/index.tsx

## Credit
Suggestion from @innocentoldguy on HackerNews

## Test plan
- [x] Verify sidebar displays correctly on desktop
- [x] Verify sidebar displays correctly on mobile
- [x] Verify banner displays correct kanji
- [x] Verify main menu displays correct kanji
- [x] Confirm new kanji characters are visually appropriate

🤖 Generated with [Claude Code](https://claude.ai/code)