### PR TITLE
chore: add PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+## 📝 Description
+
+...
+
+## 🔗 Related Issue
+
+Closes #
+
+## 🎯 Type of Change
+
+- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
+- [ ] `feat`: New feature (non-breaking change which adds functionality)
+- [ ] `docs`: Documentation update (e.g., this file, README)
+- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
+- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
+- [ ] `refactor`: Code refactor (no functional changes)
+- [ ] `test`: Test update (adding missing tests or correcting existing tests)
+- [ ] `chore`: Build, CI/CD, or dependency updates
+
+## 🧪 How Has This Been Tested?
+
+**Test Steps:**
+
+1.  ...
+2.  ...
+
+**Manual Test Checklist:**
+
+- [ ] Tested in **Kana** dojo
+- [ ] Tested in **Kanji** dojo
+- [ ] Tested in **Vocabulary** dojo
+- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
+- [ ] ... (add any other specific tests)
+
+## 📸 Screenshots/Videos (if applicable)
+
+...
+
+## ✅ Pre-Submission Checklist
+
+- [ ] My code follows the project's code style and uses `cn()` utility where needed.
+- [ ] I have run the linter (`npm run lint`) and there are no new errors.
+- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
+- [ ] I have updated the documentation (if applicable).
+- [ ] This PR is against the `main` branch.
+
+## 📦 Additional Context
+
+...


### PR DESCRIPTION
Closes #198 

Adds a standard pull request template based on the rules in `CONTRIBUTING.md`.

This template will automatically populate the description for new PRs to help standardize submissions and ensure contributors follow required testing and linting procedures.