### PR TITLE
docs(readme): complete German translation and update status

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,374 @@
+# KanaDojo かな道場
+
+<div align="center">
+
+![KanaDojo Banner](https://github.com/user-attachments/assets/d64d5fdd-e49b-4eb5-8de6-0e73c8f95d01)
+
+Eine ästhetische, minimalistische und hochgradig anpassbare Plattform zur Beherrschung der japanischen Sprache
+
+[![Live Demo](https://img.shields.io/badge/demo-live-success?style=for-the-badge)](https://kanadojo.com)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg?style=for-the-badge)](https://www.gnu.org/licenses/agpl-3.0)
+[![Next.js](https://img.shields.io/badge/Next.js-15-black?style=for-the-badge&logo=next.js)](https://nextjs.org/)
+[![React](https://img.shields.io/badge/React-19-61DAFB?style=for-the-badge&logo=react)](https://reactjs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?style=for-the-badge&logo=typescript)](https://www.typescriptlang.org/)
+
+</div>
+
+---
+
+## 📖 Über KanaDojo
+
+**KanaDojo** ist eine fesselnde, webbasierte Lernplattform für Japanisch, die das Meistern von Hiragana, Katakana, Kanji und Vokabeln spaßig und intuitiv gestaltet. Entwickelt mit Fokus auf **Ästhetik**, **Anpassbarkeit** und **effektives Lernen**, bietet KanaDojo eine immersive Trainingsumgebung für Japanischlernende aller Niveaus.
+
+Ob Sie gerade mit den grundlegenden Kana-Silbenschriften beginnen oder sich mit fortgeschrittenen Kanji und Vokabeln auf die JLPT-Prüfungen vorbereiten, KanaDojo bietet ein optimiertes, ablenkungsfreies Lernerlebnis, das sich an Ihre Präferenzen und Ihren Lernstil anpasst.
+
+---
+
+## ✨ Hauptfunktionen
+
+### 🎯 Drei Trainings-Dojos
+
+- **Kana Dojo** – Meistern Sie die Hiragana- und Katakana-Silbenschriften mit Basis-, Dakuon-, Yoon- und Fremdklang-Gruppen.
+- **Kanji Dojo** – Lernen Sie wesentliche Kanji-Zeichen, organisiert nach JLPT-Niveaus (N5, N4, N3, N2).
+- **Vokabel Dojo** – Bauen Sie Ihren japanischen Wortschatz mit kuratierten Wortsammlungen nach Sprachniveau auf.
+
+### 🎮 Vier Dynamische Spielmodi
+
+Jedes Dojo unterstützt **vier fesselnde Trainingsmodi** zur Lernverstärkung:
+
+1. **Pick (Auswahl)** – Multiple Choice: Wählen Sie die korrekte Romanisierung/Übersetzung für das angezeigte Zeichen.
+2. **Reverse-Pick (Umgekehrte Auswahl)** – Umgekehrte Multiple Choice: Wählen Sie das korrekte Zeichen für die gegebene Romanisierung/Übersetzung.
+3. **Input (Eingabe)** – Texteingabe: Tippen Sie die korrekte Romanisierung/Übersetzung ein.
+4. **Reverse-Input (Umgekehrte Eingabe)** – Umgekehrte Texteingabe: Tippen Sie das korrekte Zeichen ein.
+
+### 🎨 Umfangreiche Anpassungsmöglichkeiten
+
+- **Über 100 Themes** – Wählen Sie aus einer riesigen Sammlung wunderschöner heller und dunkler Themes oder nutzen Sie die Zufallsthema-Funktion.
+- **28 Japanische Schriftarten** – Wählen Sie aus einer Vielzahl authentischer japanischer Schriftarten, die Ihren ästhetischen Vorlieben entsprechen.
+- **Soundeffekte** – Genießen Sie befriedigende UI-Feedback-Sounds, die ein- und ausgeschaltet werden können.
+- **Anzeigeoptionen** – Wechseln Sie in den Auswahlmenüs zwischen Romaji/Englisch und Kana/Kanji-Anzeigen.
+- **Hotkeys** – Tastaturkürzel für effizientes Training (können deaktiviert werden).
+
+### 📊 Fortschrittsverfolgung
+
+- Echtzeit-Feedback mit Richtig/Falsch-Zählern.
+- Streak-Verfolgung zur Aufrechterhaltung der Motivation.
+- Statistiken zur Überwachung Ihres Lernfortschritts.
+
+### 🌐 Modernes Weberlebnis
+
+- Vollständig **responsives Design**, das auf Desktop, Tablet und Mobilgeräten funktioniert.
+- **Keine Installation erforderlich** – trainieren Sie überall mit einer Internetverbindung.
+- Saubere, minimalistische Oberfläche, die Sie auf das Lernen fokussiert.
+- Flüssige Animationen und Übergänge, angetrieben durch **Framer Motion**.
+
+---
+
+## 🖼️ Screenshots
+
+<div align="center">
+
+### Startseite
+![Home Page](https://github.com/user-attachments/assets/0bb2b37f-3e63-4f6f-a95f-32b60d6b9ef0)
+
+### Kana-Auswahl
+![Kana Selection](https://github.com/user-attachments/assets/04b8e4f6-e3b0-466d-8f62-96d31ab8130a)
+
+### Trainingsmodus
+![Training Mode](https://github.com/user-attachments/assets/f50d5b8e-d79f-4c21-9f90-8f0f42a3ff33)
+
+### Anpassung & Themes
+![Customization & Themes](https://github.com/user-attachments/assets/16ccc5a8-05d2-4e04-b6d5-10cf9ea9c9f3)
+
+</div>
+
+---
+
+## 🎨 UI & Design-Philosophie
+
+KanaDojo verbindet eine **minimalistische Ästhetik** mit **maximaler Flexibilität**. Die Design-Philosophie konzentriert sich auf:
+
+### Minimalismus Zuerst
+
+- Klare Oberflächen mit minimalen Ablenkungen.
+- Fokus auf den Lerninhalt.
+- Intuitive Navigation und klare Informationshierarchie.
+- Gezielte Nutzung von Leerraum.
+
+### Ästhetische Anpassung
+
+- Umfangreiche Theme-Bibliothek (**über 100 Optionen**), von sanften Pastelltönen bis zu lebendigen Neons.
+- Unterstützung für helle und dunkle Modi.
+- Sorgfältig kuratierte Farbpaletten, die auch bei längeren Lernsitzungen augenschonend sind.
+- Nahtlose Theme-Übergänge.
+
+### Benutzererfahrung
+
+- Flüssige Animationen und Mikro-Interaktionen für angenehmes Feedback.
+- Responsives Design, das sich jeder Bildschirmgröße perfekt anpasst.
+- Akustisches Feedback für Interaktionen (optional).
+- Konsistente visuelle Sprache in allen Bereichen.
+
+### Japanische Typografie
+
+- **28 authentische japanische Schriftarten**, die verschiedene Stile abdecken.
+- Korrekte Darstellung komplexer Kanji-Zeichen.
+- Klare Unterscheidung zwischen ähnlich aussehenden Zeichen.
+- Schriftart-Vorschauen mit echten japanischen Textbeispielen.
+
+---
+
+## 🛠️ Technischer Stack
+
+KanaDojo wurde mit modernen Web-Technologien für optimale Leistung und Entwicklererfahrung erstellt:
+
+### Kern-Framework
+
+- **Next.js 15** – React-Framework mit App Router für serverseitiges Rendering und optimale Leistung.
+- **React 19** – Neuestes React mit Concurrent Features.
+- **TypeScript** – Typensichere Entwicklung.
+
+### Styling & UI
+
+- **Tailwind CSS** – Utility-First-CSS-Framework.
+- **shadcn/ui** – Hochwertige, barrierefreie Komponentenbibliothek.
+- **Framer Motion** – Flüssige Animationen und Übergänge.
+- **Lucide React** – Schöne, konsistente Icon-Bibliothek.
+- **FontAwesome** – Zusätzliche Icon-Unterstützung.
+
+### Zustandsmanagement
+
+- **Zustand** – Leichtgewichtiges Zustandsmanagement mit minimalem Boilerplate.
+- **Zustand Persist** – Lokale Speicherpersistenz für Benutzereinstellungen.
+
+### Utilities & Funktionen
+
+- **use-sound** – Audio-Feedback-System.
+- **canvas-confetti** – Feier-Effekte.
+- **react-timer-hook** – Timer-Funktionalität.
+- **react-markdown** – Markdown-Rendering für Bildungsinhalte.
+- **random-js** – Kryptografisch starke Zufallszahlengenerierung.
+- **clsx + tailwind-merge** – Conditional Styling Utilities.
+
+### Entwicklungswerkzeuge
+
+- **ESLint** – Code-Linting.
+- **next-sitemap** – Automatische Sitemap-Generierung.
+
+### Analytik & Performance
+
+- **@vercel/analytics** – Web-Analytik.
+- **@vercel/speed-insights** – Performance-Überwachung.
+
+---
+
+## 🚀 Erste Schritte
+
+### Voraussetzungen
+
+- **Node.js** 18.x oder höher
+- **npm** 10.x oder höher (kommt mit Node.js)
+
+### Installation
+
+1. **Das Repository klonen**
+
+```bash
+git clone https://github.com/lingdojo/kanadojo.git
+cd kanadojo
+```
+
+2. **Abhängigkeiten installieren**
+
+```bash
+npm install
+```
+
+3. **Den Entwicklungsserver starten**
+
+```bash
+npm run dev
+```
+
+4. **Ihren Browser öffnen**  
+   Navigieren Sie zu [http://localhost:3000](http://localhost:3000)
+
+### Erstellung für die Produktion
+
+```bash
+# Eine optimierte Produktions-Build erstellen
+npm run build
+
+# Den Produktionsserver starten
+npm start
+```
+
+### Andere Befehle
+
+```bash
+# ESLint ausführen
+npm run lint
+
+# Sitemap generieren (läuft automatisch nach dem Build)
+npm run postbuild
+```
+
+---
+
+## 📁 Projektstruktur
+
+```
+kanadojo/
+├── app/                          # Next.js App Router Seiten
+│   ├── kana/                    # Kana Dojo Seiten
+│   │   └── train/[gameMode]/   # Trainingsseiten für jeden Spielmodus
+│   ├── kanji/                   # Kanji Dojo Seiten
+│   │   └── train/[gameMode]/
+│   ├── vocabulary/              # Vokabel Dojo Seiten
+│   │   └── train/[gameMode]/
+│   ├── preferences/             # Einstellungen und Anpassungsseite
+│   ├── academy/                 # Bildungsinhalte
+│   ├── layout.tsx               # Root-Layout mit Providern
+│   └── page.tsx                 # Startseite
+│
+├── components/                   # React Komponenten
+│   ├── Dojo/                    # Trainingsspezifische Komponenten
+│   │   ├── Kana/               # Kana Auswahl und Karten
+│   │   ├── Kanji/              # Kanji Auswahl und Karten
+│   │   └── Vocab/              # Vokabel Auswahl und Karten
+│   ├── reusable/                # Gemeinsame Komponenten
+│   │   ├── Menu/               # Navigations- und Menükomponenten
+│   │   └── ...                 # Andere wiederverwendbare Komponenten
+│   ├── Settings/                # Präferenzkomponenten
+│   └── ui/                      # shadcn/ui Komponenten
+│
+├── lib/                         # Utilities und Helferfunktionen
+│   ├── hooks/                   # Benutzerdefinierte React Hooks
+│   │   ├── useAudio.ts         # Audio-Feedback-Hooks
+│   │   └── ...
+│   ├── interfaces.ts            # TypeScript Interfaces
+│   └── utils.ts                 # Utility-Funktionen
+│
+├── store/                       # Zustand Zustandsmanagement
+│   ├── useKanaKanjiStore.ts    # Kana/Kanji Auswahlzustand
+│   ├── useVocabStore.ts        # Vokabel Auswahlzustand
+│   ├── useStatsStore.ts        # Statistiken und Fortschritt
+│   └── useThemeStore.ts        # Theme und Präferenzen
+│
+├── static/                      # Statische Daten und Konfiguration
+│   ├── kana.ts                 # Kana Zeichendaten
+│   ├── kanji/                  # Kanji Daten nach JLPT-Niveau
+│   ├── vocab/                  # Vokabeldaten
+│   ├── themes.ts               # Theme-Definitionen
+│   ├── fonts.ts                # Schriftart-Konfigurationen
+│   └── info.tsx                # Informationsinhalte
+│
+├── public/                      # Statische Assets
+│   ├── sounds/                 # Audiodateien
+│   └── wallpapers/             # Hintergrundbilder
+│
+├── CLAUDE.md                    # Entwicklerdokumentation
+├── next.config.ts              # Next.js Konfiguration
+├── tailwind.config.js          # Tailwind CSS Konfiguration
+└── tsconfig.json               # TypeScript Konfiguration
+```
+
+### Schlüsselkonzepte
+
+#### Zustandsmanagement-Fluss (State Management Flow)
+
+1. Der Benutzer wählt Inhalte in den Menükomponenten aus.
+2. Die Auswahlen werden in den Zustand-Stores (`useKanaKanjiStore`, `useVocabStore`) gespeichert.
+3. Trainingskomponenten lesen aus den Stores, um Fragen zu generieren.
+4. Statistiken werden in `useStatsStore` erfasst und persistent gespeichert.
+5. Benutzereinstellungen werden in `useThemeStore` mit localStorage-Persistenz gespeichert.
+
+#### Komponentenarchitektur
+
+- **Dojo-Komponenten**: Verwalten die Zeichen-/Wortauswahl für jeden Inhaltstyp.
+- **Trainingskomponenten**: Rendern die Spielmodi und verwalten Benutzerinteraktionen.
+- **Wiederverwendbare Komponenten**: Gemeinsame UI-Elemente (Schaltflächen, Karten, Modals usw.).
+- **Menü-Komponenten**: Navigation, Info-Bereiche und Dojo-Auswahl.
+
+#### Datenorganisation
+
+- **Kana**: Organisiert nach Typ (Hiragana/Katakana) und Gruppen (Basis, Dakuon, Yoon, Fremdklänge).
+- **Kanji**: Organisiert nach JLPT-Niveau (N5-N2), mit Lesungen und Bedeutungen.
+- **Vokabeln**: Organisiert nach JLPT-Niveau und Wortart (Nomen, Verben usw.).
+
+#### Implementierung der Spielmodi
+
+Jeder Spielmodus ist eine dynamische Route (`/[contentType]/train/[gameMode]`), die:
+
+1. Ausgewählte Inhalte aus dem entsprechenden Store liest.
+2. Zufällige Fragen aus der Auswahl generiert.
+3. Sofortiges Feedback bietet.
+4. Statistiken (richtig, falsch, Streak) verfolgt.
+
+---
+
+## 🤝 Mitwirken (Contributing)
+
+Beiträge sind willkommen! KanaDojo ist ein Open-Source-Projekt, das von der Community für die Community entwickelt wurde. Lesen Sie [CONTRIBUTING.md](CONTRIBUTING.md) für detailliertere Informationen zum Mitwirken.
+
+### So können Sie beitragen
+
+1. **Forken** Sie das Repository.
+2. Erstellen Sie einen Feature-Branch (`git checkout -b feature/AmazingFeature`).
+3. **Committen** Sie Ihre Änderungen (`git commit -m 'Add some AmazingFeature'`).
+4. **Pushen** Sie zum Branch (`git push origin feature/AmazingFeature`).
+5. Eröffnen Sie einen **Pull Request**.
+
+### Entwicklungsrichtlinien
+
+- Halten Sie sich an den bestehenden Codestil und die Konventionen.
+- Verwenden Sie TypeScript für Typensicherheit.
+- Testen Sie Ihre Änderungen gründlich.
+- Aktualisieren Sie die Dokumentation bei Bedarf.
+- Halten Sie Komponenten fokussiert und wiederverwendbar.
+
+---
+
+## 📄 Lizenz
+
+Dieses Projekt ist unter der **AGPL 3.0 Lizenz** lizenziert – Details finden Sie in der Datei [LICENSE.md](LICENSE.md).
+
+---
+
+## 🙏 Danksagungen
+
+- Japanische Sprachdaten und Zeicheninformationen.
+- Die Open-Source-Community für die großartigen Tools und Bibliotheken.
+- Alle Mitwirkenden, die helfen, KanaDojo besser zu machen.
+
+---
+
+## 🌍 Übersetzungen
+
+KanaDojo ist dank Community-Beiträgen in mehreren Sprachen verfügbar:
+
+- [🇬🇧 Englisch (Standard)](README.md)
+- [🇪🇸 Español](README.es.md)
+- [🇫🇷 Français](README.fr.md) _(in Bearbeitung)_
+- [🇮🇳 हिन्दी](README.hin.md)
+- [🇧🇷 Português (Brasil)](README.pt-br.md)
+- [🇹🇼 繁體中文](README.zh-tw.md) _(in Bearbeitung)_
+- [🇩🇪 Deutsch](README.de.md)
+
+---
+
+## 📞 Kontakt & Links
+
+- **Webseite**: [https://kanadojo.com](https://kanadojo.com)
+- **Repository**: [https://github.com/lingdojo/kanadojo](https://github.com/lingdojo/kanadojo)
+- **E-Mail**: reservecrate@gmail.com
+
+---
+
+<div align="center">
+
+**Mit ❤️ gemacht für Japanischlernende weltweit**
+
+**がんばって！** _(Ganbatte! - Geben Sie Ihr Bestes!)_
+
+</div>

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ KanaDojo is available in multiple languages thanks to community contributions:
 - English (default)
 - [Español](README.es.md)
 - [Français](README.fr.md) in progress
-- [Deutsch](README.de.md) in progress
+- [Deutsch](README.de.md)
 - [Português](README.pt-br.md)
 - [中文](README.zh.md) in progress
 - [हिन्दी](README.hin.md)


### PR DESCRIPTION
- Finalize German README translation (README.de.md)
- Update main README.md to mark German translation as complete
- Remove "in progress" status from German translation links
- Ensure all sections are accurately translated for German-speaking users
This closes #44 