### PR TITLE
[FEATURE] Collapse Vocabulary and Kanji sets by default

### DIFF
--- a/components/Dojo/Kanji/index.tsx
+++ b/components/Dojo/Kanji/index.tsx
@@ -64,9 +64,13 @@ const KanjiCards = () => {
       id: `Set ${i + 1}`
     }));
 
-  const [collapsedRows, setCollapsedRows] = useState<number[]>([]);
-
   const numColumns = useGridColumns();
+
+  const numRows = chunkArray(kanjiSetsTemp, numColumns).length;
+
+  const allRowIndices = Array.from({ length: numRows }, (_, i) => i);
+
+  const [collapsedRows, setCollapsedRows] = useState<number[]>(allRowIndices);
 
   return (
     <div className='flex flex-col w-full gap-4'>

--- a/components/Dojo/Vocab/index.tsx
+++ b/components/Dojo/Vocab/index.tsx
@@ -69,9 +69,13 @@ const VocabCards = () => {
       id: `Set ${i + 1}`
     }));
 
-  const [collapsedRows, setCollapsedRows] = useState<number[]>([]);
-
   const numColumns = useGridColumns();
+
+  const numRows = chunkArray(vocabSetsTemp, numColumns).length;
+
+  const allRowIndices = Array.from({ length: numRows }, (_, i) => i);
+
+  const [collapsedRows, setCollapsedRows] = useState<number[]>(allRowIndices);
 
   return (
     <div className='flex flex-col w-full gap-4'>


### PR DESCRIPTION
## Description

### Problem
When navigating the 'Vocabulary' and 'Kanji' tabs, all units/sets are expanded by default, leading to long scrolling and difficulty finding specific units.

### Expected Behavior
Units/sets should be collapsed by default to provide a cleaner, high-level overview. Users can then expand only the ones they want to view.

### Solution
Modified the default behavior so that all units/sets in both 'Vocabulary' and 'Kanji' tabs load in a collapsed state initially.

### Screenshot
<img width="1461" height="882" alt="image" src="https://github.com/user-attachments/assets/65bc109e-1799-45a3-8943-04f7fbfa5ff0" />


### Related Issue
Fixes #78
