### PR TITLE
Add Starlit Plum theme to Dark group

### DIFF
--- a/static/themes.ts
+++ b/static/themes.ts
@@ -708,7 +708,17 @@ const themes: ThemeGroup[] = [
         borderColor: 'hsla(176, 20%, 33%, 1)',
         mainColor: 'hsla(317, 98%, 81%, 1)',
         secondaryColor: 'hsla(61, 100%, 62%, 1)'
+      },
+      {
+        id: 'starlit-plum',
+        backgroundColor: 'hsla(285, 48%, 11%, 1)',
+        cardColor: 'hsla(285, 46%, 15%, 1)',
+        borderColor: 'hsla(285, 43%, 23%, 1)',
+        mainColor: 'hsla(320, 70%, 65%, 1)',
+        secondaryColor: 'hsla(200, 45%, 75%, 1)'
       }
+
+ 
     ]
   },
 


### PR DESCRIPTION
## 📝 Description

This PR introduces a new dark-mode theme called **Starlit Plum**, inspired by twilight skies and celestial tones.  
The theme enhances the UI with a refined blend of deep plum purples, soft twilight magenta, and silver-blue starlight accents.

The theme was added to:
``static/themes.ts``  
at the end of the **Dark** theme group.

### 🎨 Starlit Plum Colors (HSLA)
- **backgroundColor:** `hsla(285, 48%, 11%, 1)`  
- **cardColor:** `hsla(285, 46%, 15%, 1)`  
- **borderColor:** `hsla(285, 43%, 23%, 1)`  
- **mainColor:** `hsla(320, 70%, 65%, 1)`  
- **secondaryColor:** `hsla(200, 45%, 75%, 1)`

All colors follow UI_DESIGN.md rules and maintain proper elevation & contrast.

---

## 🔗 Related Issue

Closes # (add issue number if exists)

---

## 🎯 Type of Change

- [ ] `fix`
- [x] `feat`: New feature (adds new theme)
- [ ] `docs`
- [x] `style`: UI/Theme update
- [ ] `content`
- [ ] `refactor`
- [ ] `test`
- [ ] `chore`

---

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Launched the development server (`npm run dev`).
2. Opened the Theme Picker.
3. Selected **Starlit Plum**.
4. Verified colors across:
   - Cards  
   - Borders  
   - Text  
   - Main + secondary accents

**Manual Test Checklist:**

- [x] Tested theme visibility in UI
- [x] Verified color contrast readability
- [x] Tested in light/dark toggles
- [ ] Tested in Kana dojo
- [ ] Tested in Kanji dojo
- [ ] Tested in Vocabulary dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

---

## 📸 Screenshots (optional)

<img width="948" height="831" alt="Screenshot 2025-11-22 174656" src="https://github.com/user-attachments/assets/71eff2aa-21eb-4e65-a98e-abcda06c9082" />
<img width="1129" height="600" alt="Screenshot 2025-11-22 174708" src="https://github.com/user-attachments/assets/4a691857-1470-45af-9b27-74050241be43" />


---

## ✅ Pre-Submission Checklist

- [x] Code passes formatting/linting
- [x] Accessibility contrast validated
- [x] No breaking changes
- [x] PR title follows conventions
- [x] Theme appears correctly in picker
