### PR TITLE
feat: add Crazy Mode

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -1,10 +1,9 @@
 'use client';
 import clsx from 'clsx';
-// 1. Import useState to hold the dynamically imported module
-import { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
 import usePreferencesStore from '@/features/themes';
-// 2. Remove the static import
-// import fonts from '@/static/fonts';
+import useCrazyModeStore from '@/features/crazy-mode/store/useCrazyModeStore';
+import { usePathname } from 'next/navigation';
 import { ScrollRestoration } from 'next-scroll-restoration';
 import WelcomeModal from '@/shared/components/Modals/WelcomeModal';
 import { AchievementNotificationContainer } from '@/shared/components/AchievementNotification';
@@ -29,13 +28,44 @@ export default function ClientLayout({
   const { theme } = usePreferencesStore();
   const font = usePreferencesStore(state => state.font);
 
+  // Crazy Mode Integration
+  const isCrazyMode = useCrazyModeStore(state => state.isCrazyMode);
+  const activeThemeId = useCrazyModeStore(state => state.activeThemeId);
+  const activeFontName = useCrazyModeStore(state => state.activeFontName);
+  const randomize = useCrazyModeStore(state => state.randomize);
+
+  // Determine effective theme and font
+  const effectiveTheme = isCrazyMode && activeThemeId ? activeThemeId : theme;
+  const effectiveFont = isCrazyMode && activeFontName ? activeFontName : font;
+
   // 3. Create state to hold the fonts module
   const [fontsModule, setFontsModule] = useState<FontObject[] | null>(null);
 
-  // 4. Dynamically import the fonts module only in production
+  // Calculate fontClassName based on the stateful fontsModule
+  const fontClassName = fontsModule
+    ? fontsModule.find((fontObj: FontObject) => effectiveFont === fontObj.name)?.font.className
+    : '';
+
+  useEffect(() => {
+    applyTheme(effectiveTheme); // This now sets both CSS variables AND data-theme attribute
+
+    if (typeof window !== 'undefined') {
+      window.history.scrollRestoration = 'manual';
+    }
+  }, [effectiveTheme]);
+
+  // Trigger randomization on page navigation
+  const pathname = usePathname();
+  useEffect(() => {
+    if (isCrazyMode) {
+      randomize();
+    }
+  }, [pathname, isCrazyMode, randomize]);
+
+  // Dynamically import the fonts module only in production
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
-      import('@/static/fonts')
+      import('@/features/themes/data/fonts')
         .then(module => {
           // Assuming 'fonts' is a default export from that module
           setFontsModule(module.default);
@@ -43,22 +73,13 @@ export default function ClientLayout({
         .catch(err => {
           console.error('Failed to dynamically load fonts:', err);
         });
+    } else {
+      // In development, import statically for easier debugging
+      import('@/features/themes/data/fonts').then(module => {
+        setFontsModule(module.default);
+      });
     }
   }, []); // Empty dependency array ensures this runs only once on mount
-
-  // 5. Calculate fontClassName based on the stateful fontsModule
-  // This will be an empty string if fontsModule is null (i.e., in dev or before prod load)
-  const fontClassName = fontsModule
-    ? fontsModule.find(fontObj => font === fontObj.name)?.font.className
-    : '';
-
-  useEffect(() => {
-    applyTheme(theme); // This now sets both CSS variables AND data-theme attribute
-
-    if (typeof window !== 'undefined') {
-      window.history.scrollRestoration = 'manual';
-    }
-  }, [theme]);
 
   useEffect(() => {
     // Resume AudioContext on first user interaction
@@ -80,8 +101,6 @@ export default function ClientLayout({
         data-scroll-restoration-id="container"
         className={clsx(
           'bg-[var(--background-color)] text-[var(--main-color)] min-h-[100dvh] max-w-[100dvw]',
-          // 6. Apply fontClassName. This is now implicitly conditional
-          // because fontClassName will only have a value in prod after load.
           fontClassName
         )}
         style={{

--- a/features/crazy-mode/hooks/useCrazyModeTrigger.ts
+++ b/features/crazy-mode/hooks/useCrazyModeTrigger.ts
@@ -1,0 +1,14 @@
+import useCrazyModeStore from '../store/useCrazyModeStore';
+
+export const useCrazyModeTrigger = () => {
+    const isCrazyMode = useCrazyModeStore(state => state.isCrazyMode);
+    const randomize = useCrazyModeStore(state => state.randomize);
+
+    const trigger = () => {
+        if (isCrazyMode) {
+            randomize();
+        }
+    };
+
+    return { trigger };
+};

--- a/features/crazy-mode/store/useCrazyModeStore.ts
+++ b/features/crazy-mode/store/useCrazyModeStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+import { themes } from '@/features/themes';
+import fonts from '@/features/themes/data/fonts';
+import { Random } from 'random-js';
+
+interface CrazyModeState {
+  isCrazyMode: boolean;
+  activeThemeId: string | null;
+  activeFontName: string | null;
+  toggleCrazyMode: () => void;
+  randomize: () => void;
+}
+
+const random = new Random();
+
+const useCrazyModeStore = create<CrazyModeState>((set, get) => ({
+  isCrazyMode: false,
+  activeThemeId: null,
+  activeFontName: null,
+
+  toggleCrazyMode: () => {
+    const wasActive = get().isCrazyMode;
+    if (!wasActive) {
+      // Turning ON: Trigger immediate randomization
+      get().randomize();
+      set({ isCrazyMode: true });
+    } else {
+      // Turning OFF: Reset active values
+      set({ isCrazyMode: false, activeThemeId: null, activeFontName: null });
+    }
+  },
+
+  randomize: () => {
+    // Flatten themes to get all available theme IDs
+    const allThemes = themes.flatMap(group => group.themes);
+    const randomTheme = allThemes[random.integer(0, allThemes.length - 1)];
+    
+    const randomFont = fonts[random.integer(0, fonts.length - 1)];
+
+    set({
+      activeThemeId: randomTheme.id,
+      activeFontName: randomFont.name,
+    });
+  },
+}));
+
+export default useCrazyModeStore;

--- a/features/kana/components/Game/Input.tsx
+++ b/features/kana/components/Game/Input.tsx
@@ -13,6 +13,7 @@ import useStats from '@/shared/hooks/useStats';
 import useStatsStore from '@/features/statistics';
 import Stars from '@/shared/components/Game/Stars';
 import SSRAudioButton from '@/shared/components/SSRAudioButton';
+import { useCrazyModeTrigger } from '@/features/crazy-mode/hooks/useCrazyModeTrigger';
 
 const random = new Random();
 
@@ -38,6 +39,7 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
   const { playClick } = useClick();
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
+  const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
@@ -123,6 +125,7 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
         <CircleCheck className='inline text-[var(--main-color)]' />
       </>
     );
+    triggerCrazyMode();
   };
 
   const handleWrongAnswer = () => {
@@ -142,6 +145,7 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
     } else {
       setScore(score - 1);
     }
+    triggerCrazyMode();
   };
 
   const generateNewCharacter = () => {

--- a/features/kana/components/Game/Pick.tsx
+++ b/features/kana/components/Game/Pick.tsx
@@ -14,6 +14,7 @@ import useStats from '@/shared/hooks/useStats';
 import useStatsStore from '@/features/statistics';
 import Stars from '@/shared/components/Game/Stars';
 import SSRAudioButton from '@/shared/components/SSRAudioButton';
+import { useCrazyModeTrigger } from '@/features/crazy-mode/hooks/useCrazyModeTrigger';
 
 const random = new Random();
 
@@ -38,6 +39,7 @@ const PickGame = ({ isHidden, isReverse = false }: PickGameProps) => {
 
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
+  const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
 
   const kanaGroupIndices = useKanaStore(state => state.kanaGroupIndices);
 
@@ -104,11 +106,11 @@ const PickGame = ({ isHidden, isReverse = false }: PickGameProps) => {
   const [shuffledVariants, setShuffledVariants] = useState(
     isReverse
       ? [correctKanaCharReverse, ...randomIncorrectOptions].sort(
-          () => random.real(0, 1) - 0.5
-        )
+        () => random.real(0, 1) - 0.5
+      )
       : [correctRomajiChar, ...randomIncorrectOptions].sort(
-          () => random.real(0, 1) - 0.5
-        )
+        () => random.real(0, 1) - 0.5
+      )
   );
 
   const [feedback, setFeedback] = useState(<>{'feedback ~'}</>);
@@ -120,11 +122,11 @@ const PickGame = ({ isHidden, isReverse = false }: PickGameProps) => {
     setShuffledVariants(
       isReverse
         ? [correctKanaCharReverse, ...getIncorrectOptions()].sort(
-            () => random.real(0, 1) - 0.5
-          )
+          () => random.real(0, 1) - 0.5
+        )
         : [correctRomajiChar, ...getIncorrectOptions()].sort(
-            () => random.real(0, 1) - 0.5
-          )
+          () => random.real(0, 1) - 0.5
+        )
     );
     if (isReverse) {
       speedStopwatch.start();
@@ -221,6 +223,7 @@ const PickGame = ({ isHidden, isReverse = false }: PickGameProps) => {
     incrementCorrectAnswers();
     setScore(score + 1);
     setWrongSelectedAnswers([]);
+    triggerCrazyMode();
   };
 
   const handleWrongAnswer = (selectedChar: string) => {
@@ -236,6 +239,7 @@ const PickGame = ({ isHidden, isReverse = false }: PickGameProps) => {
     } else {
       setScore(score - 1);
     }
+    triggerCrazyMode();
   };
 
   const displayChar = isReverse ? correctRomajiCharReverse : correctKanaChar;
@@ -274,9 +278,9 @@ const PickGame = ({ isHidden, isReverse = false }: PickGameProps) => {
               'text-5xl font-semibold pb-6 pt-3 w-full sm:w-1/5 flex flex-row justify-center items-center gap-1',
               buttonBorderStyles,
               wrongSelectedAnswers.includes(variantChar) &&
-                'hover:bg-[var(--card-color)] hover:border-[var(--border-color)] text-[var(--border-color)]',
+              'hover:bg-[var(--card-color)] hover:border-[var(--border-color)] text-[var(--border-color)]',
               !wrongSelectedAnswers.includes(variantChar) &&
-                'text-[var(--main-color)] hover:border-[var(--main-color)]'
+              'text-[var(--main-color)] hover:border-[var(--main-color)]'
             )}
             onClick={() => handleOptionClick(variantChar)}
           >

--- a/features/kanji/components/Game/Input.tsx
+++ b/features/kanji/components/Game/Input.tsx
@@ -14,6 +14,7 @@ import Stars from '@/shared/components/Game/Stars';
 import AnswerSummary from '@/shared/components/Game/AnswerSummary';
 import SSRAudioButton from '@/shared/components/SSRAudioButton';
 import FuriganaText from '@/shared/components/FuriganaText';
+import { useCrazyModeTrigger } from '@/features/crazy-mode/hooks/useCrazyModeTrigger';
 
 const random = new Random();
 
@@ -44,6 +45,7 @@ const KanjiInputGame = ({
   const { playClick } = useClick();
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
+  const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
@@ -54,9 +56,9 @@ const KanjiInputGame = ({
   const [correctChar, setCorrectChar] = useState(
     isReverse
       ? selectedKanjiObjs[random.integer(0, selectedKanjiObjs.length - 1)]
-          .meanings[0]
+        .meanings[0]
       : selectedKanjiObjs[random.integer(0, selectedKanjiObjs.length - 1)]
-          .kanjiChar
+        .kanjiChar
   );
 
   // Find the target character/meaning based on mode
@@ -145,6 +147,7 @@ const KanjiInputGame = ({
         <CircleCheck className="inline text-[var(--main-color)]" />
       </>
     );
+    triggerCrazyMode();
   };
 
   const handleWrongAnswer = () => {
@@ -167,6 +170,7 @@ const KanjiInputGame = ({
     } else {
       setScore(score - 1);
     }
+    triggerCrazyMode();
   };
 
   const generateNewCharacter = () => {
@@ -190,8 +194,8 @@ const KanjiInputGame = ({
     const displayTarget = isReverse
       ? targetChar
       : Array.isArray(targetChar)
-      ? targetChar[0]
-      : targetChar;
+        ? targetChar[0]
+        : targetChar;
 
     setFeedback(<>{`skipped ~ ${correctChar} = ${displayTarget}`}</>);
   };

--- a/features/kanji/components/Game/Pick.tsx
+++ b/features/kanji/components/Game/Pick.tsx
@@ -15,6 +15,7 @@ import Stars from '@/shared/components/Game/Stars';
 import AnswerSummary from '@/shared/components/Game/AnswerSummary';
 import SSRAudioButton from '@/shared/components/SSRAudioButton';
 import FuriganaText from '@/shared/components/FuriganaText';
+import { useCrazyModeTrigger } from '@/features/crazy-mode/hooks/useCrazyModeTrigger';
 
 const random = new Random();
 
@@ -44,14 +45,15 @@ const KanjiPickGame = ({
 
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
+  const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
 
   // State management based on mode
   const [correctChar, setCorrectChar] = useState(
     isReverse
       ? selectedKanjiObjs[random.integer(0, selectedKanjiObjs.length - 1)]
-          .meanings[0]
+        .meanings[0]
       : selectedKanjiObjs[random.integer(0, selectedKanjiObjs.length - 1)]
-          .kanjiChar
+        .kanjiChar
   );
 
   // Find the correct object based on the current mode
@@ -165,6 +167,7 @@ const KanjiPickGame = ({
     incrementCorrectAnswers();
     setScore(score + 1);
     setWrongSelectedAnswers([]);
+    triggerCrazyMode();
   };
 
   const handleWrongAnswer = (selectedOption: string) => {
@@ -177,6 +180,7 @@ const KanjiPickGame = ({
     } else {
       setScore(score - 1);
     }
+    triggerCrazyMode();
   };
 
   const generateNewCharacter = () => {
@@ -251,9 +255,9 @@ const KanjiPickGame = ({
                   buttonBorderStyles,
                   'text-[var(--border-color)]',
                   wrongSelectedAnswers.includes(option) &&
-                    'hover:bg-[var(--card-color)]',
+                  'hover:bg-[var(--card-color)]',
                   !wrongSelectedAnswers.includes(option) &&
-                    'text-[var(--main-color)]'
+                  'text-[var(--main-color)]'
                 )}
                 onClick={() => handleOptionClick(option)}
                 lang={isReverse ? 'ja' : undefined}
@@ -263,9 +267,9 @@ const KanjiPickGame = ({
                   reading={
                     isReverse
                       ? selectedKanjiObjs.find(obj => obj.kanjiChar === option)
-                          ?.onyomi[0] ||
-                        selectedKanjiObjs.find(obj => obj.kanjiChar === option)
-                          ?.kunyomi[0]
+                        ?.onyomi[0] ||
+                      selectedKanjiObjs.find(obj => obj.kanjiChar === option)
+                        ?.kunyomi[0]
                       : undefined
                   }
                 />

--- a/features/themes/components/Behavior.tsx
+++ b/features/themes/components/Behavior.tsx
@@ -3,7 +3,8 @@ import clsx from 'clsx';
 import { buttonBorderStyles } from '@/shared/lib/styles';
 import usePreferencesStore from '@/features/themes';
 import { useClick } from '@/shared/hooks';
-import { AudioLines, VolumeX, Volume2, RefreshCw, Play } from 'lucide-react';
+import { AudioLines, VolumeX, Volume2, RefreshCw, Play, Zap, ZapOff } from 'lucide-react';
+import useCrazyModeStore from '@/features/crazy-mode/store/useCrazyModeStore';
 import { useJapaneseTTS } from '@/shared/hooks/useJapaneseTTS';
 // import{Command, KeyboardOff} from 'lucide-react'
 // import HotkeyReference from './HotkeyReference';
@@ -523,6 +524,36 @@ const Behavior = () => {
           </div>
         </>
       )}
+
+      <h4 className="text-lg">Crazy Mode (Experimental):</h4>
+      <div className="flex flex-row gap-4">
+        <button
+          className={clsx(
+            buttonBorderStyles,
+            'text-center text-lg',
+            'w-1/2 md:w-1/4 p-4',
+            'flex flex-row gap-1.5 justify-center items-end',
+            'text-[var(--secondary-color)]',
+            'flex-1 overflow-hidden'
+          )}
+          onClick={() => {
+            playClick();
+            useCrazyModeStore.getState().toggleCrazyMode();
+          }}
+        >
+          <span>
+            <span className="text-[var(--main-color)]">
+              {useCrazyModeStore(state => state.isCrazyMode) && '\u2B24 '}
+            </span>
+            {useCrazyModeStore(state => state.isCrazyMode) ? 'On' : 'Off'}
+          </span>
+          {useCrazyModeStore(state => state.isCrazyMode) ? (
+            <Zap size={20} className="mb-0.5" />
+          ) : (
+            <ZapOff size={20} className="mb-0.5" />
+          )}
+        </button>
+      </div>
 
       {/*       <h4 className="text-lg">Enable hotkeys (desktop only):</h4>
       <div className="flex flex-row gap-4">

--- a/features/vocabulary/components/Game/Input.tsx
+++ b/features/vocabulary/components/Game/Input.tsx
@@ -15,6 +15,7 @@ import Stars from '@/shared/components/Game/Stars';
 import AnswerSummary from '@/shared/components/Game/AnswerSummary';
 import SSRAudioButton from '@/shared/components/SSRAudioButton';
 import FuriganaText from '@/shared/components/FuriganaText';
+import { useCrazyModeTrigger } from '@/features/crazy-mode/hooks/useCrazyModeTrigger';
 
 const random = new Random();
 
@@ -45,6 +46,7 @@ const VocabInputGame = ({
   const { playClick } = useClick();
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
+  const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
@@ -58,7 +60,7 @@ const VocabInputGame = ({
   const [correctChar, setCorrectChar] = useState(
     isReverse
       ? selectedWordObjs[random.integer(0, selectedWordObjs.length - 1)]
-          .meanings[0]
+        .meanings[0]
       : selectedWordObjs[random.integer(0, selectedWordObjs.length - 1)].word
   );
 
@@ -160,6 +162,7 @@ const VocabInputGame = ({
         <CircleCheck className='inline text-[var(--main-color)]' />
       </>
     );
+    triggerCrazyMode();
   };
 
   const handleWrongAnswer = () => {
@@ -181,6 +184,7 @@ const VocabInputGame = ({
     } else {
       setScore(score - 1);
     }
+    triggerCrazyMode();
   };
 
   const generateNewCharacter = () => {
@@ -209,8 +213,8 @@ const VocabInputGame = ({
     const displayTarget = isReverse
       ? targetChar
       : Array.isArray(targetChar)
-      ? targetChar[0]
-      : targetChar;
+        ? targetChar[0]
+        : targetChar;
 
     setFeedback(<>{`skipped ~ ${correctChar} = ${displayTarget}`}</>);
   };

--- a/features/vocabulary/components/Game/Pick.tsx
+++ b/features/vocabulary/components/Game/Pick.tsx
@@ -15,6 +15,7 @@ import Stars from '@/shared/components/Game/Stars';
 import AnswerSummary from '@/shared/components/Game/AnswerSummary';
 import SSRAudioButton from '@/shared/components/SSRAudioButton';
 import FuriganaText from '@/shared/components/FuriganaText';
+import { useCrazyModeTrigger } from '@/features/crazy-mode/hooks/useCrazyModeTrigger';
 
 const random = new Random();
 
@@ -44,6 +45,7 @@ const VocabPickGame = ({
 
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
+  const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
 
   // Quiz type: 'meaning' or 'reading'
   const [quizType, setQuizType] = useState<'meaning' | 'reading'>('meaning');
@@ -52,7 +54,7 @@ const VocabPickGame = ({
   const [correctChar, setCorrectChar] = useState(
     isReverse
       ? selectedWordObjs[random.integer(0, selectedWordObjs.length - 1)]
-          .meanings[0]
+        .meanings[0]
       : selectedWordObjs[random.integer(0, selectedWordObjs.length - 1)].word
   );
 
@@ -70,18 +72,18 @@ const VocabPickGame = ({
       ? correctWordObj?.word
       : correctWordObj?.meanings[0]
     : isReverse
-    ? correctWordObj?.reading
-    : correctWordObj?.reading;
+      ? correctWordObj?.reading
+      : correctWordObj?.reading;
 
   // Get incorrect options based on mode and quiz type
   const getIncorrectOptions = (): string[] => {
     const incorrectWordObjs = isReverse
       ? selectedWordObjs.filter(
-          currentWordObj => currentWordObj.meanings[0] !== correctChar
-        )
+        currentWordObj => currentWordObj.meanings[0] !== correctChar
+      )
       : selectedWordObjs.filter(
-          currentWordObj => currentWordObj.word !== correctChar
-        );
+        currentWordObj => currentWordObj.word !== correctChar
+      );
 
     if (quizType === 'meaning') {
       return incorrectWordObjs
@@ -173,6 +175,7 @@ const VocabPickGame = ({
     incrementCorrectAnswers();
     setScore(score + 1);
     setWrongSelectedAnswers([]);
+    triggerCrazyMode();
   };
 
   const handleWrongAnswer = (selectedOption: string) => {
@@ -185,6 +188,7 @@ const VocabPickGame = ({
     } else {
       setScore(score - 1);
     }
+    triggerCrazyMode();
   };
 
   const generateNewCharacter = () => {
@@ -274,9 +278,9 @@ const VocabPickGame = ({
                   'text-[var(--border-color)]',
                   isReverse ? 'text-4xl' : 'text-3xl',
                   wrongSelectedAnswers.includes(option) &&
-                    'hover:bg-[var(--card-color)]',
+                  'hover:bg-[var(--card-color)]',
                   !wrongSelectedAnswers.includes(option) &&
-                    'text-[var(--main-color)]'
+                  'text-[var(--main-color)]'
                 )}
                 onClick={() => handleOptionClick(option)}
                 lang={optionLang}
@@ -288,7 +292,7 @@ const VocabPickGame = ({
                     reading={
                       isReverse
                         ? selectedWordObjs.find(obj => obj.word === option)
-                            ?.reading
+                          ?.reading
                         : undefined
                     }
                   />


### PR DESCRIPTION
## 📝 Description

This PR introduces **Crazy Mode**, an experimental feature designed to make training more dynamic and fun (or chaotic!).

When enabled, Crazy Mode randomly changes the application's **theme** and **font**:
1.  **On Navigation**: Every time you navigate to a new page.
2.  **On Answer**: After every correct or incorrect answer in the Kana, Kanji, and Vocabulary games.

**Key Implementation Details:**
-   **State Management**: Uses a new `useCrazyModeStore` to manage the active random theme/font and toggle state.
-   **Performance**: Fonts are loaded dynamically via [ClientLayout](cci:1://file:///c:/Users/noor4/opensource/kana-dojo/app/ClientLayout.tsx:22:0-119:1) to ensure performance is not impacted when the feature is unused.
-   **Integration**: Hooks into the existing `applyTheme` logic and game components ([Pick](cci:1://file:///c:/Users/noor4/opensource/kana-dojo/features/kana/components/Game/Pick.tsx:25:0-303:2) and [Input](cci:1://file:///c:/Users/noor4/opensource/kana-dojo/features/kana/components/Game/Input.tsx:24:0-214:2) modes).
-   **User Preference**: Overrides user preferences while active but restores them perfectly when disabled.

## 🔗 Related Issue

Closes #189 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  Enabled "Crazy Mode" in **Settings > Behavior**.
2.  Navigated between Home, Kana, Kanji, and Vocabulary pages to verify theme/font randomization on route change.
3.  Played through Kana, Kanji, and Vocabulary games (both Pick and Input modes).
4.  Verified that the theme and font change immediately upon submitting an answer (correct or incorrect).
5.  Disabled Crazy Mode and verified that the original user-selected theme and font were restored.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Verified font loading works in both Dev and Production environments

## 📸 Screenshots/Videos (if applicable)

<img width="1882" height="913" alt="image" src="https://github.com/user-attachments/assets/b5ff139f-4684-4fbc-8717-7d7fd158f1e3" />
<img width="1886" height="903" alt="image" src="https://github.com/user-attachments/assets/6c2d47bb-756f-4b06-9d6f-ef77e458aee4" />
<img width="1875" height="908" alt="image" src="https://github.com/user-attachments/assets/300a4186-3323-4e7b-b5b5-00a0b895f210" />



## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

The font loading logic in [ClientLayout.tsx](/app/ClientLayout.tsx:0:0-0:0) was updated to use a dynamic import pointing to `@/features/themes/data/fonts`. This ensures fonts are loaded correctly in both development and production builds while maintaining code-splitting benefits.