### PR TITLE
fix(vocab): include 'international student' in meanings for ryuugakusei

### DIFF
--- a/static/vocab/n5/nouns.ts
+++ b/static/vocab/n5/nouns.ts
@@ -1911,8 +1911,8 @@ const N5Nouns = [
   {
     word: '留学生',
     reading: 'ryuugakusei りゅうがくせい',
-    displayMeanings: ['overseas student', 'exchange student'],
-    meanings: ['overseas student', 'exchange student']
+    displayMeanings: ['overseas student', 'exchange student', 'international student'],
+    meanings: ['overseas student', 'exchange student', 'international student']
   },
   {
     word: '財布',


### PR DESCRIPTION
Although according to [RomajiDesu Dictionary](https://www.romajidesu.com/dictionary/meaning-of-%E3%82%8A%E3%82%85%E3%81%86%E3%81%8C%E3%81%8F%E3%81%9B%E3%81%84.html), がいこくじんりゅうがくせい  (_gaikokujinryuugakusei_) is translated to _international student_, 
I can see in the [Oxford Dictionary](https://dictionary.cambridge.org/zhs/%E8%AF%8D%E5%85%B8/japanese-english/%E7%95%99%E5%AD%A6%E7%94%9F) that **りゅうがくせい**  (**_ryuugakusei_**) can be **also** translated to _international student_.