### PR TITLE
Add Starlit Plum theme to Dark group

### DIFF
--- a/static/themes.ts
+++ b/static/themes.ts
@@ -708,7 +708,17 @@ const themes: ThemeGroup[] = [
         borderColor: 'hsla(176, 20%, 33%, 1)',
         mainColor: 'hsla(317, 98%, 81%, 1)',
         secondaryColor: 'hsla(61, 100%, 62%, 1)'
+      },
+      {
+        id: 'starlit-plum',
+        backgroundColor: 'hsla(285, 48%, 11%, 1)',
+        cardColor: 'hsla(285, 46%, 15%, 1)',
+        borderColor: 'hsla(285, 43%, 23%, 1)',
+        mainColor: 'hsla(320, 70%, 65%, 1)',
+        secondaryColor: 'hsla(200, 45%, 75%, 1)'
       }
+
+ 
     ]
   },
 


### PR DESCRIPTION
## Description
Adds the new **Starlit Plum** theme to the Dark theme group in `static/themes.ts`.

This theme is inspired by elegant twilight plum tones, with silver and magenta highlights.

## Type of Change
- [x] style: UI/Theme changes (new theme)

## How Has This Been Tested?
- [x] Tested theme rendering locally
- [x] Verified theme appears in theme picker
- [x] Verified no visual issues or missing variables

