### PR TITLE
Further move translation links to the top of README.md in all versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **KanaDojo is available in multiple languages thanks to community contributions:**
 
-English (default)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>	
+English (default)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/**  [Русский](docs/translations/README.ru.md)
 
 # KanaDojo かな道場
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo is available in multiple languages thanks to community contributions:**
+
+English (default)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>	
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -443,21 +447,6 @@ This project is licensed under the AGPL 3.0 License - see the [LICENSE.md](LICEN
 - Japanese language data and character information
 - Open-source community for the amazing tools and libraries
 - All contributors who help make KanaDojo better
-
-## Translations
-
-KanaDojo is available in multiple languages thanks to community contributions:
-
-- English (default)
-- [Español](docs/translations/README.es.md)
-- [Français](docs/translations/README.fr.md) in progress
-- [Deutsch](docs/translations/README.de.md)
-- [Português](docs/translations/README.pt-br.md)
-- [Türkçe](docs/translations/README.tr.md)
-- [中文（简体）](docs/translations/README.zh-CN.md)
-- [中文（繁體）](docs/translations/README.zh-tw.md)
-- [हिन्दी](docs/translations/README.hin.md)
-- <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>
 
 ## 📞 Contact & Links
 

--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo متاح بعدة لغات بفضل مساهمات المجتمع:**
+
+[English](../../README.md) **/** [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md) **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/** [हिन्दी](docs/translations/README.hin.md) **/** العربية  **/** [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -205,7 +209,7 @@ npm run lint
 # توليد خريطة الموقع (يتم تلقائيًا بعد البناء)
 npm run postbuild
 ```
- 
+
 ###استكشاف الأخطاء
 وإصلاحهاإذا واجهت مشكلات أثناء التطوير، جرب هذه الحلول:
 
@@ -304,7 +308,7 @@ taskkill /PID PID /F
 PORT=3001 npm run dev
 ```
  ## 📁 هيكل المشروع
- 
+
 ```
 kanadojo/
 ├── app/                          # صفحات Next.js App Router
@@ -402,7 +406,7 @@ ___
 4. يتتبع الإحصائيات (صحيح، خاطئ، سلسلة)
 
  ## 🤝 المساهمة
- 
+
  لمساهمات مرحب بها! KanaDojo هو مشروع مفتوح المصدر يبنيه المجتمع، من أجل المجتمع. اطلع على [CONTRIBUTING.md](CONTRIBUTING.md) للحصول على معلومات مفصلة 
  حول كيفية المساهمة.كيفية المساهمةفرّع المستودع
 
@@ -421,29 +425,15 @@ ___
 - حافظ على تركيز المكونات وقابليتها لإعادة الاستخدام
 
  ## 📄 رخصة 
- 
+
  المشروع مرخص بموجب ترخيص AGPL 3.0 - اطلع على ملف LICENSE.md للتفاصيل.
- 
+
  ## 🙏 الشكر
- 
+
  - بيانات اللغة اليابانية ومعلومات الأحرف
  - مجتمع المصادر المفتوحة على الأدوات والمكتبات الرائعة
  - جميع المساهمين الذين ساعدوا في تحسين KanaDojo
    
-## الترجمات
-
-KanaDojo متاح بعدة لغات بفضل مساهمات المجتمع:
-
-- English (default)
-- Español (docs/translations/README.es.md)
-- Français (docs/translations/README.fr.md) قيد التقدم
-- Deutsch (docs/translations/README.de.md)
-- Português (docs/translations/README.pt-br.md)
-- 中文（简体） (docs/translations/README.zh-CN.md)
-- 中文（繁體） (docs/translations/README.zh-tw.md)
-- हिन्दी (docs/translations/README.hin.md)
-- <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>
-
 ## 📞 الاتصال والروابط
 
 الاتصال والروابطالموقع الإلكتروني: [kanadojo.com](https://kanadojo.com)

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -1,10 +1,14 @@
 <div id="top"></div>
 
+**KanaDojo ist dank Community-Beiträgen in mehreren Sprachen verfügbar:**
+
+[English](../../README.md) **/** [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md) **/** Deutsch **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/** [हिन्दी](docs/translations/README.hin.md) **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/** [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
 
-![KanaDojo Banner](https://github.com/user-attachments/assets/d64d5fdd-e49b-4eb5-8de6-0e73c8f95d01)
+![KanaDojo Banner](https://github.com/user-attachments/assets/b7931764-be5e-43c7-b1b3-9d2568b2fecf)
 
 Eine ästhetische, minimalistische und hochgradig anpassbare Plattform zur Beherrschung der japanischen Sprache
 
@@ -445,20 +449,6 @@ Dieses Projekt ist unter der **AGPL 3.0 Lizenz** lizenziert – Details finden S
 - Japanische Sprachdaten und Zeicheninformationen.
 - Die Open-Source-Community für die großartigen Tools und Bibliotheken.
 - Alle Mitwirkenden, die helfen, KanaDojo besser zu machen.
-
----
-
-## 🌍 Übersetzungen
-
-KanaDojo ist dank Community-Beiträgen in mehreren Sprachen verfügbar:
-
-- [🇬🇧 Englisch (Standard)](../../README.md)
-- [🇪🇸 Español](README.es.md)
-- [🇫🇷 Français](README.fr.md) _(in Bearbeitung)_
-- [🇮🇳 हिन्दी](README.hin.md)
-- [🇧🇷 Português (Brasil)](README.pt-br.md)
-- [🇹🇼 繁體中文](README.zh-tw.md) _(in Bearbeitung)_
-- [🇩🇪 Deutsch](README.de.md)
 
 ---
 

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo está disponible en varios idiomas gracias a las contribuciones de la comunidad:**
+
+[English](../../README.md) **/** Español **/** [Français (in progress)](docs/translations/README.fr.md) **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/** [हिन्दी](docs/translations/README.hin.md) **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/** [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -451,19 +455,6 @@ Este proyecto está bajo la Licencia AGPL 3.0 - consulta el archivo [LICENSE.md]
 - **Sitio Web**: [kanadojo.com](https://kanadojo.com)
 - **Repositorio**: [github.com/lingdojo/kanadojo](https://github.com/lingdojo/kanadojo)
 - **Email**: lingdojo.dev@gmail.com
-
----
-
-## 🌍 Traducciones
-
-- [English (default)](../../README.md)
-- Español (este documento)
-- [Français](README.fr.md)
-- [Deutsch](README.de.md)
-- [Português](README.pt-br.md)
-- [中文（简体）](README.zh-CN.md)
-- [中文（繁體）](README.zh-tw.md)
-- [हिन्दी](README.hin.md)
 
 ---
 

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo est disponible en plusieurs langues grâce aux contributions de la communauté :**
+
+[English](../../README.md)  **/**  [Español](docs/translations/README.es.md) **/**  Français (in progress)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/** [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -405,18 +409,7 @@ Ce projet est sous licence AGPL 3.0 - voir le fichier [LICENSE.md](LICENSE.md) p
 - Communauté open-source pour les outils et bibliothèques incroyables
 - Tous les contributeurs qui aident à améliorer KanaDojo
 
-## Traductions
-
-KanaDojo est disponible en plusieurs langues grâce aux contributions de la communauté :
-
-- [English (par défaut)](../../README.md)
-- [Español](README.es.md)
-- Français (ce document)
-- [Deutsch](README.de.md)
-- [Português](README.pt-br.md)
-- [中文（简体）](README.zh-CN.md)
-- [中文（繁體）](README.zh-tw.md)
-- [हिन्दी](README.hin.md)
+- README.hin.md)
 
 ## 📞 Contact & Liens
 

--- a/docs/translations/README.hin.md
+++ b/docs/translations/README.hin.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo कई भाषाओं में उपलब्ध है, समुदाय के योगदानों के कारण।:**
+
+[English](../../README.md)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  हिन्दी  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/** [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">

--- a/docs/translations/README.pt-br.md
+++ b/docs/translations/README.pt-br.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo está disponível em vários idiomas graças às contribuições da comunidade:**
+
+[English](../../README.md)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** Português **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/**  [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -451,19 +455,6 @@ Este projeto está licenciado sob a Licença AGPL 3.0 - veja o arquivo [LICENSE.
 - **Website**: [kanadojo.com](https://kanadojo.com)
 - **Repositório**: [github.com/lingdojo/kanadojo](https://github.com/lingdojo/kanadojo)
 - **Email**: lingdojo.dev@gmail.com
-
----
-
-## 🌍 Traduções
-
-- [English (padrão)](../../README.md)
-- [Español](README.es.md)
-- [Français](README.fr.md)
-- [Deutsch](README.de.md)
-- Português (este documento)
-- [中文（简体）](README.zh-CN.md)
-- [中文（繁體）](README.zh-tw.md)
-- [हिन्दी](README.hin.md)
 
 ---
 

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo доступен на нескольких языках благодаря вкладу сообщества:**
+
+[English](../../README.md)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/**  Русский
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -442,21 +446,6 @@ kanadojo/
 - Данные по японскому языку и информация о символах
 - Сообществу с открытым исходным кодом за отличные инструменты и библиотеки
 - Всем участникам, которые помогают улучшать KanaDojo
-
-## 🌐 Переводы
-
-KanaDojo доступен на нескольких языках благодаря вкладу сообщества:
-
-- English (по умолчанию)
-- [Español](docs/translations/README.es.md)
-- [Français](docs/translations/README.fr.md) — в процессе
-- [Deutsch](docs/translations/README.de.md)
-- [Português](docs/translations/README.pt-br.md)
-- [Türkçe](docs/translations/README.tr.md)
-- [中文（简体）](docs/translations/README.zh-CN.md)
-- [中文（繁體）](docs/translations/README.zh-tw.md)
-- [हिन्दी](docs/translations/README.hin.md)
-- <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>
 
 ## 📞 Контакты и ссылки
 

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo, topluluk katkıları sayesinde birden çok dilde mevcuttur:**
+
+[English](../../README.md)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** Türkçe **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/**  [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -439,21 +443,6 @@ Bu proje AGPL 3.0 Lisansı altında lisanslanmıştır - ayrıntılar için [LIC
 - Japonca dil verileri ve karakter bilgileri
 - Harika araçlar ve kütüphaneler için açık kaynak topluluğu
 - KanaDojo'yu daha iyi hale getirmek için katkı katkıda bulunanlar
-
-## Çeviriler
-
-KanaDojo, topluluk katkıları sayesinde birden çok dilde mevcuttur:
-
-- English (varsayılan)
-- [Español](docs/translations/README.es.md)
-- [Français](docs/translations/README.fr.md) çeviriliyor
-- [Deutsch](docs/translations/README.de.md)
-- [Português](docs/translations/README.pt-br.md)
-- [Türkçe](docs/translations/README.tr.md)
-- [中文（简体）](docs/translations/README.zh-CN.md)
-- [中文（繁體）](docs/translations/README.zh-tw.md)
-- [हिन्दी](docs/translations/README.hin.md)
-- <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>
 
 ## 📞 İletişim & Bağlantılar
 

--- a/docs/translations/README.vi.md
+++ b/docs/translations/README.vi.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo is available in multiple languages thanks to community contributions:**
+
+[English](../../README.md)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/** [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -439,21 +443,6 @@ This project is licensed under the AGPL 3.0 License - see the [LICENSE.md](LICEN
 - Japanese language data and character information
 - Open-source community for the amazing tools and libraries
 - All contributors who help make KanaDojo better
-
-## Translations
-
-KanaDojo is available in multiple languages thanks to community contributions:
-
-- English (default)
-- [Español](docs/translations/README.es.md)
-- [Français](docs/translations/README.fr.md) in progress
-- [Deutsch](docs/translations/README.de.md)
-- [Português](docs/translations/README.pt-br.md)
-- [Türkçe](docs/translations/README.tr.md)
-- [中文（简体）](docs/translations/README.zh-CN.md)
-- [中文（繁體）](docs/translations/README.zh-tw.md)
-- [हिन्दी](docs/translations/README.hin.md)
-- <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>
 
 ## 📞 Contact & Links
 

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo 支持多语言，感谢社区贡献：**
+
+[English](../../README.md)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/**  中文（简体）**/** [中文（繁體）](docs/translations/README.zh-tw.md) **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/** [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -454,21 +458,6 @@ kanadojo/
 - 日语语言数据与字符信息
 - 开源社区提供的优秀工具与库
 - 所有为 KanaDojo 贡献的伙伴
-
----
-
-## 翻译
-
-KanaDojo 因社区贡献而支持多语言：
-
-- [English（默认）](../../README.md)
-- [Español](README.es.md)
-- [Français](README.fr.md)（进行中）
-- [Deutsch](README.de.md)
-- [Português](README.pt-br.md)
-- 中文（简体，当前文档）
-- [中文（繁體）](README.zh-tw.md)
-- [हिन्दी](README.hin.md)
 
 ---
 

--- a/docs/translations/README.zh-tw.md
+++ b/docs/translations/README.zh-tw.md
@@ -1,5 +1,9 @@
 <div id="top"></div>
 
+**KanaDojo 感謝社群貢獻，支持多種語言：**
+
+[English(default)](../../README.md)  **/**  [Español](docs/translations/README.es.md) **/** [Français (in progress)](docs/translations/README.fr.md)  **/** [Deutsch](docs/translations/README.de.md) **/** [Português](docs/translations/README.pt-br.md) **/** [Türkçe](docs/translations/README.tr.md) **/** [中文（简体）](docs/translations/README.zh-CN.md) **/**  中文（繁體） **/**  [हिन्दी](docs/translations/README.hin.md)  **/**  <span dir="ltr">[العربية](docs/translations/README.ar.md)</span>  **/** [Русский](docs/translations/README.ru.md)
+
 # KanaDojo かな道場
 
 <div align="center">
@@ -451,19 +455,6 @@ kanadojo/
 - **網站**：[kanadojo.com](https://kanadojo.com)
 - **儲存庫**：[github.com/lingdojo/kanadojo](https://github.com/lingdojo/kanadojo)
 - **電子郵件**: lingdojo.dev@gmail.com
-
----
-
-## 🌍 翻譯
-
-- [English（預設）](../../README.md)
-- [Español](README.es.md)
-- [Français](README.fr.md)
-- [Deutsch](README.de.md)
-- [Português](README.pt-br.md)
-- 中文（繁體，當前文件）
-- [中文（简体）](README.zh-CN.md)
-- [हिन्दी](README.hin.md)
 
 ---
 


### PR DESCRIPTION
I :
1. Moved translation links to the top of README in docs/translations and updated the default README.md.
2. Added `README.ru.md` to the links, as it was in the translations folder but missing from the list.
3. Replaced the first image in `README.de.md` due to a broken link (see Figure f).
4. Added AI-translated versions of "KanaDojo is available in multiple languages thanks to community contributions" to files missing them.
5. README.vi.md matches the English version exactly, so only the link was moved—no other changes.

Here are the screenshots of the modification:
Figure a.
<img width="1214" height="362" alt="屏幕截图 2025-11-15 233200" src="https://github.com/user-attachments/assets/676eaef2-5bf9-4016-ad2d-77ec6145f2c8" />
Figure b.
<img width="1200" height="320" alt="屏幕截图 2025-11-15 233226" src="https://github.com/user-attachments/assets/96893176-9363-493e-ad06-4388d8c08587" />
Figure c.
<img width="1218" height="358" alt="屏幕截图 2025-11-15 233132" src="https://github.com/user-attachments/assets/bef5820e-5df2-4d3b-b598-db261eda7b57" />
Figure d.
<img width="1261" height="367" alt="屏幕截图 2025-11-15 232513" src="https://github.com/user-attachments/assets/e8f9c701-5825-45f0-951f-a4616e7d3838" />
Figure e.
<img width="1227" height="340" alt="屏幕截图 2025-11-15 232559" src="https://github.com/user-attachments/assets/84e03e0b-7a82-48a7-9a4a-f03b5e971a50" />
Figure f.
<img width="1249" height="482" alt="屏幕截图 2025-11-15 232818" src="https://github.com/user-attachments/assets/71d8b555-e866-4780-a954-738889371e3c" />
Figure g.
<img width="1231" height="432" alt="屏幕截图 2025-11-15 232851" src="https://github.com/user-attachments/assets/ccbc15f8-1f95-48c7-9069-c877ae55ed9f" />
Figure h.
<img width="1257" height="359" alt="屏幕截图 2025-11-15 232917" src="https://github.com/user-attachments/assets/ad83cad7-26ef-4809-9fb8-212ed1477c34" />
Figure i.
<img width="1302" height="346" alt="屏幕截图 2025-11-15 232950" src="https://github.com/user-attachments/assets/2441d1d5-e628-4a02-96d8-8efd2b7b2c36" />
Figure j.
<img width="1212" height="368" alt="屏幕截图 2025-11-15 233048" src="https://github.com/user-attachments/assets/56973e07-68f5-4c3a-8628-f2d6ca9e22c9" />
Figure k.
<img width="1233" height="334" alt="屏幕截图 2025-11-15 233113" src="https://github.com/user-attachments/assets/8dfd0d95-73e5-4a77-9c13-c3621ead67ea" />
Figure i.
<img width="1259" height="377" alt="屏幕截图 2025-11-15 233302" src="https://github.com/user-attachments/assets/197c69b2-017f-477e-9db7-04bfd7fa9aaa" />
