### PR TITLE
Add Dusk Voyager Theme

### DIFF
--- a/static/themes.ts
+++ b/static/themes.ts
@@ -108,6 +108,14 @@ const themes: ThemeGroup[] = [
         secondaryColor: 'hsla(280, 65%, 68%, 1)',
       },
       {
+        id: "dusk-voyager",
+        backgroundColor: "hsla(216, 32%, 11%, 1)",
+        cardColor: "hsla(216, 29%, 16%, 1)",
+        borderColor: "hsla(216, 26%, 24%, 1)",
+        mainColor: "hsla(198, 78%, 71%, 1)",
+        secondaryColor: "hsla(49, 94%, 57%, 1)",
+      },
+      {
         id: 'aizome',
         backgroundColor: 'hsla(215, 48%, 11%, 1)',
         cardColor: 'hsla(215, 46%, 15%, 1)',

--- a/static/themes.ts
+++ b/static/themes.ts
@@ -116,6 +116,14 @@ const themes: ThemeGroup[] = [
         secondaryColor: 'hsla(35, 35%, 72%, 1)',
       },
       {
+        id: "arashiyama",
+        backgroundColor: "hsla(150, 32%, 10%, 1)",
+        cardColor: "hsla(150, 30%, 14%, 1)",
+        borderColor: "hsla(150, 28%, 22%, 1)",
+        mainColor: "hsla(125, 65%, 52%, 1)",
+        secondaryColor: "hsla(85, 40%, 65%, 1)",
+      },
+      {
         id: 'matrix',
         backgroundColor: 'hsl(0, 0%, 0%)',
         cardColor: 'hsl(0, 0%, 2.5%)',


### PR DESCRIPTION
This PR adds the Dusk Voyager dark theme, inspired by the ambiance of a midnight bullet train and the subtle glow of urban nights. The palette blends deep inky blues with high-speed turquoise and warm streetlight gold, creating a calm, modern, and globally sophisticated study environment.

close #153 