### PR TITLE
Correct the Overflow of the content 

### DIFF
--- a/components/Settings/Behavior.tsx
+++ b/components/Settings/Behavior.tsx
@@ -37,7 +37,7 @@ const Behavior = () => {
             buttonBorderStyles,
             'text-center text-lg',
             'w-1/2 md:w-1/4 p-4',
-            'text-[var(--secondary-color)]'
+            'text-[var(--secondary-color)]',"flex-1 overflow-hidden"
           )}
           onClick={() => {
             playClick();
@@ -54,7 +54,7 @@ const Behavior = () => {
             buttonBorderStyles,
             'text-center text-lg',
             'w-1/2 md:w-1/4 p-4',
-            'text-[var(--secondary-color)]'
+            'text-[var(--secondary-color)]',"flex-1 overflow-hidden"
           )}
           onClick={() => {
             playClick();

--- a/components/Settings/Fonts.tsx
+++ b/components/Settings/Fonts.tsx
@@ -26,7 +26,7 @@ const Fonts = () => {
         className={clsx(
           'p-6 flex justify-center items-center gap-2 w-1/4',
           buttonBorderStyles,
-          'text-xl w-full'
+          'text-xl w-full','flex-1 overflow-hidden'
         )}
         onClick={() => {
           playClick();
@@ -51,7 +51,7 @@ const Fonts = () => {
             className={clsx(
               'flex justify-center items-center',
               buttonBorderStyles,
-              'py-4 px-4'
+              'py-4 px-4','flex-1 overflow-hidden'
             )}
             onClick={() => playClick()}
           >

--- a/components/Settings/Themes.tsx
+++ b/components/Settings/Themes.tsx
@@ -29,7 +29,7 @@ const Themes = () => {
       <div className='flex gap-2'>
         <button
           className={clsx(
-            'p-6 flex justify-center items-center gap-2 w-full md:w-1/2',
+            'p-6 flex justify-center items-center gap-2 w-full md:w-1/2 flex-1 overflow-hidden',
             buttonBorderStyles
           )}
           onMouseEnter={() => setIsHovered(randomTheme.id)}
@@ -96,7 +96,7 @@ const Themes = () => {
             )}
           >
             {themeSet.themes.map(currentTheme => (
-              <label
+              <label 
                 key={currentTheme.id}
                 style={{
                   color: currentTheme.mainColor,
@@ -112,7 +112,7 @@ const Themes = () => {
                 onMouseLeave={() => setIsHovered('')}
                 className={clsx(
                   currentTheme.id === 'long' && 'col-span-full',
-                  'py-4 flex justify-center items-center',
+                  'py-4 flex justify-center items-center','flex-1 overflow-hidden',
                   buttonBorderStyles
                 )}
                 onClick={() => {
@@ -150,7 +150,7 @@ const Themes = () => {
                   {currentTheme.id === 'long'
                     ? 'long loooooooong theme'
                     : currentTheme.id.split('-').map((themeNamePart, i) => (
-                        <span
+                        <span 
                           key={themeNamePart + Math.random() * 9999}
                           style={{
                             color:

--- a/components/reusable/Menu/Sidebar.tsx
+++ b/components/reusable/Menu/Sidebar.tsx
@@ -109,7 +109,7 @@ const Sidebar = () => {
         )}
         onClick={playClick}
       >
-        字<span className='max-lg:hidden'> </span>
+        字<span className='max-lg:hidden'> Kanji</span>
       </Link>
       <Link
         href='/preferences'

--- a/components/reusable/Menu/Sidebar.tsx
+++ b/components/reusable/Menu/Sidebar.tsx
@@ -109,7 +109,7 @@ const Sidebar = () => {
         )}
         onClick={playClick}
       >
-        字<span className='max-lg:hidden'> Kanji</span>
+        字<span className='max-lg:hidden'> </span>
       </Link>
       <Link
         href='/preferences'

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@radix-ui/react-select": "^2.2.5",
+        "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/postcss": "^4.0.17",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
@@ -2291,7 +2292,6 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
-      "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2300,7 +2300,7 @@
       "version": "19.1.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3622,8 +3622,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7990,9 +7989,9 @@
       }
     },
     "node_modules/simple-swizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.3.tgz",
-      "integrity": "sha512-NLgA1P4m+AAQuaetDKl899hwnPQd8cF0XjfIX/zdMga/kgeanRFn0MP2/HbMxPYNeJckKiB/1M4DLpb1XSWcvA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/static/info.tsx
+++ b/static/info.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 const info = {
   '/': {
     header: (
-      <p className='flex gap-2 items-center'>
+      <p className='flex gap-2 items-center flex-1 overflow-hidden '>
         <span>Welcome to KanaDojo!</span>
         <i className='text-[var(--secondary-color)] text-xs mt-1.5 max-md:hidden'>
           v0.1.2 (alpha)


### PR DESCRIPTION
 Enhance layout stability using Tailwind flex and overflow-hidden property

- Applied `flex` and `overflow-hidden` in Sidebar and Settings components to prevent layout overflow

Error Images are :-

1. <img width="272" height="347" alt="Screenshot 2025-10-05 222003" src="https://github.com/user-attachments/assets/6c5e5bee-5f39-4290-990f-818f5c5861ee" />

2.<img width="305" height="643" alt="Screenshot 2025-10-05 231213" src="https://github.com/user-attachments/assets/b6e128c6-100c-4c37-a556-e2bfdeab40cd" />

3.<img width="156" height="482" alt="Screenshot 2025-10-05 221841" src="https://github.com/user-attachments/assets/7efb1088-6f29-43be-88bb-71e368129b9a" />


@lingdojo check it out? Suggest me for further enhancements!

Merge it under the hacktoberfest 2025 (💯 )
