### PR TITLE
feat(theme): add Cosmic Dream dark theme — #142

### DIFF
--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -411,6 +411,32 @@ The `Cosmic Dream` theme brings an aurora/nebula-inspired dark palette to KanaDo
 - Use `--main-color` for headings, CTAs, and high-emphasis text.
 - Use `--secondary-color` for secondary text, icons, and supportive UI elements.
 
+* **Tailwind example:**
+
+```tsx
+<div className="bg-[var(--background-color)] min-h-screen text-[var(--main-color)]">
+  <div className="rounded-xl bg-[var(--card-color)] border border-[var(--border-color)] p-6">
+    <h1 className="text-2xl font-bold text-[var(--main-color)]">Cosmic Dream — Nebula Aurora</h1>
+    <p className="text-sm text-[var(--secondary-color)]">Soft, ethereal helper text and accents</p>
+  </div>
+</div>
+```
+
+* **Accessibility / contrast notes:**
+
+  * `--main-color` (vibrant magenta) on `--background-color` should provide strong contrast for primary content; still validate with WebAIM, axe, or Lighthouse for edge cases.
+  * `--secondary-color` (soft light blue) is intended for secondary text and icons — confirm it maintains adequate contrast on both `--background-color` and `--card-color` for the sizes you use.
+  * `--border-color` on `--card-color` should meet at least a 3:1 ratio for interactive affordances; increase opacity if used as the primary focus indicator or for small UI chrome.
+  * If any contrast checks fail, adjust the lightness (L) value of the HSLA color(s) while keeping HSLA format and re-run checks.
+
+* **Developer checklist when adding/using `Cosmic Dream`:**
+
+  * Add the theme object to `static/themes.ts` under the `Dark` theme group (IDs must be kebab-case).
+  * Verify `applyTheme('cosmic-dream')` correctly updates CSS variables and the `data-theme` attribute.
+  * Run automated contrast tests (axe, Lighthouse) on both accent colors and document ratios in the PR.
+  * Test buttons, dialogs, inputs, modals, and other interactive components across breakpoints and accessibility modes.
+  * Consider providing a slightly lighter variant of `--main-color` or `--secondary-color` for disabled/low-emphasis states if needed to avoid blending with `--card-color`.
+
 **Accessibility / contrast notes:**
 - Verify `--main-color` and `--secondary-color` against `--background-color` and `--card-color` meet WCAG 2.1 AA for normal text (>= 4.5:1). Use WebAIM, axe, or Lighthouse to confirm.
 - If a contrast check fails, adjust the lightness (L) in the HSLA values and re-test, keeping the color values in HSLA format.

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -387,6 +387,40 @@ The `wabi` theme is inspired by traditional Japanese minimalism — the calm cla
   * Run automated contrast tests (axe, Lighthouse) on both accent colors.
   * Test buttons, dialogs, inputs, and other interactive components across breakpoints and accessibility modes.
 
+#### Cosmic Dream Theme (Dark — Nebula Aurora)
+
+The `Cosmic Dream` theme brings an aurora/nebula-inspired dark palette to KanaDojo. It uses only HSLA values and follows the 5-variable color model used across the project.
+
+- **id:** `cosmic-dream`
+- **Palette (from `static/themes.ts`):**
+```ts
+{
+  id: 'cosmic-dream',
+  backgroundColor: 'hsla(260, 62%, 11%, 1)', // deep cosmic purple/navy
+  cardColor:       'hsla(255, 58%, 16%, 1)', // slightly lighter starfield purple
+  borderColor:     'hsla(190, 98%, 58%, 1)', // luminous teal/cyan (nebula outline)
+  mainColor:       'hsla(294, 100%, 67%, 1)', // vibrant cosmic magenta (headline/primary)
+  secondaryColor:  'hsla(192, 100%, 86%, 1)', // soft light blue (subtle UI text/icons)
+}
+```
+
+**Usage guidance:**
+- Use `--background-color` for the large page background and overlays to establish the deep cosmic base.
+- Use `--card-color` for panels and cards to create subtle separation from the page background.
+- Use `--border-color` for borders, highlights, and luminous accents that suggest nebula edges.
+- Use `--main-color` for headings, CTAs, and high-emphasis text.
+- Use `--secondary-color` for secondary text, icons, and supportive UI elements.
+
+**Accessibility / contrast notes:**
+- Verify `--main-color` and `--secondary-color` against `--background-color` and `--card-color` meet WCAG 2.1 AA for normal text (>= 4.5:1). Use WebAIM, axe, or Lighthouse to confirm.
+- If a contrast check fails, adjust the lightness (L) in the HSLA values and re-test, keeping the color values in HSLA format.
+
+**Developer checklist when adding `Cosmic Dream`:**
+1. Ensure the theme object is added in `static/themes.ts` under the `Dark` group (IDs must be kebab-case).
+2. Run `applyTheme('cosmic-dream')` locally and visually inspect key UI surfaces (page background, cards, borders, headings, icons).
+3. Run automated contrast checks and include contrast ratios in the PR description.
+4. Add at least one screenshot (card + page + controls) to the PR for visual review.
+
 
 
   ### Theme Color Guidelines

--- a/docs/UI_DESIGN.md
+++ b/docs/UI_DESIGN.md
@@ -437,16 +437,6 @@ The `Cosmic Dream` theme brings an aurora/nebula-inspired dark palette to KanaDo
   * Test buttons, dialogs, inputs, modals, and other interactive components across breakpoints and accessibility modes.
   * Consider providing a slightly lighter variant of `--main-color` or `--secondary-color` for disabled/low-emphasis states if needed to avoid blending with `--card-color`.
 
-**Accessibility / contrast notes:**
-- Verify `--main-color` and `--secondary-color` against `--background-color` and `--card-color` meet WCAG 2.1 AA for normal text (>= 4.5:1). Use WebAIM, axe, or Lighthouse to confirm.
-- If a contrast check fails, adjust the lightness (L) in the HSLA values and re-test, keeping the color values in HSLA format.
-
-**Developer checklist when adding `Cosmic Dream`:**
-1. Ensure the theme object is added in `static/themes.ts` under the `Dark` group (IDs must be kebab-case).
-2. Run `applyTheme('cosmic-dream')` locally and visually inspect key UI surfaces (page background, cards, borders, headings, icons).
-3. Run automated contrast checks and include contrast ratios in the PR description.
-4. Add at least one screenshot (card + page + controls) to the PR for visual review.
-
 
 
   ### Theme Color Guidelines

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -692,6 +692,14 @@ const themes: ThemeGroup[] = [
         borderColor: "hsla(210, 24%, 23%, 1)",
         mainColor: "hsla(200, 55%, 75%, 1)",
         secondaryColor: "hsla(0, 0%, 92%, 1)",
+      },
+      {
+        id: 'cosmic-dream',
+        backgroundColor: 'hsla(260, 62%, 11%, 1)',
+        cardColor: 'hsla(255, 58%, 16%, 1)',
+        borderColor: 'hsla(190, 98%, 58%, 1)',
+        mainColor: 'hsla(294, 100%, 67%, 1)',
+        secondaryColor: 'hsla(192, 100%, 86%, 1)',
       }
     ],
   },


### PR DESCRIPTION
This PR adds a new dark theme called Cosmic Dream, inspired by nebulae and auroras to create an immersive, night-time study atmosphere. The theme uses only HSLA values, follows the repository’s 5-variable theme model, and is designed to be visually distinctive while preserving readability and accessibility.


close #142 