### PR TITLE
feat: added furigana for kanji characters

### DIFF
--- a/components/Dojo/Kanji/Game/Input.tsx
+++ b/components/Dojo/Kanji/Game/Input.tsx
@@ -13,6 +13,7 @@ import useStatsStore from '@/store/useStatsStore';
 import Stars from '@/components/reusable/Game/Stars';
 import AnswerSummary from '@/components/reusable/Game/AnswerSummary';
 import SSRAudioButton from '@/components/reusable/SSRAudioButton';
+import FuriganaText from '@/components/reusable/FuriganaText';
 
 const random = new Random();
 
@@ -219,9 +220,12 @@ const KanjiInputGame = ({
       {!displayAnswerSummary && (
         <>
           <div className='flex flex-col items-center gap-4'>
-            <p className={textSize} lang={displayCharLang}>
-              {correctChar}
-            </p>
+            <FuriganaText 
+              text={correctChar}
+              reading={!isReverse ? (correctKanjiObj?.onyomi[0] || correctKanjiObj?.kunyomi[0]) : undefined}
+              className={textSize}
+              lang={displayCharLang}
+            />
             <SSRAudioButton
               text={correctChar}
               variant='icon-only'

--- a/components/Dojo/Kanji/Game/Pick.tsx
+++ b/components/Dojo/Kanji/Game/Pick.tsx
@@ -14,6 +14,7 @@ import useStatsStore from '@/store/useStatsStore';
 import Stars from '@/components/reusable/Game/Stars';
 import AnswerSummary from '@/components/reusable/Game/AnswerSummary';
 import SSRAudioButton from '@/components/reusable/SSRAudioButton';
+import FuriganaText from '@/components/reusable/FuriganaText';
 
 const random = new Random();
 
@@ -213,12 +214,12 @@ const KanjiPickGame = ({
       {!displayAnswerSummary && (
         <>
           <div className='flex flex-col items-center gap-4'>
-            <p
+            <FuriganaText 
+              text={correctChar}
+              reading={!isReverse ? (correctKanjiObj?.onyomi[0] || correctKanjiObj?.kunyomi[0]) : undefined}
               className={clsx(isReverse ? 'text-6xl md:text-8xl' : 'text-9xl')}
               lang={displayCharLang}
-            >
-              {correctChar}
-            </p>
+            />
             <SSRAudioButton
               text={correctChar}
               variant='icon-only'
@@ -253,7 +254,10 @@ const KanjiPickGame = ({
                 onClick={() => handleOptionClick(option)}
                 lang={isReverse ? 'ja' : undefined}
               >
-                <span>{option}</span>
+                <FuriganaText 
+                  text={option}
+                  reading={isReverse ? selectedKanjiObjs.find(obj => obj.kanjiChar === option)?.onyomi[0] || selectedKanjiObjs.find(obj => obj.kanjiChar === option)?.kunyomi[0] : undefined}
+                />
                 <span
                   className={clsx(
                     'hidden lg:inline text-xs rounded-full bg-[var(--border-color)] px-1',

--- a/components/Dojo/Kanji/SetDictionary.tsx
+++ b/components/Dojo/Kanji/SetDictionary.tsx
@@ -7,6 +7,7 @@ import N3KanjiArray from '@/static/kanji/N3';
 import N2KanjiArray from '@/static/kanji/N2';
 import useKanjiStore from '@/store/useKanjiStore';
 import useThemeStore from '@/store/useThemeStore';
+import FuriganaText from '@/components/reusable/FuriganaText';
 
 const createKanjiSetRanges = (numSets: number) =>
   Array.from({ length: numSets }, (_, i) => i + 1).reduce(
@@ -60,9 +61,12 @@ const KanjiSetDictionary = ({ set }: { set: string }) => {
                   <div className=''></div>
                 </div>
 
-                <p lang='ja' className='text-7xl pb-2 relative z-10'>
-                  {kanjiObj.kanjiChar}
-                </p>
+                <FuriganaText 
+                  text={kanjiObj.kanjiChar}
+                  reading={kanjiObj.onyomi[0] || kanjiObj.kunyomi[0]}
+                  className='text-7xl pb-2 relative z-10'
+                  lang='ja'
+                />
               </div>
 
               <div className='flex flex-col gap-2 w-full'>

--- a/components/Dojo/Vocab/Game/Input.tsx
+++ b/components/Dojo/Vocab/Game/Input.tsx
@@ -13,6 +13,7 @@ import useStatsStore from '@/store/useStatsStore';
 import Stars from '@/components/reusable/Game/Stars';
 import AnswerSummary from '@/components/reusable/Game/AnswerSummary';
 import SSRAudioButton from '@/components/reusable/SSRAudioButton';
+import FuriganaText from '@/components/reusable/FuriganaText';
 
 const random = new Random();
 
@@ -218,9 +219,12 @@ const VocabInputGame = ({
       {!displayAnswerSummary && (
         <>
           <div className='flex flex-col items-center gap-4'>
-            <p className={clsx(textSize, 'text-center')} lang={displayCharLang}>
-              {correctChar}
-            </p>
+            <FuriganaText 
+              text={correctChar}
+              reading={!isReverse ? correctWordObj?.reading : undefined}
+              className={clsx(textSize, 'text-center')}
+              lang={displayCharLang}
+            />
             <SSRAudioButton
               text={correctChar}
               variant='icon-only'

--- a/components/Dojo/Vocab/Game/Pick.tsx
+++ b/components/Dojo/Vocab/Game/Pick.tsx
@@ -14,6 +14,7 @@ import useStatsStore from '@/store/useStatsStore';
 import Stars from '@/components/reusable/Game/Stars';
 import AnswerSummary from '@/components/reusable/Game/AnswerSummary';
 import SSRAudioButton from '@/components/reusable/SSRAudioButton';
+import FuriganaText from '@/components/reusable/FuriganaText';
 
 const random = new Random();
 
@@ -212,9 +213,12 @@ const VocabPickGame = ({
       {!displayAnswerSummary && (
         <>
           <div className='flex flex-col items-center gap-4'>
-            <p className={clsx(textSize, 'text-center')} lang={displayCharLang}>
-              {correctChar}
-            </p>
+            <FuriganaText 
+              text={correctChar}
+              reading={!isReverse ? correctWordObj?.reading : undefined}
+              className={clsx(textSize, 'text-center')}
+              lang={displayCharLang}
+            />
             <SSRAudioButton
               text={correctChar}
               variant='icon-only'
@@ -251,7 +255,10 @@ const VocabPickGame = ({
                 onClick={() => handleOptionClick(option)}
                 lang={optionLang}
               >
-                <span>{option}</span>
+                <FuriganaText 
+                  text={option}
+                  reading={isReverse ? selectedWordObjs.find(obj => obj.word === option)?.reading : undefined}
+                />
                 <span
                   className={clsx(
                     'hidden lg:inline text-xs rounded-full bg-[var(--border-color)] px-1',

--- a/components/Dojo/Vocab/SetDictionary.tsx
+++ b/components/Dojo/Vocab/SetDictionary.tsx
@@ -4,6 +4,7 @@ import { IWord } from '@/lib/interfaces';
 import { cardBorderStyles } from '@/static/styles';
 import useVocabStore from '@/store/useVocabStore';
 import useThemeStore from '@/store/useThemeStore';
+import FuriganaText from '@/components/reusable/FuriganaText';
 
 import N5Nouns from '@/static/vocab/n5/nouns';
 import N4Nouns from '@/static/vocab/n4/nouns';
@@ -66,9 +67,12 @@ const SetDictionary = ({ set }: { set: string }) => {
               i !== 9 && 'border-b-1 border-[var(--border-color)]'
             )}
           >
-            <p lang='ja' className='text-6xl md:text-5xl'>
-              {wordObj.word}
-            </p>
+            <FuriganaText 
+              text={wordObj.word}
+              reading={wordObj.reading}
+              className='text-6xl md:text-5xl'
+              lang='ja'
+            />
             <div className='flex flex-col gap-2 items-start'>
               <span
                 className={clsx(

--- a/components/Settings/Behavior.tsx
+++ b/components/Settings/Behavior.tsx
@@ -31,6 +31,8 @@ const Behavior = () => {
   const setPronunciationPitch = useThemeStore(
     state => state.setPronunciationPitch
   );
+  const furiganaEnabled = useThemeStore(state => state.furiganaEnabled);
+  const setFuriganaEnabled = useThemeStore(state => state.setFuriganaEnabled);
 
   /*   const hotkeysOn = useThemeStore(state => state.hotkeysOn);
   const setHotkeys = useThemeStore(state => state.setHotkeys);
@@ -216,6 +218,53 @@ const Behavior = () => {
           </div>
         </>
       )}
+
+      <h4 className='text-lg'>Show furigana (reading) for kanji and vocabulary:</h4>
+      <div className='flex flex-row gap-4'>
+        <button
+          className={clsx(
+            buttonBorderStyles,
+            'text-center text-lg',
+            'w-1/2 md:w-1/4 p-4',
+            'flex flex-row gap-1.5 justify-center items-end',
+            'text-[var(--secondary-color)]',
+            'flex-1 overflow-hidden'
+          )}
+          onClick={() => {
+            playClick();
+            setFuriganaEnabled(true);
+          }}
+        >
+          <span>
+            <span className='text-[var(--main-color)]'>
+              {furiganaEnabled && '\u2B24 '}
+            </span>
+            on
+          </span>
+          <span className='text-sm mb-1'>ふり</span>
+        </button>
+        <button
+          className={clsx(
+            buttonBorderStyles,
+            'text-center text-lg',
+            'w-1/2 md:w-1/4 p-4',
+            'flex flex-row gap-1.5 justify-center items-end',
+            'text-[var(--secondary-color)]',
+            'flex-1 overflow-hidden'
+          )}
+          onClick={() => {
+            playClick();
+            setFuriganaEnabled(false);
+          }}
+        >
+          <span>
+            <span className='text-[var(--main-color)]'>
+              {!furiganaEnabled && '\u2B24 '}
+            </span>
+            off
+          </span>
+        </button>
+      </div>
 
       {/*       <h4 className="text-lg">Enable hotkeys (desktop only):</h4>
       <div className="flex flex-row gap-4">

--- a/components/reusable/FuriganaText.tsx
+++ b/components/reusable/FuriganaText.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { ReactNode } from 'react';
+import useThemeStore from '@/store/useThemeStore';
+
+interface FuriganaTextProps {
+  text: string;
+  reading?: string;
+  className?: string;
+  furiganaClassName?: string;
+  lang?: string;
+  children?: ReactNode;
+}
+
+/**
+ * Component for displaying Japanese text with optional furigana (reading annotations)
+ * When furigana is enabled in settings, displays reading above the main text
+ * When disabled, displays only the main text
+ */
+const FuriganaText = ({
+  text,
+  reading,
+  className = '',
+  furiganaClassName = '',
+  lang = 'ja',
+  children
+}: FuriganaTextProps) => {
+  const furiganaEnabled = useThemeStore(state => state.furiganaEnabled);
+
+  // If children are provided, render them with optional furigana
+  if (children) {
+    if (furiganaEnabled && reading) {
+      return (
+        <ruby className={className} lang={lang}>
+          {children}
+          <rt className={`text-xs ${furiganaClassName}`}>{reading}</rt>
+        </ruby>
+      );
+    }
+    return <span className={className} lang={lang}>{children}</span>;
+  }
+
+  if (furiganaEnabled && reading) {
+    const hiraganaReading = reading.includes(' ') 
+      ? reading.split(' ')[1] 
+      : reading;
+
+    return (
+      <ruby className={className} lang={lang}>
+        {text}
+        <rt className={`text-xs ${furiganaClassName}`}>{hiraganaReading}</rt>
+      </ruby>
+    );
+  }
+  return <span className={className} lang={lang}>{text}</span>;
+};
+
+export default FuriganaText;

--- a/components/reusable/Game/AnswerSummary.tsx
+++ b/components/reusable/Game/AnswerSummary.tsx
@@ -5,6 +5,7 @@ import { buttonBorderStyles } from '@/static/styles';
 import { CircleArrowRight } from 'lucide-react';
 import { Dispatch, SetStateAction, useRef, useEffect } from 'react';
 import { useClick } from '@/lib/hooks/useAudio';
+import FuriganaText from '@/components/reusable/FuriganaText';
 
 const AnswerSummary = ({
   payload,
@@ -63,9 +64,12 @@ const AnswerSummary = ({
             <div className=''></div>
           </div>
 
-          <p lang='ja' className='text-7xl pb-2 relative z-10'>
-            {payload.kanjiChar}
-          </p>
+          <FuriganaText 
+            text={payload.kanjiChar}
+            reading={payload.onyomi[0] || payload.kunyomi[0]}
+            className='text-7xl pb-2 relative z-10'
+            lang='ja'
+          />
         </div>
 
         <div className='flex flex-col gap-2 w-full '>
@@ -150,9 +154,12 @@ const AnswerSummary = ({
         {feedback}
       </p>
 
-      <p lang='ja' className='text-6xl flex justify-center w-full'>
-        {payload.word}
-      </p>
+      <FuriganaText 
+        text={payload.word}
+        reading={payload.reading}
+        className='text-6xl flex justify-center w-full'
+        lang='ja'
+      />
       <div className='flex flex-col gap-2 items-start'>
         <span
           className={clsx(

--- a/store/useThemeStore.ts
+++ b/store/useThemeStore.ts
@@ -26,6 +26,8 @@ interface ThemeState {
   
   pronunciationPitch: number;
   setPronunciationPitch: (pitch: number) => void;
+  furiganaEnabled: boolean;
+  setFuriganaEnabled: (enabled: boolean) => void;
 }
 
 const useThemeStore = create<ThemeState>()(
@@ -48,7 +50,9 @@ const useThemeStore = create<ThemeState>()(
       pronunciationSpeed: 0.8,
       setPronunciationSpeed: speed => set({ pronunciationSpeed: speed }),
       pronunciationPitch: 1.0,
-      setPronunciationPitch: pitch => set({ pronunciationPitch: pitch })
+      setPronunciationPitch: pitch => set({ pronunciationPitch: pitch }),
+      furiganaEnabled: false,
+      setFuriganaEnabled: enabled => set({ furiganaEnabled: enabled })
     }),
 
     {


### PR DESCRIPTION
# Furigana Display Feature
Added a new furigana toggle option to help Japanese learners by displaying pronunciation guides above kanji and vocabulary words.

## Changes Made
State Management

- Added `furiganaEnabled` boolean and [\`setFuriganaEnabled` function to `useThemeStore`
- Integrated with existing Zustand persist middleware for user preference storage

## UI Components

- Created FuriganaText component using HTML ruby tags for pronunciation display
- Added furigana toggle switch to Settings/Behavior page
- Updated all game components (Pick, Input) and summary displays to conditionally show furigana
- Data Integration

## Utilized existing reading data from vocabulary and kanji JSON files
- Implemented reading extraction logic for both hiragana (vocabulary) and combined readings (kanji)
- Applied furigana display across vocabulary games, kanji games, answer summaries, and dictionary views

The feature provides an optional learning aid that can be toggled on/off based on user preference, making the app more accessible for learners at different Japanese proficiency levels. Close #20 
