### PR TITLE
[FIX] Back button not centered & missing click sound on legal pages

### DIFF
--- a/components/reusable/PostWrapper.tsx
+++ b/components/reusable/PostWrapper.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import clsx from 'clsx';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -5,70 +7,81 @@ import Banner from './Menu/Banner';
 import { buttonBorderStyles } from '@/static/styles';
 import { ChevronsLeft } from 'lucide-react';
 import { Link } from '@/i18n/routing';
+import { useClick } from '@/hooks/useAudio';
 
 const PostWrapper = ({ textContent }: { textContent: string }) => {
+  const { playClick } = useClick();
+
   return (
-    <div className='min-h-[100dvh] max-w-[100dvw] px-4 pb-10 sm:px-8 md:px-20 xl:px-66'>
+    <div className="min-h-[100dvh] max-w-[100dvw] px-4 pb-10 sm:px-8 md:px-20 xl:px-66">
       <Banner />
-      <Link href='/' className='w-full md:w-1/3 lg:w-1/4'>
-        <button className={clsx(buttonBorderStyles, 'py-4 px-16', 'w-full')}>
+      <Link href="/" className="w-full md:w-1/3 lg:w-1/4">
+        <button
+          onClick={() => playClick()}
+          className={clsx(
+            buttonBorderStyles,
+            'py-4 px-16',
+            'w-full',
+            'flex items-center justify-center'
+          )}
+        >
           <ChevronsLeft />
         </button>
       </Link>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          h1: props => (
-            <h1 className='text-3xl font-bold mt-4 pb-3' {...props} />
+          h1: (props) => (
+            <h1 className="text-3xl font-bold mt-4 pb-3" {...props} />
           ),
-          h2: props => (
-            <h2 className='text-2xl font-semibold mt-4 pb-2' {...props} />
+          h2: (props) => (
+            <h2 className="text-2xl font-semibold mt-4 pb-2" {...props} />
           ),
-          h3: props => (
-            <h3 className='text-xl font-medium mt-4 pb-2' {...props} />
+          h3: (props) => (
+            <h3 className="text-xl font-medium mt-4 pb-2" {...props} />
           ),
-          p: props => (
+          p: (props) => (
             <p
-              className='my-1  leading-relaxed text-[var(--secondary-color)]'
+              className="my-1  leading-relaxed text-[var(--secondary-color)]"
               {...props}
             />
           ),
-          ul: props => (
+          ul: (props) => (
             <ul
-              className='list-disc list-inside pb-2 text-[var(--secondary-color)]'
+              className="list-disc list-inside pb-2 text-[var(--secondary-color)]"
               {...props}
             />
           ),
-          ol: props => (
+          ol: (props) => (
             <ol
-              className='list-decimal list-inside pb-4 text-[var(--secondary-color)]'
+              className="list-decimal list-inside pb-4 text-[var(--secondary-color)]"
               {...props}
             />
           ),
-          li: props => <li className='mb-1' {...props} />,
-          a: props => <a className='underline' {...props} />,
+          li: (props) => <li className="mb-1" {...props} />,
+          a: (props) => <a className="underline" {...props} />,
 
-          table: props => (
+          table: (props) => (
             <table
-              className='border-collapse border border-[var(--border-color)] w-full'
+              className="border-collapse border border-[var(--border-color)] w-full"
               {...props}
             />
           ),
-          th: props => (
+          th: (props) => (
             <th
-              className='border border-[var(--border-color)] px-2 py-1'
+              className="border border-[var(--border-color)] px-2 py-1"
               {...props}
             />
           ),
-          td: props => (
+          td: (props) => (
             <td
-              className='border border-[var(--border-color)] px-2 py-1'
+              className="border border-[var(--border-color)] px-2 py-1"
               {...props}
             />
           ),
-          hr: props => (
-            <hr className='border-[var(--border-color)]' {...props} />
-          )
+          hr: (props) => (
+            <hr className="border-[var(--border-color)]" {...props} />
+          ),
         }}
       >
         {textContent}


### PR DESCRIPTION
## Description

The back button on the legal pages (`/terms`, `/privacy`, `/security`) wasn't centered and didn't play the click sound. This fixes both; it's now centered properly and plays the sound when pressed.

## Fixes

Closes #126 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] I followed the code style
- [x] I tested the changes locally
- [x] My changes work on mobile, tablet, and desktop