### PR TITLE
fix(dojo): respect displayKana toggle in vocab and kanji dictionaries

### DIFF
--- a/components/Dojo/Kana/SubsetDictionary.tsx
+++ b/components/Dojo/Kana/SubsetDictionary.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 // import Banner from '@/components/reusable/Banner';
 import { kana } from '@/static/kana';
 import { useParams } from 'next/navigation';
+import useThemeStore from '@/store/useThemeStore';
 
 const sliceRanges = {
   hiraganabase: [0, 10],
@@ -18,6 +19,7 @@ const SetDictionary = () => {
   const params = useParams<{ subset: string }>();
   const { subset }: { subset: string } = params;
   const [group, subgroup] = subset.split('-');
+  const displayKana = useThemeStore(state => state.displayKana);
 
   const [startIndex, endIndex] =
     sliceRanges[(group + subgroup) as keyof typeof sliceRanges];
@@ -40,14 +42,16 @@ const SetDictionary = () => {
               {kanaSubgroup.kana.join(' ')}
             </p>
             <div className='flex flex-col gap-2 items-start'>
-              <span
-                className={clsx(
-                  'rounded-2xl px-2 py-1 flex flex-row items-center',
-                  'bg-[var(--border-color)]'
-                )}
-              >
-                {kanaSubgroup.romanji.join(' ')}
-              </span>
+              {!displayKana && (
+                <span
+                  className={clsx(
+                    'rounded-2xl px-2 py-1 flex flex-row items-center',
+                    'bg-[var(--border-color)]'
+                  )}
+                >
+                  {kanaSubgroup.romanji.join(' ')}
+                </span>
+              )}
             </div>
           </div>
         ))}

--- a/components/Dojo/Kanji/SetDictionary.tsx
+++ b/components/Dojo/Kanji/SetDictionary.tsx
@@ -6,6 +6,7 @@ import N4KanjiArray from '@/static/kanji/N4';
 import N3KanjiArray from '@/static/kanji/N3';
 import N2KanjiArray from '@/static/kanji/N2';
 import useKanjiStore from '@/store/useKanjiStore';
+import useThemeStore from '@/store/useThemeStore';
 
 const createKanjiSetRanges = (numSets: number) =>
   Array.from({ length: numSets }, (_, i) => i + 1).reduce(
@@ -29,6 +30,8 @@ const KanjiSetDictionary = ({ set }: { set: string }) => {
   const selectedKanjiCollection = useKanjiStore(
     state => state.selectedKanjiCollection
   );
+  const displayKana = useThemeStore(state => state.displayKana);
+  
   const displayKanjiCollection =
     kanjiCollections[selectedKanjiCollection as keyof typeof kanjiCollections];
 
@@ -63,58 +66,62 @@ const KanjiSetDictionary = ({ set }: { set: string }) => {
               </div>
 
               <div className='flex flex-col gap-2 w-full'>
-                <div
-                  className={clsx(
-                    'h-1/2',
-                    'bg-[var(--background-color)] rounded-2xl',
-                    'flex flex-row gap-2',
-                    // 'border-1 border-[var(--border-color)]',
-                    (kanjiObj.onyomi[0] === '' ||
-                      kanjiObj.onyomi.length === 0) &&
-                      'hidden'
-                  )}
-                >
-                  {kanjiObj.onyomi.slice(0, 2).map((onyomiReading, i) => (
-                    <span
-                      key={onyomiReading}
+                {!displayKana && (
+                  <>
+                    <div
                       className={clsx(
-                        'px-2 py-1 flex flex-row justify-center items-center text-sm md:text-base',
-                        'text-[var(--secondary-color)] w-full ',
-
-                        i < kanjiObj.onyomi.slice(0, 2).length - 1 &&
-                          'border-r-1 border-[var(--card-color)]'
+                        'h-1/2',
+                        'bg-[var(--background-color)] rounded-2xl',
+                        'flex flex-row gap-2',
+                        // 'border-1 border-[var(--border-color)]',
+                        (kanjiObj.onyomi[0] === '' ||
+                          kanjiObj.onyomi.length === 0) &&
+                          'hidden'
                       )}
                     >
-                      {onyomiReading}
-                    </span>
-                  ))}
-                </div>
+                      {kanjiObj.onyomi.slice(0, 2).map((onyomiReading, i) => (
+                        <span
+                          key={onyomiReading}
+                          className={clsx(
+                            'px-2 py-1 flex flex-row justify-center items-center text-sm md:text-base',
+                            'text-[var(--secondary-color)] w-full ',
 
-                <div
-                  className={clsx(
-                    'h-1/2',
-                    'bg-[var(--background-color)] rounded-2xl',
-                    // 'border-1 border-[var(--border-color)]',
-                    'flex flex-row gap-2',
-                    (kanjiObj.kunyomi[0] === '' ||
-                      kanjiObj.kunyomi.length === 0) &&
-                      'hidden'
-                  )}
-                >
-                  {kanjiObj.kunyomi.slice(0, 2).map((kunyomiReading, i) => (
-                    <span
-                      key={kunyomiReading}
+                            i < kanjiObj.onyomi.slice(0, 2).length - 1 &&
+                              'border-r-1 border-[var(--card-color)]'
+                          )}
+                        >
+                          {onyomiReading}
+                        </span>
+                      ))}
+                    </div>
+
+                    <div
                       className={clsx(
-                        'px-2 py-1 flex flex-row justify-center items-center text-sm md:text-base',
-                        'text-[var(--secondary-color)] w-full ',
-                        i < kanjiObj.kunyomi.slice(0, 2).length - 1 &&
-                          'border-r-1 border-[var(--card-color)]'
+                        'h-1/2',
+                        'bg-[var(--background-color)] rounded-2xl',
+                        // 'border-1 border-[var(--border-color)]',
+                        'flex flex-row gap-2',
+                        (kanjiObj.kunyomi[0] === '' ||
+                          kanjiObj.kunyomi.length === 0) &&
+                          'hidden'
                       )}
                     >
-                      {kunyomiReading}
-                    </span>
-                  ))}
-                </div>
+                      {kanjiObj.kunyomi.slice(0, 2).map((kunyomiReading, i) => (
+                        <span
+                          key={kunyomiReading}
+                          className={clsx(
+                            'px-2 py-1 flex flex-row justify-center items-center text-sm md:text-base',
+                            'text-[var(--secondary-color)] w-full ',
+                            i < kanjiObj.kunyomi.slice(0, 2).length - 1 &&
+                              'border-r-1 border-[var(--card-color)]'
+                          )}
+                        >
+                          {kunyomiReading}
+                        </span>
+                      ))}
+                    </div>
+                  </>
+                )}
               </div>
             </div>
 

--- a/components/Dojo/Vocab/SetDictionary.tsx
+++ b/components/Dojo/Vocab/SetDictionary.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { IWord } from '@/lib/interfaces';
 import { cardBorderStyles } from '@/static/styles';
 import useVocabStore from '@/store/useVocabStore';
+import useThemeStore from '@/store/useThemeStore';
 
 import N5Nouns from '@/static/vocab/n5/nouns';
 import N4Nouns from '@/static/vocab/n4/nouns';
@@ -44,6 +45,8 @@ const SetDictionary = ({ set }: { set: string }) => {
   const selectedVocabCollection = useVocabStore(
     state => state.selectedVocabCollection
   );
+  const displayKana = useThemeStore(state => state.displayKana);
+  
   const displayVocabCollection = (vocabData as VocabData)['jlpt'][
     selectedVocabCollection
   ]['nouns'];
@@ -67,15 +70,17 @@ const SetDictionary = ({ set }: { set: string }) => {
               {wordObj.word}
             </p>
             <div className='flex flex-col gap-2 items-start'>
-              <span
-                className={clsx(
-                  'rounded-xl px-2 py-1 flex flex-row items-center',
-                  'bg-[var(--background-color)] text-lg',
-                  'text-[var(--secondary-color)] '
-                )}
-              >
-                {wordObj.reading}
-              </span>
+              {!displayKana && (
+                <span
+                  className={clsx(
+                    'rounded-xl px-2 py-1 flex flex-row items-center',
+                    'bg-[var(--background-color)] text-lg',
+                    'text-[var(--secondary-color)] '
+                  )}
+                >
+                  {wordObj.reading}
+                </span>
+              )}
               <p className='text-xl md:text-2xl text-[var(--secondary-color)]'>
                 {wordObj.displayMeanings.join(', ')}
               </p>


### PR DESCRIPTION
- Add displayKana state check in Vocab/SetDictionary to conditionally show romaji readings
- Add displayKana state check in Kanji/SetDictionary to conditionally show onyomi/kunyomi readings
- Add displayKana state check in Kana/SubsetDictionary to conditionally show romanji
- Import useThemeStore in all three dictionary components
- When displayKana is true, only kana/kanji characters are shown (romaji hidden)
- When displayKana is false, romaji/readings are displayed as before

Fixes #18