### PR TITLE
Add Starlit Plum theme to Dark group

### DIFF
--- a/static/themes.ts
+++ b/static/themes.ts
@@ -708,7 +708,17 @@ const themes: ThemeGroup[] = [
         borderColor: 'hsla(176, 20%, 33%, 1)',
         mainColor: 'hsla(317, 98%, 81%, 1)',
         secondaryColor: 'hsla(61, 100%, 62%, 1)'
+      },
+      {
+        id: 'starlit-plum',
+        backgroundColor: 'hsla(285, 48%, 11%, 1)',
+        cardColor: 'hsla(285, 46%, 15%, 1)',
+        borderColor: 'hsla(285, 43%, 23%, 1)',
+        mainColor: 'hsla(320, 70%, 65%, 1)',
+        secondaryColor: 'hsla(200, 45%, 75%, 1)'
       }
+
+ 
     ]
   },
 


### PR DESCRIPTION
Added a new Starlit Plum theme to the Dark theme group in static/themes.ts.
This theme is inspired by elegant twilight plum tones, with silver and magenta accents.
Includes full HSLA color definitions following UI_DESIGN.md rules.

🔗 Related Issue

Closes # (leave empty if no issue exists)

🎯 Type of Change

 feat: New feature (adds functionality)

 style: UI/Theme change

 fix

 docs

 content

 refactor

 test

 chore

🧪 How Has This Been Tested?

Verified theme loads correctly in the app.

Confirmed colors apply through CSS variables.

Tested in theme picker.

Ensured there are no console errors.

<img width="948" height="831" alt="Screenshot 2025-11-22 174656" src="https://github.com/user-attachments/assets/47d533f6-9157-4fb3-93f0-af6563e8f24f" />

✅ Pre-Submission Checklist

 Theme added to the Dark group

 Colors follow HSLA format

 No unused variables

 Conflicts resolved

 Branch builds successfully