### PR TITLE
feat(preferences): import/export user settings and stats (backup/restore)

### DIFF
--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,5 @@
+import Settings from '@/components/Settings';
+
+export default function SettingsAlias() {
+  return <Settings />;
+}

--- a/components/Dojo/Kana/TimedChallenge.tsx
+++ b/components/Dojo/Kana/TimedChallenge.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import useKanaKanjiStore from '@/store/useKanaKanjiStore';
+import React, { useEffect, useMemo, useState } from 'react';
+import useKanaStore from '@/store/useKanaStore';
 import useStatsStore from '@/store/useStatsStore';
 import { useChallengeTimer } from '@/hooks/useTimer';
 import { Button } from '@/components/ui/button';
 import { generateKanaQuestion } from '@/lib/generateKanaQuestions';
+import { kana as KANA_GROUPS } from '@/static/kana';
 
 export type KanaCharacter = {
   kana: string;
@@ -17,7 +18,24 @@ export type KanaCharacter = {
 const CHALLENGE_DURATION = 60; // seconds
 
 export default function TimedChallengeKana() {
-  const selectedKana = useKanaKanjiStore((state) => state.selectedKana);
+  const kanaGroupIndices = useKanaStore(state => state.kanaGroupIndices);
+  const selectedKana = useMemo(() => {
+    const list: KanaCharacter[] = [];
+    for (const idx of kanaGroupIndices) {
+      const group = KANA_GROUPS[idx];
+      if (!group) continue;
+      const type = group.groupName?.startsWith('h') ? 'hiragana' : 'katakana';
+      for (let i = 0; i < group.kana.length; i++) {
+        list.push({
+          kana: group.kana[i],
+          romaji: group.romanji[i],
+          type,
+          group: group.groupName
+        });
+      }
+    }
+    return list;
+  }, [kanaGroupIndices]);
 
   const incrementTimedCorrectAnswers = useStatsStore((s) => s.incrementTimedCorrectAnswers);
   const incrementTimedWrongAnswers = useStatsStore((s) => s.incrementTimedWrongAnswers);

--- a/components/Dojo/Kana/TimedChallenge.tsx
+++ b/components/Dojo/Kana/TimedChallenge.tsx
@@ -1,41 +1,19 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import useKanaStore from '@/store/useKanaStore';
 import useStatsStore from '@/store/useStatsStore';
 import { useChallengeTimer } from '@/hooks/useTimer';
 import { Button } from '@/components/ui/button';
 import { generateKanaQuestion } from '@/lib/generateKanaQuestions';
-import { kana as KANA_GROUPS } from '@/static/kana';
-
-export type KanaCharacter = {
-  kana: string;
-  romaji: string;
-  type: string;
-  group: string;
-};
+import type { KanaCharacter } from '@/lib/generateKanaQuestions';
+import { flattenKanaGroups } from '@/lib/flattenKanaGroup';
 
 const CHALLENGE_DURATION = 60; // seconds
 
 export default function TimedChallengeKana() {
-  const kanaGroupIndices = useKanaStore(state => state.kanaGroupIndices);
-  const selectedKana = useMemo(() => {
-    const list: KanaCharacter[] = [];
-    for (const idx of kanaGroupIndices) {
-      const group = KANA_GROUPS[idx];
-      if (!group) continue;
-      const type = group.groupName?.startsWith('h') ? 'hiragana' : 'katakana';
-      for (let i = 0; i < group.kana.length; i++) {
-        list.push({
-          kana: group.kana[i],
-          romaji: group.romanji[i],
-          type,
-          group: group.groupName
-        });
-      }
-    }
-    return list;
-  }, [kanaGroupIndices]);
+  const kanaGroupIndices = useKanaStore((state) => state.kanaGroupIndices);
+  const selectedKana = flattenKanaGroups(kanaGroupIndices) as unknown as KanaCharacter[];
 
   const incrementTimedCorrectAnswers = useStatsStore((s) => s.incrementTimedCorrectAnswers);
   const incrementTimedWrongAnswers = useStatsStore((s) => s.incrementTimedWrongAnswers);

--- a/components/Settings/Backup.tsx
+++ b/components/Settings/Backup.tsx
@@ -1,0 +1,65 @@
+'use client';
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { applyBackup, createBackup, type BackupFile } from '@/lib/backup';
+
+const Backup: React.FC = () => {
+  const fileRef = React.useRef<HTMLInputElement | null>(null);
+  const [message, setMessage] = React.useState<string | null>(null);
+
+  const onExport = () => {
+    const data = createBackup();
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json'
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'kanadojo-backup.json';
+    a.click();
+    URL.revokeObjectURL(url);
+    setMessage('Exported to kanadojo-backup.json');
+  };
+
+  const onFilePicked = async (file: File) => {
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text) as BackupFile;
+      const ok = applyBackup(parsed);
+      setMessage(ok ? 'Imported backup successfully' : 'Import failed');
+    } catch {
+      setMessage('Invalid file');
+    } finally {
+      if (fileRef.current) fileRef.current.value = '';
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-row gap-3">
+        <Button onClick={onExport}>Export</Button>
+        <Button variant="secondary" onClick={() => fileRef.current?.click()}>
+          Import
+        </Button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="application/json"
+          hidden
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            const f = e.target.files?.[0];
+            if (f) onFilePicked(f);
+          }}
+        />
+      </div>
+      {message && (
+        <p className="text-sm text-[var(--secondary-color)]">{message}</p>
+      )}
+      <p className="text-xs opacity-70">
+        Exports only preferences and stats. No account data is included.
+      </p>
+    </div>
+  );
+};
+
+export default Backup;

--- a/components/Settings/index.tsx
+++ b/components/Settings/index.tsx
@@ -4,6 +4,7 @@ import Banner from '@/components/reusable/Menu/Banner';
 import Themes from './Themes';
 import Fonts from './Fonts';
 import Behavior from './Behavior';
+import Backup from './Backup';
 import {
   Joystick,
   Sparkles,
@@ -50,6 +51,12 @@ const Settings = () => {
               <span>Fonts</span>
             </h3>
             <Fonts />
+          </div>
+          <div className='flex flex-col gap-4'>
+            <h3 className='flex flex-row text-2xl gap-2 items-end pb-2 border-b-1 border-[var(--border-color)]'>
+              <span>Backup</span>
+            </h3>
+            <Backup />
           </div>
           <div className='flex flex-col gap-4 mb-12'>
             <h3

--- a/lib/backup.ts
+++ b/lib/backup.ts
@@ -1,0 +1,98 @@
+// Helpers to export/import user preferences and stats (client-side only)
+
+import useThemeStore from '@/store/useThemeStore';
+import useStatsStore from '@/store/useStatsStore';
+
+// JSON-safe type
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [k: string]: JSONValue }
+  | JSONValue[];
+
+export type BackupFile = {
+  version: string;
+  createdAt: string;
+  theme?: Record<string, JSONValue>;
+  stats?: Record<string, JSONValue>;
+};
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function toJSONValue(v: unknown): JSONValue | undefined {
+  const t = typeof v;
+  if (v === null) return null;
+  if (t === 'string' || t === 'number' || t === 'boolean') return v as JSONValue;
+  if (Array.isArray(v)) {
+    const arr: JSONValue[] = [];
+    for (const item of v) {
+      const j = toJSONValue(item);
+      if (j !== undefined) arr.push(j);
+    }
+    return arr;
+  }
+  if (isPlainObject(v)) {
+    const obj: { [k: string]: JSONValue } = {};
+    for (const [k, val] of Object.entries(v)) {
+      const j = toJSONValue(val);
+      if (j !== undefined) obj[k] = j;
+    }
+    return obj;
+  }
+  // Skip functions, symbols, undefined, etc.
+  return undefined;
+}
+
+// Keep only keys from current state that are non-functions and exist in source
+function filterToKnownKeys<T extends object>(
+  current: T,
+  source: Record<string, JSONValue>
+): Partial<T> {
+  const result: Record<string, JSONValue> = {};
+  for (const [k, v] of Object.entries(current as Record<string, unknown>)) {
+    if (typeof v === 'function') continue;
+    if (k in source) result[k] = source[k];
+  }
+  return result as Partial<T>;
+}
+
+function getAppVersion(): string {
+  type G = typeof globalThis & { process?: { env?: Record<string, string | undefined> } };
+  const env = (globalThis as G).process?.env;
+  return env?.NEXT_PUBLIC_APP_VERSION ?? 'dev';
+}
+
+export function createBackup(): BackupFile {
+  const themeState = useThemeStore.getState();
+  const statsState = useStatsStore.getState();
+
+  return {
+    version: getAppVersion(),
+    createdAt: new Date().toISOString(),
+    theme: toJSONValue(themeState) as Record<string, JSONValue>,
+    stats: toJSONValue(statsState) as Record<string, JSONValue>
+  };
+}
+
+export function applyBackup(data: BackupFile): boolean {
+  try {
+    if (data.theme) {
+      const current = useThemeStore.getState();
+      const picked = filterToKnownKeys(current, data.theme);
+      useThemeStore.setState(picked);
+    }
+    if (data.stats) {
+      const current = useStatsStore.getState();
+      const picked = filterToKnownKeys(current, data.stats);
+      useStatsStore.setState(picked);
+    }
+    return true;
+  } catch (err) {
+    console.error('[backup] apply failed', err);
+    return false;
+  }
+}

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://kanadojo.com/academy/hiragana-101</loc><lastmod>2025-04-23T10:34:42.438Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
-<url><loc>https://kanadojo.com/kanji</loc><lastmod>2025-04-23T10:34:42.438Z</lastmod><changefreq>daily</changefreq><priority>1.0</priority></url>
-<url><loc>https://kanadojo.com</loc><lastmod>2025-04-23T10:34:42.438Z</lastmod><changefreq>daily</changefreq><priority>1.2</priority></url>
-<url><loc>https://kanadojo.com/preferences</loc><lastmod>2025-04-23T10:34:42.439Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
-<url><loc>https://kanadojo.com/sentences</loc><lastmod>2025-04-23T10:34:42.439Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
-<url><loc>https://kanadojo.com/terms</loc><lastmod>2025-04-23T10:34:42.439Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
-<url><loc>https://kanadojo.com/privacy</loc><lastmod>2025-04-23T10:34:42.439Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
-<url><loc>https://kanadojo.com/security</loc><lastmod>2025-04-23T10:34:42.439Z</lastmod><changefreq>daily</changefreq><priority>0.6</priority></url>
-<url><loc>https://kanadojo.com/vocabulary</loc><lastmod>2025-04-23T10:34:42.439Z</lastmod><changefreq>daily</changefreq><priority>1.0</priority></url>
-<url><loc>https://kanadojo.com/kana</loc><lastmod>2025-04-23T10:34:42.439Z</lastmod><changefreq>daily</changefreq><priority>1.0</priority></url>
-<url><loc>https://kanadojo.com/academy</loc><lastmod>2025-04-23T10:34:42.439Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com</loc><lastmod>2025-10-18T16:19:18.906Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/patch-notes</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/privacy</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/sandbox</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/settings</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/security</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/terms</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/preferences</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/kana</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/kanji</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/vocabulary</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/academy</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+<url><loc>https://kanadojo.com/academy/hiragana-101</loc><lastmod>2025-10-18T16:19:18.907Z</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
 </urlset>


### PR DESCRIPTION
### Problem

Users lose their theme/preferences and practice stats when clearing site data or switching devices. There’s no built‑in way to back up or transfer this data.

### Solution

Adds a Backup section to Settings with Export and Import buttons.
Export downloads a JSON file containing only serializable fields from the Zustand stores (theme + stats) plus app version and timestamp.
Import validates JSON, applies only known non-function keys, ignores unknown fields, and updates stores without a page reload.
Fully client-side; no network calls or account required.
Adds a /settings route alias (in addition to /preferences) for easier discoverability.

### Changes

#### New
[backup.ts]— createBackup/applyBackup helpers, JSON-safe serialization, selective restore
[Backup.tsx]— UI for Export/Import in Settings
[page.tsx] — alias route for settings
#### Updated
[index.tsx]— renders the new Backup section
[TimedChallenge.tsx]— fixed broken store import by using useKanaStore + static kana data
Backup file format (kanadojo-backup.json)
{
"version": "<NEXT_PUBLIC_APP_VERSION | dev>",
"createdAt": "<ISO8601>",
"theme": { ... },
"stats": { ... }
}

### Safety/validation

Only keys present in current store state and not functions are applied.
Unknown keys are ignored.
No network calls; file remains on the user’s device.

### How to test

Go to /settings (or /preferences).
Change theme and play a quick round to update stats.
Click Export to download kanadojo-backup.json.
Clear site storage or change theme/stats to different values.
Click Import and choose the exported file.
Confirm theme and stats restore immediately without reload.

### Closes: #61 

This will be an official contribution for Hacktoberfest 25'
