### PR TITLE
[fix] Move translation links to top of page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo is available in multiple languages thanks to community contributions:**
+
+English (default)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>	
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -443,21 +447,6 @@ This project is licensed under the AGPL 3.0 License - see the [LICENSE.md](LICEN
 - Japanese language data and character information
 - Open-source community for the amazing tools and libraries
 - All contributors who help make KanaDojo better
-
-## Translations
-
-KanaDojo is available in multiple languages thanks to community contributions:
-
-- English (default)
-- [Español](docs/translations/README.es.md)
-- [Français](docs/translations/README.fr.md) in progress
-- [Deutsch](docs/translations/README.de.md)
-- [Português](docs/translations/README.pt-br.md)
-- [Türkçe](docs/translations/README.tr.md)
-- [中文（简体）](docs/translations/README.zh-CN.md)
-- [中文（繁體）](docs/translations/README.zh-tw.md)
-- [हिन्दी](docs/translations/README.hin.md)
-- <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>
 
 ## 📞 Contact & Links
 


### PR DESCRIPTION
As #185 mentioned, I move translation links to top of README for better visibility. 
Before:
<img width="1098" height="722" alt="屏幕截图 2025-11-15 215710" src="https://github.com/user-attachments/assets/352d0d6d-4d5e-4fc1-9db3-987851fc2204" />

After:
<img width="1287" height="680" alt="屏幕截图 2025-11-15 215721" src="https://github.com/user-attachments/assets/5954686b-c0b9-43a6-ae40-acafccae9a00" />
