### PR TITLE
feat(preferences): add voice selection with test playback; persist se…

### DIFF
--- a/components/Settings/Behavior.tsx
+++ b/components/Settings/Behavior.tsx
@@ -3,7 +3,8 @@ import clsx from 'clsx';
 import { buttonBorderStyles } from '@/static/styles';
 import usePreferencesStore from '@/store/usePreferencesStore';
 import { useClick } from '@/lib/hooks/useAudio';
-import { AudioLines, VolumeX, Volume2 } from 'lucide-react';
+import { AudioLines, VolumeX, Volume2, RefreshCw, Play } from 'lucide-react';
+import { useJapaneseTTS } from '@/lib/hooks/useJapaneseTTS';
 // import{Command, KeyboardOff} from 'lucide-react'
 // import HotkeyReference from './HotkeyReference';
 
@@ -39,6 +40,17 @@ const Behavior = () => {
   const setFuriganaEnabled = usePreferencesStore(
     state => state.setFuriganaEnabled
   );
+
+  type Prefs = ReturnType<typeof usePreferencesStore.getState>;
+  const pronunciationVoiceName = usePreferencesStore(
+    (state: Prefs) => state.pronunciationVoiceName
+  );
+  const setPronunciationVoiceName = usePreferencesStore(
+    (state: Prefs) => state.setPronunciationVoiceName
+  );
+
+  const { availableVoices, currentVoice, setVoice, speak, refreshVoices } =
+    useJapaneseTTS();
 
   /*   const hotkeysOn = useThemeStore(state => state.hotkeysOn);
   const setHotkeys = useThemeStore(state => state.setHotkeys);
@@ -220,6 +232,52 @@ const Behavior = () => {
             />
             <div className='text-sm text-[var(--secondary-color)] text-center'>
               {pronunciationPitch}x
+            </div>
+          </div>
+
+          <h4 className='text-lg'>Pronunciation voice:</h4>
+          <div className='flex flex-col gap-2'>
+            <div className='flex gap-2 items-center'>
+              <select
+                className={clsx(buttonBorderStyles, 'p-2 flex-1')}
+                value={pronunciationVoiceName || currentVoice?.name || ''}
+                onChange={e => {
+                  const name = e.target.value || null;
+                  setPronunciationVoiceName(name);
+                  const match = availableVoices.find(v => v.name === name);
+                  if (match) setVoice(match);
+                }}
+              >
+                <option value=''>Auto (best available)</option>
+                {availableVoices.map(v => (
+                  <option key={v.name} value={v.name}>
+                    {v.name} ({v.lang})
+                  </option>
+                ))}
+              </select>
+              <button
+                className={clsx(buttonBorderStyles, 'px-3 py-2')}
+                onClick={() => {
+                  playClick();
+                  refreshVoices();
+                }}
+                title='Refresh voices'
+              >
+                <RefreshCw size={18} />
+              </button>
+              <button
+                className={clsx(buttonBorderStyles, 'px-3 py-2')}
+                onClick={async () => {
+                  playClick();
+                  await speak('こんにちは');
+                }}
+                title='Test voice'
+              >
+                <Play size={18} />
+              </button>
+            </div>
+            <div className='text-sm text-[var(--secondary-color)] text-center'>
+              {currentVoice ? `${currentVoice.name} • ${currentVoice.lang}` : 'No voice selected'}
             </div>
           </div>
         </>

--- a/store/usePreferencesStore.ts
+++ b/store/usePreferencesStore.ts
@@ -27,6 +27,10 @@ interface PreferencesState {
   pronunciationPitch: number;
   setPronunciationPitch: (pitch: number) => void;
 
+  // Voice selection
+  pronunciationVoiceName: string | null;
+  setPronunciationVoiceName: (name: string | null) => void;
+
   furiganaEnabled: boolean;
   setFuriganaEnabled: (enabled: boolean) => void;
 }
@@ -53,6 +57,8 @@ const usePreferencesStore = create<PreferencesState>()(
       setPronunciationSpeed: speed => set({ pronunciationSpeed: speed }),
       pronunciationPitch: 1.0,
       setPronunciationPitch: pitch => set({ pronunciationPitch: pitch }),
+      pronunciationVoiceName: null,
+      setPronunciationVoiceName: name => set({ pronunciationVoiceName: name }),
       furiganaEnabled: true,
       setFuriganaEnabled: enabled => set({ furiganaEnabled: enabled })
     }),


### PR DESCRIPTION
## Summary
This PR adds selectable Text-to-Speech (TTS) voices and a built-in “Test” playback on the Preferences page, so users can pick the preferred voice and preview it without leaving settings.

## Changes
- Preferences store (`store/usePreferencesStore.ts`)
  - Added `pronunciationVoiceName` and `setPronunciationVoiceName` (persisted)
- TTS hook (`lib/hooks/useJapaneseTTS.ts`)
  - Loads available voices (prioritizes ja-JP), sets `isSupported` on client
  - Applies preferred voice from preferences, and updates preferences on selection
  - Exposes `refreshVoices`, `setVoice`, `speak` for UI
- Preferences UI (`components/Settings/Behavior.tsx`)
  - Voice dropdown with refresh and a play button to test (“こんにちは”)
  - Uses existing speed/pitch preferences

## How to Test
1. Run dev server and navigate to `/en/preferences`.
2. Enable “pronunciation audio”.
3. Choose a voice under “Pronunciation voice” and click Play to preview.
4. Adjust Speed/Pitch and Play again.
5. Reload the page; voice choice should persist.

## Notes
- Uses Web Speech API for TTS; voice availability varies by browser/OS.
- If no Japanese voice is found, falls back to any available voice.

## Screenshots
- Preferences → Behavior: Voice select with Refresh + Test buttons

## Checklist
- [x] Voice selection persisted
- [x] Test playback in Preferences
- [x] Respects silent mode, speed, pitch
- [x] No linter errors locally