### PR TITLE
Fix: Enhance Japanese TTS Voice System - Fixes #127

### DIFF
--- a/components/Settings/Behavior.tsx
+++ b/components/Settings/Behavior.tsx
@@ -224,7 +224,7 @@ const Behavior = () => {
             <input
               type='range'
               min='0.5'
-              max='2.0'
+              max='1.5'
               step='0.1'
               value={pronunciationPitch}
               onChange={e => setPronunciationPitch(parseFloat(e.target.value))}

--- a/components/Settings/Behavior.tsx
+++ b/components/Settings/Behavior.tsx
@@ -49,7 +49,7 @@ const Behavior = () => {
     (state: Prefs) => state.setPronunciationVoiceName
   );
 
-  const { availableVoices, currentVoice, setVoice, speak, refreshVoices } =
+  const { availableVoices, currentVoice, setVoice, speak, refreshVoices, hasJapaneseVoices } =
     useJapaneseTTS();
 
   /*   const hotkeysOn = useThemeStore(state => state.hotkeysOn);
@@ -269,7 +269,11 @@ const Behavior = () => {
                 className={clsx(buttonBorderStyles, 'px-3 py-2')}
                 onClick={async () => {
                   playClick();
-                  await speak('こんにちは');
+                  await speak('こんにちは', {
+                    rate: pronunciationSpeed,
+                    pitch: pronunciationPitch,
+                    volume: 0.8
+                  });
                 }}
                 title='Test voice'
               >
@@ -281,6 +285,99 @@ const Behavior = () => {
                 ? `${currentVoice.name} • ${currentVoice.lang}`
                 : 'No voice selected'}
             </div>
+            {!hasJapaneseVoices && availableVoices.length > 0 && (() => {
+              const isFirefox = typeof window !== 'undefined' && /Firefox/i.test(navigator.userAgent);
+              const isChrome = typeof window !== 'undefined' && /Chrome/i.test(navigator.userAgent) && !/Edge/i.test(navigator.userAgent);
+              
+              return (
+                <div className='text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 p-3 rounded-lg border border-red-200 dark:border-red-800'>
+                  <strong className='block mb-2'>⚠️ Notice: No Japanese voices found</strong>
+                  <p className='mb-2'>
+                    {isFirefox && (
+                      <>
+                        <strong>Firefox uses system voices</strong> - it requires Japanese language packs installed on your operating system. 
+                        Chrome/Edge come with built-in Google TTS voices (including Japanese), which is why you might see Japanese voices in Chrome but not Firefox.
+                      </>
+                    )}
+                    {!isFirefox && !isChrome && (
+                      <>
+                        A fallback voice is being used, but pronunciation may not be accurate. 
+                        This is not a system issue - please install Japanese language packs for your operating system.
+                      </>
+                    )}
+                    {isChrome && (
+                      <>
+                        Chrome usually includes Japanese voices by default. If you're not seeing them, try refreshing voices or check chrome://flags.
+                      </>
+                    )}
+                  </p>
+                  <details className='mt-2'>
+                    <summary className='cursor-pointer font-semibold hover:underline'>
+                      How to install Japanese voices:
+                    </summary>
+                    <div className='mt-2 pl-4 space-y-2 text-xs'>
+                      {isFirefox && (
+                        <div className='mb-3 p-2 bg-yellow-50 dark:bg-yellow-900/20 rounded border border-yellow-200 dark:border-yellow-800'>
+                          <strong>⚠️ Firefox-specific:</strong> Firefox relies on your operating system's voices. 
+                          You must install Japanese language packs in your OS, then restart Firefox.
+                        </div>
+                      )}
+                      <div>
+                        <strong>Windows:</strong>
+                        <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <li>Open Settings → Time & Language → Language</li>
+                          <li>Click "Add a language" → Search for "Japanese"</li>
+                          <li>Install Japanese language pack</li>
+                          <li>Restart your browser</li>
+                        </ol>
+                      </div>
+                      <div>
+                        <strong>macOS:</strong>
+                        <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <li>Open System Settings → General → Language & Region</li>
+                          <li>Click "+" to add Japanese</li>
+                          <li>System will download Japanese voices automatically</li>
+                          <li>Restart your browser</li>
+                        </ol>
+                      </div>
+                      <div>
+                        <strong>Linux (Ubuntu/Debian):</strong>
+                        <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <li>Install speech-dispatcher: <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>sudo apt install speech-dispatcher</code></li>
+                          <li>Install espeak with Japanese: <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>sudo apt install espeak espeak-data</code></li>
+                          <li>Or install festival: <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>sudo apt install festival festvox-ja</code></li>
+                          <li>Restart your browser</li>
+                        </ol>
+                      </div>
+                      <div>
+                        <strong>Chrome/Edge:</strong>
+                        <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <li>Chrome includes built-in Google TTS voices (including Japanese) - no installation needed</li>
+                          <li>If voices don't appear, go to chrome://flags and search for "Web Speech API"</li>
+                          <li>Ensure it's enabled, then restart Chrome</li>
+                        </ol>
+                      </div>
+                      <div>
+                        <strong>Firefox:</strong>
+                        <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <li>Type <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>about:config</code> in address bar</li>
+                          <li>Search for <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>media.webspeech.synth.enabled</code></li>
+                          <li>Ensure it's set to <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>true</code></li>
+                          <li><strong>Install Japanese voices in your OS first</strong> (Firefox uses system voices)</li>
+                          <li>Restart Firefox</li>
+                        </ol>
+                      </div>
+                    </div>
+                  </details>
+                </div>
+              );
+            })()}
+            {availableVoices.length === 0 && (
+              <div className='text-sm text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20 p-3 rounded-lg border border-orange-200 dark:border-orange-800'>
+                <strong>⚠️ Notice:</strong> No voices are available. Please refresh voices or check your browser's speech synthesis settings. 
+                This is not a system issue - your browser may need additional language packs.
+              </div>
+            )}
           </div>
         </>
       )}

--- a/components/reusable/AudioButton.tsx
+++ b/components/reusable/AudioButton.tsx
@@ -50,8 +50,10 @@ const AudioButton: React.FC<AudioButtonProps> = ({
       // Refresh voices before speaking
       if (typeof window !== 'undefined') {
         refreshVoices();
-        // Small delay to ensure voices are loaded
-        await new Promise(resolve => setTimeout(resolve, 100));
+        // Firefox needs longer delay to ensure voices are loaded
+        const isFirefox = /Firefox/i.test(navigator.userAgent);
+        const delay = isFirefox ? 300 : 100;
+        await new Promise(resolve => setTimeout(resolve, delay));
       }
 
       await speak(text, {

--- a/hooks/useJapaneseTTS.ts
+++ b/hooks/useJapaneseTTS.ts
@@ -209,12 +209,12 @@ export const useJapaneseTTS = () => {
             utterance.lang = 'ja-JP';
             
             // Validate and apply rate (0.5-1.5)
-            const rate = options?.rate ?? 0.8;
+            const rate = options?.rate ?? 1.0;
             utterance.rate = Math.max(0.5, Math.min(1.5, rate));
             
-            // Validate and apply pitch (0.5-2.0)
+            // Validate and apply pitch (0.5-1.5)
             const pitch = options?.pitch ?? 1.0;
-            utterance.pitch = Math.max(0.5, Math.min(2.0, pitch));
+            utterance.pitch = Math.max(0.5, Math.min(1.5, pitch));
             
             // Validate and apply volume (0-1)
             const volume = options?.volume ?? 0.8;

--- a/hooks/useJapaneseTTS.ts
+++ b/hooks/useJapaneseTTS.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useState, useEffect, useRef } from 'react';
 import usePreferencesStore from '@/store/usePreferencesStore';
 
 interface JapaneseVoice {
@@ -13,6 +13,7 @@ interface TTSState {
   isSupported: boolean;
   availableVoices: JapaneseVoice[];
   currentVoice: JapaneseVoice | null;
+  hasJapaneseVoices: boolean;
 }
 
 export const useJapaneseTTS = () => {
@@ -28,14 +29,31 @@ export const useJapaneseTTS = () => {
     isPlaying: false,
     isSupported: false,
     availableVoices: [],
-    currentVoice: null
+    currentVoice: null,
+    hasJapaneseVoices: false
   });
+
+  // Use ref to store current voice for access in callbacks without stale closures
+  const currentVoiceRef = useRef<JapaneseVoice | null>(null);
+  
+  // Update ref whenever currentVoice changes
+  useEffect(() => {
+    currentVoiceRef.current = state.currentVoice;
+  }, [state.currentVoice]);
 
   // SSR-safe check for browser environment
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
     setIsClient(true);
+  }, []);
+
+  // Detect Firefox for special handling
+  const isFirefox = useRef(false);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      isFirefox.current = /Firefox/i.test(navigator.userAgent);
+    }
   }, []);
 
   // Check browser support and load voices
@@ -49,22 +67,21 @@ export const useJapaneseTTS = () => {
       // Load voices when they become available
       const loadVoices = () => {
         const voices = speechSynthesis.getVoices();
+        
+        // Firefox sometimes returns empty array initially, skip if so
+        if (voices.length === 0) return;
 
-        // Filter for Japanese voices with fallback support
+        // Strictly filter for Japanese voices only
+        // Only accept voices with Japanese language code or Japanese in name
         const japaneseVoices = voices
           .filter(voice => {
-            // Accept Japanese voices or voices that can handle Japanese text
+            // Only accept actual Japanese voices
             return (
               voice.lang.startsWith('ja') ||
               voice.lang === 'ja-JP' ||
               voice.lang === 'ja' ||
-              // Accept common voice providers as fallback
               voice.name.toLowerCase().includes('japanese') ||
-              voice.name.toLowerCase().includes('japan') ||
-              voice.name.toLowerCase().includes('google') ||
-              voice.name.toLowerCase().includes('microsoft') ||
-              // Fallback: accept any voice if few are available
-              voices.length <= 3
+              voice.name.toLowerCase().includes('japan')
             );
           })
           .map(voice => ({
@@ -86,32 +103,40 @@ export const useJapaneseTTS = () => {
           ? japaneseVoices.find(v => v.name === pronunciationVoiceName) || null
           : null;
 
+        const newCurrentVoice = preferred || japaneseVoices[0] || null;
+
+        // Update state with Japanese voices
+        const hasJapaneseVoices = japaneseVoices.length > 0;
         setState((prev: TTSState) => ({
           ...prev,
           isSupported: true,
           availableVoices: japaneseVoices,
-          currentVoice: preferred || japaneseVoices[0] || null
+          currentVoice: newCurrentVoice,
+          hasJapaneseVoices
         }));
 
-        // Fallback: If no Japanese voices, use any available voice
+        // Update ref immediately to avoid race conditions
+        currentVoiceRef.current = newCurrentVoice;
+
+        // Fallback: If no Japanese voices found, use any available voice but log warning
         if (voices.length > 0 && japaneseVoices.length === 0) {
-          const fallbackVoice = voices[0];
+          console.warn(
+            'No Japanese voices found. Using fallback voice. Pronunciation may not be accurate.'
+          );
+          const fallbackVoice = voices.find(v => v.lang.startsWith('ja')) || voices[0];
+          const fallbackJapaneseVoice = {
+            name: fallbackVoice.name,
+            lang: fallbackVoice.lang,
+            voice: fallbackVoice
+          };
           setState((prev: TTSState) => ({
             ...prev,
             isSupported: true,
-            availableVoices: [
-              {
-                name: fallbackVoice.name,
-                lang: fallbackVoice.lang,
-                voice: fallbackVoice
-              }
-            ],
-            currentVoice: {
-              name: fallbackVoice.name,
-              lang: fallbackVoice.lang,
-              voice: fallbackVoice
-            }
+            availableVoices: [fallbackJapaneseVoice],
+            currentVoice: fallbackJapaneseVoice,
+            hasJapaneseVoices: false
           }));
+          currentVoiceRef.current = fallbackJapaneseVoice;
         }
       };
 
@@ -121,9 +146,17 @@ export const useJapaneseTTS = () => {
       // Also listen for voice changes (some browsers load voices asynchronously)
       speechSynthesis.addEventListener('voiceschanged', loadVoices);
 
-      // Try to load voices after a short delay (some browsers load voices asynchronously)
-      setTimeout(loadVoices, 100);
-      setTimeout(loadVoices, 500);
+      // Firefox needs more time and multiple attempts to load voices
+      if (isFirefox.current) {
+        setTimeout(loadVoices, 100);
+        setTimeout(loadVoices, 500);
+        setTimeout(loadVoices, 1000);
+        setTimeout(loadVoices, 2000);
+      } else {
+        // Other browsers typically load faster
+        setTimeout(loadVoices, 100);
+        setTimeout(loadVoices, 500);
+      }
 
       return () => {
         speechSynthesis.removeEventListener('voiceschanged', loadVoices);
@@ -151,67 +184,144 @@ export const useJapaneseTTS = () => {
         // Stop any currently playing speech
         speechSynthesis.cancel();
 
-        const utterance = new SpeechSynthesisUtterance(text);
-
-        // Set language for Japanese text
-        utterance.lang = 'ja-JP';
-
-        // Set voice with fallback support
-        const selectedVoice = options?.voice || state.currentVoice;
-        if (selectedVoice) {
-          utterance.voice = selectedVoice.voice;
-        } else {
-          // Fallback: try to find any available voice
-          const voices = speechSynthesis.getVoices();
-          if (voices.length > 0) {
-            // Try to find a Japanese voice first, then fall back to any voice
-            const japaneseVoice = voices.find(v => v.lang.startsWith('ja'));
-            utterance.voice = japaneseVoice || voices[0];
-          }
-        }
-
-        // Set speech parameters
-        utterance.rate = options?.rate || 0.8;
-        utterance.pitch = options?.pitch || 1.0;
-        utterance.volume = options?.volume || 0.8;
-
-        // Event handlers for speech synthesis
-        utterance.onstart = () => {
-          setState((prev: TTSState) => ({ ...prev, isPlaying: true }));
-        };
-
-        utterance.onend = () => {
-          setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
-          resolve();
-        };
-
-        utterance.onerror = event => {
-          console.warn('TTS Error:', event.error);
-          setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
-          resolve();
-        };
-
-        // Add a small delay to ensure voices are loaded
-        setTimeout(() => {
+        // Firefox needs voices to be loaded before creating utterance
+        const attemptSpeak = (retries = 0) => {
           try {
-            // Try to speak even if no Japanese voice is available
-            if (!utterance.voice && typeof window !== 'undefined') {
-              const voices = speechSynthesis.getVoices();
-              if (voices.length > 0) {
-                utterance.voice = voices[0];
+            // Get current voices (Firefox requires this to be fresh)
+            const voices = speechSynthesis.getVoices();
+            
+            // Firefox: voices might not be loaded yet, wait for them
+            if (voices.length === 0) {
+              if (retries < 10) {
+                // Wait for voices to load (Firefox can take time)
+                setTimeout(() => attemptSpeak(retries + 1), isFirefox.current ? 200 : 100);
+                return;
+              } else {
+                console.warn('No voices available after retries');
+                setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
+                resolve();
+                return;
               }
             }
 
-            speechSynthesis.speak(utterance);
+            // Create utterance fresh each time (Firefox requirement)
+            const utterance = new SpeechSynthesisUtterance(text);
+            utterance.lang = 'ja-JP';
+            
+            // Validate and apply rate (0.5-1.5)
+            const rate = options?.rate ?? 0.8;
+            utterance.rate = Math.max(0.5, Math.min(1.5, rate));
+            
+            // Validate and apply pitch (0.5-2.0)
+            const pitch = options?.pitch ?? 1.0;
+            utterance.pitch = Math.max(0.5, Math.min(2.0, pitch));
+            
+            // Validate and apply volume (0-1)
+            const volume = options?.volume ?? 0.8;
+            utterance.volume = Math.max(0, Math.min(1, volume));
+
+            // Set voice - Always prioritize Japanese voices
+            // Firefox requires voice to be matched from current voices list
+            const selectedVoice = options?.voice || currentVoiceRef.current;
+            
+            // First, try to find Japanese voices
+            const japaneseVoices = voices.filter(v => 
+              v.lang.startsWith('ja') || 
+              v.lang === 'ja-JP' || 
+              v.lang === 'ja' ||
+              v.name.toLowerCase().includes('japanese') ||
+              v.name.toLowerCase().includes('japan')
+            );
+            
+            if (selectedVoice) {
+              // Try to match selected voice from current voices list (Firefox requirement)
+              const matchedVoice = voices.find(
+                v => v.name === selectedVoice.name && v.lang === selectedVoice.lang
+              );
+              
+              // Check if matched voice is Japanese
+              const isMatchedVoiceJapanese = matchedVoice && (
+                matchedVoice.lang.startsWith('ja') ||
+                matchedVoice.lang === 'ja-JP' ||
+                matchedVoice.lang === 'ja' ||
+                matchedVoice.name.toLowerCase().includes('japanese') ||
+                matchedVoice.name.toLowerCase().includes('japan')
+              );
+              
+              // If matched voice is Japanese, use it; otherwise prefer Japanese voices
+              if (isMatchedVoiceJapanese && matchedVoice) {
+                utterance.voice = matchedVoice;
+              } else if (japaneseVoices.length > 0) {
+                // Prefer Japanese voice even if selected voice is not Japanese
+                // Sort: ja-JP first, then ja, then others
+                const sortedJapanese = japaneseVoices.sort((a, b) => {
+                  if (a.lang === 'ja-JP' && b.lang !== 'ja-JP') return -1;
+                  if (b.lang === 'ja-JP' && a.lang !== 'ja-JP') return 1;
+                  return 0;
+                });
+                utterance.voice = sortedJapanese[0];
+              } else {
+                // Fallback to matched voice or any voice
+                utterance.voice = matchedVoice || voices[0];
+              }
+            } else {
+              // No voice selected, prioritize Japanese voices
+              if (japaneseVoices.length > 0) {
+                // Sort: ja-JP first, then ja, then others
+                const sortedJapanese = japaneseVoices.sort((a, b) => {
+                  if (a.lang === 'ja-JP' && b.lang !== 'ja-JP') return -1;
+                  if (b.lang === 'ja-JP' && a.lang !== 'ja-JP') return 1;
+                  return 0;
+                });
+                utterance.voice = sortedJapanese[0];
+              } else if (voices.length > 0) {
+                // Fallback if no Japanese voices
+                utterance.voice = voices[0];
+                console.warn('No Japanese voices available, using fallback voice');
+              }
+            }
+
+            // Firefox requires voice to be explicitly set
+            if (!utterance.voice && voices.length > 0) {
+              utterance.voice = voices[0];
+            }
+
+            // Event handlers
+            utterance.onstart = () => {
+              setState((prev: TTSState) => ({ ...prev, isPlaying: true }));
+            };
+
+            utterance.onend = () => {
+              setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
+              resolve();
+            };
+
+            utterance.onerror = event => {
+              console.warn('TTS Error:', event.error);
+              setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
+              resolve();
+            };
+
+            // Speak only if we have a voice set
+            if (utterance.voice) {
+              speechSynthesis.speak(utterance);
+            } else {
+              console.warn('Could not set voice for speech synthesis');
+              setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
+              resolve();
+            }
           } catch (error) {
             console.warn('Speech synthesis error:', error);
             setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
             resolve();
           }
-        }, 50);
+        };
+
+        // Start attempt immediately (will retry if voices not ready)
+        attemptSpeak();
       });
     },
-    [isClient, state.isSupported, state.currentVoice, silentMode]
+    [isClient, state.isSupported, silentMode]
   );
 
   const stop = useCallback(() => {
@@ -224,46 +334,84 @@ export const useJapaneseTTS = () => {
   const setVoice = useCallback((voice: JapaneseVoice) => {
     setState((prev: TTSState) => ({ ...prev, currentVoice: voice }));
     setPronunciationVoiceName(voice?.name ?? null);
-  }, []);
+    // Update ref immediately to avoid race conditions
+    currentVoiceRef.current = voice;
+  }, [setPronunciationVoiceName]);
 
   // Method to refresh voices
   const refreshVoices = useCallback(() => {
-    if (isClient && state.isSupported) {
-      const voices = speechSynthesis.getVoices();
-      const japaneseVoices = voices
-        .filter(voice => {
-          return (
-            voice.lang.startsWith('ja') ||
-            voice.lang === 'ja-JP' ||
-            voice.lang === 'ja' ||
-            voice.name.toLowerCase().includes('japanese') ||
-            voice.name.toLowerCase().includes('japan')
-          );
-        })
-        .map(voice => ({
-          name: voice.name,
-          lang: voice.lang,
-          voice: voice
-        }))
-        .sort((a, b) => {
-          if (a.lang === 'ja-JP' && b.lang !== 'ja-JP') return -1;
-          if (b.lang === 'ja-JP' && a.lang !== 'ja-JP') return 1;
-          if (a.lang.startsWith('ja') && !b.lang.startsWith('ja')) return -1;
-          if (b.lang.startsWith('ja') && !a.lang.startsWith('ja')) return 1;
-          return a.name.localeCompare(b.name);
-        });
+    if (!isClient) return;
+    
+    const voices = speechSynthesis.getVoices();
+    
+    // Firefox sometimes returns empty array, skip if so
+    if (voices.length === 0) return;
+    
+    // Strictly filter for Japanese voices only (same logic as loadVoices)
+    const japaneseVoices = voices
+      .filter(voice => {
+        // Only accept actual Japanese voices
+        return (
+          voice.lang.startsWith('ja') ||
+          voice.lang === 'ja-JP' ||
+          voice.lang === 'ja' ||
+          voice.name.toLowerCase().includes('japanese') ||
+          voice.name.toLowerCase().includes('japan')
+        );
+      })
+      .map(voice => ({
+        name: voice.name,
+        lang: voice.lang,
+        voice: voice
+      }))
+      .sort((a, b) => {
+        if (a.lang === 'ja-JP' && b.lang !== 'ja-JP') return -1;
+        if (b.lang === 'ja-JP' && a.lang !== 'ja-JP') return 1;
+        if (a.lang.startsWith('ja') && !b.lang.startsWith('ja')) return -1;
+        if (b.lang.startsWith('ja') && !a.lang.startsWith('ja')) return 1;
+        return a.name.localeCompare(b.name);
+      });
 
-      const preferred = pronunciationVoiceName
-        ? japaneseVoices.find(v => v.name === pronunciationVoiceName) || null
-        : null;
+    const preferred = pronunciationVoiceName
+      ? japaneseVoices.find(v => v.name === pronunciationVoiceName) || null
+      : null;
 
+    const newCurrentVoice = preferred || japaneseVoices[0] || null;
+    
+    // Update state with Japanese voices
+    const hasJapaneseVoices = japaneseVoices.length > 0;
+    setState((prev: TTSState) => ({
+      ...prev,
+      isSupported: true,
+      availableVoices: japaneseVoices,
+      currentVoice: newCurrentVoice,
+      hasJapaneseVoices
+    }));
+    
+    // Update ref immediately to avoid race conditions
+    currentVoiceRef.current = newCurrentVoice;
+    
+    // Fallback: If no Japanese voices found, use any available voice but log warning
+    if (voices.length > 0 && japaneseVoices.length === 0) {
+      console.warn(
+        'No Japanese voices found. Using fallback voice. Pronunciation may not be accurate.'
+      );
+      const fallbackVoice = voices.find(v => v.lang.startsWith('ja')) || voices[0];
+      const fallbackJapaneseVoice = {
+        name: fallbackVoice.name,
+        lang: fallbackVoice.lang,
+        voice: fallbackVoice
+      };
       setState((prev: TTSState) => ({
         ...prev,
-        availableVoices: japaneseVoices,
-        currentVoice: preferred || japaneseVoices[0] || prev.currentVoice
+        isSupported: true,
+        availableVoices: [fallbackJapaneseVoice],
+        currentVoice: fallbackJapaneseVoice,
+        hasJapaneseVoices: false
       }));
+      currentVoiceRef.current = fallbackJapaneseVoice;
     }
-  }, [isClient, state.isSupported, pronunciationVoiceName]);
+  }, [isClient, pronunciationVoiceName]);
 
   return {
     speak,
@@ -273,6 +421,7 @@ export const useJapaneseTTS = () => {
     isPlaying: state.isPlaying,
     isSupported: state.isSupported,
     availableVoices: state.availableVoices,
-    currentVoice: state.currentVoice
+    currentVoice: state.currentVoice,
+    hasJapaneseVoices: state.hasJapaneseVoices
   };
 };

--- a/store/usePreferencesStore.ts
+++ b/store/usePreferencesStore.ts
@@ -53,7 +53,7 @@ const usePreferencesStore = create<PreferencesState>()(
       pronunciationEnabled: true,
       setPronunciationEnabled: enabled =>
         set({ pronunciationEnabled: enabled }),
-      pronunciationSpeed: 0.8,
+      pronunciationSpeed: 1.0,
       setPronunciationSpeed: speed => set({ pronunciationSpeed: speed }),
       pronunciationPitch: 1.0,
       setPronunciationPitch: pitch => set({ pronunciationPitch: pitch }),


### PR DESCRIPTION
## Summary
This PR fixes and enhances the Japanese text-to-speech (TTS) voice system to ensure it always uses Japanese voices, properly applies speed/pitch settings, and works reliably in both Chrome and Firefox.

## Issues Fixed
- ✅ Voice features not working in Firefox after merge
- ✅ Voice selection not strictly prioritizing Japanese voices
- ✅ Stale closure bugs causing incorrect voice selection
- ✅ Speed/pitch settings not properly validated (defaults and ranges)
- ✅ No user notification when Japanese voices aren't available
- ✅ Users confused why Chrome has Japanese voices but Firefox doesn't

## Solution
- ✅ **Strict Japanese Voice Priority**: Only accepts Japanese voices (ja-JP → ja), fallback only if none exist
- ✅ **Fixed Stale Closure Bug**: Uses refs to avoid stale closures in speak callback
- ✅ **Speed/Pitch Validation**: Added validation (0.5-1.5 range) with defaults at 1.0x
- ✅ **Firefox Compatibility**: Proper voice matching from current voices list
- ✅ **User Notifications**: Clear messages explaining browser differences and installation steps
- ✅ **Ref Updates**: Fixed currentVoiceRef updates in loadVoices and refreshVoices

## Changes

### `hooks/useJapaneseTTS.ts`
- Enhanced voice filtering to strictly prioritize Japanese voices
- Fixed stale closure bug using refs (`currentVoiceRef`)
- Added speed/pitch validation (0.5-1.5 range)
- Improved Firefox compatibility with proper voice matching
- Added `hasJapaneseVoices` flag to track voice availability

### `components/reusable/AudioButton.tsx`
- Improved Firefox handling with longer delays
- Properly passes speed/pitch settings to speak function

### `components/Settings/Behavior.tsx`
- Added user notifications with browser-specific instructions
- Test button now uses speed/pitch settings
- Red warning text for better visibility
- Collapsible installation instructions for all OS/browsers

### `store/usePreferencesStore.ts`
- Updated default `pronunciationSpeed` from 0.8 to 1.0
- Pitch already defaulted to 1.0 (unchanged)

## Testing Checklist
- [x] Tested in Chrome - Japanese voices work correctly
- [x] Tested in Firefox - Japanese voices work with proper voice matching
- [x] Speed adjustment works (0.5x - 1.5x range)
- [x] Pitch adjustment works (0.5x - 1.5x range)
- [x] Voice selection prioritizes Japanese voices
- [x] User notifications display correctly when voices unavailable
- [x] Test button uses speed/pitch settings
- [x] Voice refresh works correctly
- [x] Fallback voices work when no Japanese voices available

## Browser Compatibility
- ✅ **Chrome/Edge** (Recommended): Works best with built-in Google TTS voices (includes Japanese by default)
- ⚠️ **Firefox**: Works but has limitations - relies on system voices (requires OS language packs to be installed)
- ⚠️ **Other browsers**: May have limitations depending on their Web Speech API implementation

**Note**: Chrome/Chromium-based browsers provide the best experience as they include Japanese TTS voices built-in. Firefox and other browsers require the user to install Japanese language packs in their operating system, which may not be available on all systems.

## User Experience Improvements
- Clear notifications explaining why Chrome has voices but Firefox doesn't
- Browser-specific installation instructions
- Better error messaging when voices aren't available
- Consistent speed/pitch defaults (1.0x)
- Warning that Chrome works best, other browsers may have limitations

## Breaking Changes
None - this is a bug fix and enhancement.

## Related Issues
Closes #127