### PR TITLE
fix(layout): Prevent Kana cards from stretching to equal height

### DIFF
--- a/components/Dojo/Kana/KanaCards/index.tsx
+++ b/components/Dojo/Kana/KanaCards/index.tsx
@@ -62,15 +62,15 @@ const KanaCards = () => {
   return (
     <div
       className={clsx(
-        'flex flex-col gap-2 sm:flex-row w-full ',
-        cardBorderStyles
+        'flex flex-col gap-2 sm:flex-row w-full sm:items-start'
       )}
     >
-      {kanaGroups.map((kanaGroup, i) => (
+      {kanaGroups.map((kanaGroup) => (
         <Fragment key={kanaGroup.name}>
           <form
             className={clsx(
-              'flex flex-col w-full gap-2 sm:w-1/2 p-4 rounded-2xl'
+              'flex flex-col w-full gap-2 sm:w-1/2 p-4',
+              cardBorderStyles
             )}
           >
             <legend
@@ -165,16 +165,7 @@ const KanaCards = () => {
                 </div>
               ))}
           </form>
-
-          {i < kanaGroups.length - 1 && (
-            <div
-              className={clsx(
-                'sm:border-l-1 sm:h-auto sm:w-0',
-                'border-[var(--border-color)]',
-                'border-t-1 w-full border-[var(--border-color)]'
-              )}
-            />
-          )}
+          
         </Fragment>
       ))}
     </div>


### PR DESCRIPTION
### `fix(layout): Prevent Kana cards from stretching to equal height`

**Description**

This PR fixes a layout bug on the kana selection page where expanding one card (e.g., Hiragana) would cause the adjacent card (Katakana) to stretch vertically to match its height.

This was caused by the parent flex container (`sm:flex-row`) using the default `align-items: stretch`.

The fix involves two changes:
1.  **Moved `cardBorderStyles`**: The styles for the card background and border were moved from the parent wrapper `div` to the individual `<form>` elements. This correctly styles them as two separate cards.
2.  **Added `sm:items-start`**: This class was added to the parent flex container. It changes the alignment from `stretch` to `flex-start`, allowing each card to have its own independent height.

**Type of Change**
* [x] **Bug fix** (non-breaking change which fixes an issue)

**How to Test**
1.  Navigate to the page with the Hiragana and Katakana cards.
2.  View the page on a desktop or screen wider than the `sm` breakpoint.
3.  Click on the "Hiragana" heading to expand its content.
4.  **Verify:** The Hiragana card expands downwards, while the Katakana card remains at its original, compact height and does not stretch.

**Screenshots**

**Before:**
When the Hiragana card expands, the Katakana card is forced to stretch to the same height, even if its content is minimal.

<img width="1543" height="907" alt="image" src="https://github.com/user-attachments/assets/ad76a042-0dcb-4414-9927-8c29f46e69cf" />



**After:**
The Hiragana card expands as expected, while the Katakana card retains its independent height and does not stretch.

<img width="1544" height="898" alt="Screenshot 2025-11-15 022848" src="https://github.com/user-attachments/assets/5e9caf85-9256-4874-b1bc-103cca279e23" />

<img width="1542" height="906" alt="image" src="https://github.com/user-attachments/assets/586a5fcf-44e9-483a-aefe-34745a9db4fe" />

