### PR TITLE
Added shared button component. Added enhanced color variables. 

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -77,6 +77,19 @@ input[type="checkbox"]:checked::after {
 
   --main-color: hsl(0, 0%, 0%);
   --secondary-color: hsl(0, 0%, 35%);
+
+  /* New aliases */
+  --surface: hsla(210, 17%, 100%, 1);
+  --on-surface: hsl(0, 0%, 0%);
+  --surface-variant: hsla(210, 17%, 91%, 1);
+  --on-surface-variant: hsl(0, 0%, 0%);
+  --outline: hsla(210, 17%, 76%, 1);
+  --primary: hsl(0, 0%, 0%);
+  --on-primary: hsla(210, 17%, 100%, 1);
+  --secondary: hsl(0, 0%, 35%);
+  --on-secondary: hsla(210, 17%, 100%, 1);
+  --background: hsla(210, 17%, 100%, 1);
+  --on-background: hsl(0, 0%, 0%);
 }
 
 /* @media (prefers-color-scheme: light) {
@@ -109,6 +122,18 @@ input[type="checkbox"]:checked::after {
 
   --main-color: hsl(0, 0%, 0%);
   --secondary-color: hsl(0, 0%, 35%);
+
+  --surface: hsla(210, 24%, 99%, 1);
+  --on-surface: hsl(222, 47%, 11%);
+  --surface-variant: hsla(210, 20%, 92%, 1);
+  --on-surface-variant: hsl(222, 32%, 20%);
+  --outline: hsla(210, 16%, 70%, 1);
+  --primary: hsl(212, 88%, 56%);
+  --on-primary: hsla(0, 0%, 100%, 1);
+  --secondary: hsl(33, 100%, 58%);
+  --on-secondary: hsla(0, 0%, 100%, 1);
+  --background: hsla(210, 28%, 97%, 1);
+  --on-background: hsl(222, 45%, 15%);
 }
 
 /* Dark Theme */
@@ -119,6 +144,18 @@ input[type="checkbox"]:checked::after {
 
   --main-color: hsl(0, 0%, 100%);
   --secondary-color: hsl(0, 0%, 75%);
+
+  --surface: hsla(0, 0%, 13%, 1);
+  --on-surface: hsl(204, 40%, 92%);
+  --surface-variant: hsla(204, 32%, 18%, 1);
+  --on-surface-variant: hsl(204, 40%, 80%);
+  --outline: hsla(204, 28%, 32%, 1);
+  --primary: hsl(212, 88%, 56%);
+  --on-primary: hsla(0, 0%, 100%, 1);
+  --secondary: hsl(33, 100%, 58%);
+  --on-secondary: hsla(0, 0%, 100%, 1);
+  --background: hsla(210, 25%, 9%, 1);
+  --on-background: hsl(204, 38%, 90%);
 }
 
 /* LIGHT THEMES */

--- a/components/MainMenu/index.tsx
+++ b/components/MainMenu/index.tsx
@@ -20,6 +20,7 @@ import { useClick } from '@/lib/hooks/useAudio';
 import useThemeStore from '@/store/useThemeStore';
 import { useMediaQuery } from 'react-responsive';
 import { buttonBorderStyles } from '@/static/styles';
+import { Button } from '@/components/ui/button';
 
 const Decorations = lazy(() => import('./Decorations'));
 
@@ -73,11 +74,13 @@ const MainMenu = () => {
       {isLG && (
         <Suspense fallback={<></>}>
           {process.env.NODE_ENV === 'production' && <Decorations expandDecorations={expandDecorations}/>}
-          <button
+          <Button
+            variant='secondary'
+            size='icon'
             className={clsx(
-              'fixed top-4 right-8 z-50',
+              'fixed top-4 right-8 z-50 opacity-90',
               buttonBorderStyles,
-              'p-2.5 opacity-90'
+              'transition-transform duration-250 active:scale-95'
             )}
             onClick={() => {
               playClick();
@@ -85,7 +88,7 @@ const MainMenu = () => {
             }}
           >
             <Sparkle />
-          </button>
+          </Button>
         </Suspense>
       )}
       <div

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg border border-transparent text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--main-color)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--background-color)] disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-[var(--main-color)] text-[var(--background-color)] shadow-[0_10px_30px_-12px_rgba(0,0,0,0.45)] hover:brightness-110 hover:shadow-[0_12px_36px_-16px_rgba(0,0,0,0.55)] active:brightness-95",
+        destructive:
+          "bg-red-500 text-white shadow-sm hover:bg-red-600 focus-visible:ring-red-500",
+        outline:
+          "border border-[var(--border-color)] bg-transparent text-[var(--main-color)] hover:bg-[var(--card-color)] hover:text-[var(--main-color)]",
+        secondary:
+          "border border-[var(--border-color)] bg-[var(--card-color)] text-[var(--main-color)] shadow-sm hover:bg-[var(--border-color)]",
+        ghost:
+          "bg-transparent text-[var(--main-color)] hover:bg-[var(--card-color)]",
+        link:
+          "text-[var(--main-color)] underline-offset-4 hover:text-[var(--secondary-color)] hover:underline",
+      },
+      size: {
+        default: "h-10 px-5",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-12 rounded-xl px-8 text-base",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@radix-ui/react-select": "^2.2.5",
+    "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/postcss": "^4.0.17",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",


### PR DESCRIPTION
Currently default html buttons are being used throughout the project. Which makes it cumbersome to style it every time it's being used. 

Added Button component from shadcn but with updated styles from the project. Only replaced one button on the main screen. 

Also added some additional color alias. Only updated in globals.css. Not used anywhere yet. 
Why? It hard to read in some themes. Color should be used strategically so this doesn't happen. I have added material design naming conventions.  

Exact Colors are for reference. Should be changed when it is actually used. 

```CSS
  --surface: hsla(210, 17%, 100%, 1);
  --on-surface: hsl(0, 0%, 0%);
  --surface-variant: hsla(210, 17%, 91%, 1);
  --on-surface-variant: hsl(0, 0%, 0%);
  --outline: hsla(210, 17%, 76%, 1);
  --primary: hsl(0, 0%, 0%);
  --on-primary: hsla(210, 17%, 100%, 1);
  --secondary: hsl(0, 0%, 35%);
  --on-secondary: hsla(210, 17%, 100%, 1);
  --background: hsla(210, 17%, 100%, 1);
  --on-background: hsl(0, 0%, 0%);
```