### PR TITLE
Add randomly-appearing Furigana to Kanji and Vocab pick game

### DIFF
--- a/components/Dojo/Kanji/Game/Pick.tsx
+++ b/components/Dojo/Kanji/Game/Pick.tsx
@@ -175,7 +175,7 @@ const Pick = ({
         lang="ja"
       >
         <span>{correctKanjiChar}</span>
-        {showFurigana && <span className="text-base text-gray-500">{correctKunyomiReadings?.join(', ')}</span>}
+        {showFurigana && <span className="text-base text-[var(--secondary-color)]">{correctKunyomiReadings?.join(', ')}</span>}
       </p>
       <div
         className={clsx(

--- a/components/Dojo/Kanji/Game/Pick.tsx
+++ b/components/Dojo/Kanji/Game/Pick.tsx
@@ -1,6 +1,6 @@
 'use client';
 import clsx from 'clsx';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { CircleCheck } from 'lucide-react';
 import { CircleX } from 'lucide-react';
 import { Random } from 'random-js';
@@ -34,6 +34,7 @@ const Pick = ({
     addCharacterToHistory,
     addCorrectAnswerTime,
     incrementCharacterScore,
+    characterHistory,
   } = useStats();
 
   const { playCorrect } = useCorrect();
@@ -42,6 +43,17 @@ const Pick = ({
   const [correctKanjiChar, setCorrectKanjiChar] = useState(
     selectedKanjiObjs[random.integer(0, selectedKanjiObjs.length - 1)].kanjiChar
   );
+
+  // avoid rerunning random.bool unless correctKanjiChar changes
+  const showFurigana = useMemo(() => {
+      const currentKanjiInHistory = characterHistory.indexOf(correctKanjiChar) > -1;
+      // show furigana if current kanji is not in history, or one in six times if it is
+      return !currentKanjiInHistory || random.bool(1, 6);
+  }, [correctKanjiChar])
+
+  const correctKunyomiReadings = selectedKanjiObjs.find(
+      obj => obj.kanjiChar === correctKanjiChar
+  )?.kunyomi;
 
   const correctMeaning = selectedKanjiObjs.find(
     obj => obj.kanjiChar === correctKanjiChar
@@ -159,10 +171,11 @@ const Pick = ({
       />
 
       <p
-        className="text-9xl"
+        className="flex flex-col gap-4 text-9xl text-center"
         lang="ja"
       >
-        {correctKanjiChar}
+        <span>{correctKanjiChar}</span>
+        {showFurigana && <span className="text-base text-gray-500">{correctKunyomiReadings?.join(', ')}</span>}
       </p>
       <div
         className={clsx(

--- a/components/Dojo/Vocab/Game/Pick.tsx
+++ b/components/Dojo/Vocab/Game/Pick.tsx
@@ -174,7 +174,7 @@ const Pick = ({
         lang="ja"
       >
         <span>{correctWord}</span>
-        {showFurigana && <span class="text-base text-gray-500">{correctReading}</span>}
+        {showFurigana && <span class="text-base text-[var(--secondary-color)]">{correctReading}</span>}
       </p>
       <div
         className={clsx(

--- a/components/Dojo/Vocab/Game/Pick.tsx
+++ b/components/Dojo/Vocab/Game/Pick.tsx
@@ -1,6 +1,6 @@
 'use client';
 import clsx from 'clsx';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import { CircleCheck } from 'lucide-react';
 import { CircleX } from 'lucide-react';
 import { Random } from 'random-js';
@@ -34,6 +34,7 @@ const Pick = ({
     addCharacterToHistory,
     addCorrectAnswerTime,
     incrementCharacterScore,
+    characterHistory,
   } = useStats();
 
   const { playCorrect } = useCorrect();
@@ -42,6 +43,19 @@ const Pick = ({
   const [correctWord, setCorrectWord] = useState(
     selectedWordObjs[random.integer(0, selectedWordObjs.length - 1)].word
   );
+
+  // avoid rerunning random.bool unless correctWord changes
+  const showFurigana = useMemo(() => {
+    const currentWordInHistory = characterHistory.indexOf(correctWord) > -1;
+    // show furigana if current word is not in history, or one in six times if it is
+    return !currentWordInHistory || random.bool(1, 6);
+  }, [correctWord])
+
+
+  // jp reading is the second word usually, so pick the last word when available
+  const correctReading = selectedWordObjs.find(
+    wordObj => wordObj.word == correctWord
+  )?.reading.split(' ').at(-1);
 
   const correctMeaning = selectedWordObjs.find(
     wordObj => wordObj.word === correctWord
@@ -156,10 +170,11 @@ const Pick = ({
         gameMode="pick"
       />
       <p
-        className="text-6xl md:text-9xl text-center"
+        className="flex flex-col gap-4 text-6xl md:text-9xl text-center"
         lang="ja"
       >
-        {correctWord}
+        <span>{correctWord}</span>
+        {showFurigana && <span class="text-base text-gray-500">{correctReading}</span>}
       </p>
       <div
         className={clsx(


### PR DESCRIPTION
Adds Furigana to the Kanji and Vocabulary Pick games. Solves #10.

The word reading is used in the case of the Vocabulary game, and Kun'yomi readings are used for Kanji.

Furigana is shown if the player hasn't seen it before in the session, or 1/6th of the time otherwise.

### Preview:

#### Vocabulary:

<img width="1396" height="648" alt="pr-ss1" src="https://github.com/user-attachments/assets/5aeab28d-c879-486c-be31-0765075d6d68" />

#### Kanji:

<img width="1366" height="616" alt="pr-ss2" src="https://github.com/user-attachments/assets/d576b6fc-3ddb-47d9-bfa6-d398517a45f9" />

