### PR TITLE
[FIX] Preferences Page not working on Opera

### DIFF
--- a/components/Settings/Behavior.tsx
+++ b/components/Settings/Behavior.tsx
@@ -517,10 +517,7 @@ const Behavior = () => {
               })()}
             {availableVoices.length === 0 && (
               <div className="text-sm text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20 p-3 rounded-lg border border-orange-200 dark:border-orange-800">
-                <strong>⚠️ Notice:</strong> No voices are available. Please
-                refresh voices or check your browser&apos;s speech synthesis
-                settings. This is not a system issue - your browser may need
-                additional language packs.
+                <strong>⚠️ Notice:</strong> No voices are available. Please refresh voices or check your system and browser speech synthesis settings. This may be due to the operating system (e.g., privacy-oriented OS without a default TTS engine) or an unsupported API (e.g., Opera Mobile does not support speech synthesis).
               </div>
             )}
           </div>

--- a/hooks/useJapaneseTTS.ts
+++ b/hooks/useJapaneseTTS.ts
@@ -58,7 +58,7 @@ export const useJapaneseTTS = () => {
 
   // Check browser support and load voices
   useEffect(() => {
-    if (!isClient) return;
+    if (!isClient || !('speechSynthesis' in window)) return;
 
     // Assume TTS is supported in modern browsers
     const isSupported = true;


### PR DESCRIPTION
## Description

Fix crash on Opera Mobile caused by unsupported speech synthesis
**Note:** Users may need to switch to a different browser if they want to use the 'Voice pronunciation' feature.

## Fix

Closes #179

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] I followed the code style
- [x] I tested the changes locally
- [x] My changes work on mobile, tablet, and desktop