### PR TITLE
feat(themes): add toggle for theme preview on hover

### DIFF
--- a/features/Themes/components/Behavior.tsx
+++ b/features/Themes/components/Behavior.tsx
@@ -10,7 +10,7 @@ import {
   RefreshCw,
   Play,
   Zap,
-  ZapOff
+  ZapOff,
 } from 'lucide-react';
 import useCrazyModeStore from '@/features/CrazyMode/store/useCrazyModeStore';
 import { useJapaneseTTS } from '@/shared/hooks/useJapaneseTTS';
@@ -20,35 +20,37 @@ import { useJapaneseTTS } from '@/shared/hooks/useJapaneseTTS';
 const Behavior = () => {
   const { playClick } = useClick();
 
-  const displayKana = usePreferencesStore(state => state.displayKana);
-  const setDisplayKana = usePreferencesStore(state => state.setDisplayKana);
+  const displayKana = usePreferencesStore((state) => state.displayKana);
+  const setDisplayKana = usePreferencesStore((state) => state.setDisplayKana);
 
-  const silentMode = usePreferencesStore(state => state.silentMode);
-  const setSilentMode = usePreferencesStore(state => state.setSilentMode);
+  const silentMode = usePreferencesStore((state) => state.silentMode);
+  const setSilentMode = usePreferencesStore((state) => state.setSilentMode);
 
   // Pronunciation settings
   const pronunciationEnabled = usePreferencesStore(
-    state => state.pronunciationEnabled
+    (state) => state.pronunciationEnabled
   );
   const setPronunciationEnabled = usePreferencesStore(
-    state => state.setPronunciationEnabled
+    (state) => state.setPronunciationEnabled
   );
   const pronunciationSpeed = usePreferencesStore(
-    state => state.pronunciationSpeed
+    (state) => state.pronunciationSpeed
   );
   const setPronunciationSpeed = usePreferencesStore(
-    state => state.setPronunciationSpeed
+    (state) => state.setPronunciationSpeed
   );
   const pronunciationPitch = usePreferencesStore(
-    state => state.pronunciationPitch
+    (state) => state.pronunciationPitch
   );
   const setPronunciationPitch = usePreferencesStore(
-    state => state.setPronunciationPitch
+    (state) => state.setPronunciationPitch
   );
-  const furiganaEnabled = usePreferencesStore(state => state.furiganaEnabled);
+  const furiganaEnabled = usePreferencesStore((state) => state.furiganaEnabled);
   const setFuriganaEnabled = usePreferencesStore(
-    state => state.setFuriganaEnabled
+    (state) => state.setFuriganaEnabled
   );
+  const themePreview = usePreferencesStore((state) => state.themePreview);
+  const setThemePreview = usePreferencesStore((state) => state.setThemePreview);
 
   type Prefs = ReturnType<typeof usePreferencesStore.getState>;
   const pronunciationVoiceName = usePreferencesStore(
@@ -64,7 +66,7 @@ const Behavior = () => {
     setVoice,
     speak,
     refreshVoices,
-    hasJapaneseVoices
+    hasJapaneseVoices,
   } = useJapaneseTTS();
 
   /*   const hotkeysOn = useThemeStore(state => state.hotkeysOn);
@@ -78,11 +80,11 @@ const Behavior = () => {
   ]; */
 
   return (
-    <div className='flex flex-col gap-4'>
-      <h4 className='text-lg'>
+    <div className="flex flex-col gap-4">
+      <h4 className="text-lg">
         In the character selection menu, for readings, display:
       </h4>
-      <div className='flex flex-row gap-4'>
+      <div className="flex flex-row gap-4">
         <button
           className={clsx(
             buttonBorderStyles,
@@ -96,7 +98,7 @@ const Behavior = () => {
             setDisplayKana(false);
           }}
         >
-          <span className='text-[var(--main-color)]'>
+          <span className="text-[var(--main-color)]">
             {!displayKana && '\u2B24 '}
           </span>
           Romaji&nbsp;🇺🇸
@@ -114,16 +116,16 @@ const Behavior = () => {
             setDisplayKana(true);
           }}
         >
-          <span className='text-[var(--main-color)]'>
+          <span className="text-[var(--main-color)]">
             {displayKana && '\u2B24 '}
           </span>
           Kana&nbsp;🇯🇵
         </button>
       </div>
-      <h4 className='text-lg'>
+      <h4 className="text-lg">
         Show furigana (reading) above the character/word for kanji/vocabulary:
       </h4>
-      <div className='flex flex-row gap-4'>
+      <div className="flex flex-row gap-4">
         <button
           className={clsx(
             buttonBorderStyles,
@@ -139,12 +141,12 @@ const Behavior = () => {
           }}
         >
           <span>
-            <span className='text-[var(--main-color)]'>
+            <span className="text-[var(--main-color)]">
               {furiganaEnabled && '\u2B24 '}
             </span>
             on
           </span>
-          <span className='text-sm mb-0.5'>ふり</span>
+          <span className="text-sm mb-0.5">ふり</span>
         </button>
         <button
           className={clsx(
@@ -161,7 +163,7 @@ const Behavior = () => {
           }}
         >
           <span>
-            <span className='text-[var(--main-color)]'>
+            <span className="text-[var(--main-color)]">
               {!furiganaEnabled && '\u2B24 '}
             </span>
             off
@@ -169,8 +171,8 @@ const Behavior = () => {
         </button>
       </div>
 
-      <h4 className='text-lg'>Play UI + feedback sound effects:</h4>
-      <div className='flex flex-row gap-4'>
+      <h4 className="text-lg">Play UI + feedback sound effects:</h4>
+      <div className="flex flex-row gap-4">
         <button
           className={clsx(
             buttonBorderStyles,
@@ -186,12 +188,12 @@ const Behavior = () => {
           }}
         >
           <span>
-            <span className='text-[var(--main-color)]'>
+            <span className="text-[var(--main-color)]">
               {!silentMode && '\u2B24 '}
             </span>
             on
           </span>
-          <AudioLines size={20} className='mb-0.5' />
+          <AudioLines size={20} className="mb-0.5" />
         </button>
         <button
           className={clsx(
@@ -208,17 +210,17 @@ const Behavior = () => {
           }}
         >
           <span>
-            <span className='text-[var(--main-color)]'>
+            <span className="text-[var(--main-color)]">
               {silentMode && '\u2B24 '}
             </span>
             off
           </span>
-          <VolumeX size={20} className='mb-0.5' />
+          <VolumeX size={20} className="mb-0.5" />
         </button>
       </div>
 
-      <h4 className='text-lg'>Enable pronunciation audio:</h4>
-      <div className='flex flex-row gap-4'>
+      <h4 className="text-lg">Enable pronunciation audio:</h4>
+      <div className="flex flex-row gap-4">
         <button
           className={clsx(
             buttonBorderStyles,
@@ -234,12 +236,12 @@ const Behavior = () => {
           }}
         >
           <span>
-            <span className='text-[var(--main-color)]'>
+            <span className="text-[var(--main-color)]">
               {pronunciationEnabled && '\u2B24 '}
             </span>
             on
           </span>
-          <Volume2 size={20} className='mb-0.5' />
+          <Volume2 size={20} className="mb-0.5" />
         </button>
         <button
           className={clsx(
@@ -256,64 +258,68 @@ const Behavior = () => {
           }}
         >
           <span>
-            <span className='text-[var(--main-color)]'>
+            <span className="text-[var(--main-color)]">
               {!pronunciationEnabled && '\u2B24 '}
             </span>
             off
           </span>
-          <VolumeX size={20} className='mb-0.5' />
+          <VolumeX size={20} className="mb-0.5" />
         </button>
       </div>
 
       {pronunciationEnabled && (
         <>
-          <h4 className='text-lg'>Pronunciation speed:</h4>
-          <div className='flex flex-col gap-2'>
+          <h4 className="text-lg">Pronunciation speed:</h4>
+          <div className="flex flex-col gap-2">
             <input
-              type='range'
-              min='0.5'
-              max='1.5'
-              step='0.1'
+              type="range"
+              min="0.5"
+              max="1.5"
+              step="0.1"
               value={pronunciationSpeed}
-              onChange={e => setPronunciationSpeed(parseFloat(e.target.value))}
-              className='w-full'
+              onChange={(e) =>
+                setPronunciationSpeed(parseFloat(e.target.value))
+              }
+              className="w-full"
             />
-            <div className='text-sm text-[var(--secondary-color)] text-center'>
+            <div className="text-sm text-[var(--secondary-color)] text-center">
               {pronunciationSpeed}x
             </div>
           </div>
 
-          <h4 className='text-lg'>Pronunciation pitch:</h4>
-          <div className='flex flex-col gap-2'>
+          <h4 className="text-lg">Pronunciation pitch:</h4>
+          <div className="flex flex-col gap-2">
             <input
-              type='range'
-              min='0.5'
-              max='1.5'
-              step='0.1'
+              type="range"
+              min="0.5"
+              max="1.5"
+              step="0.1"
               value={pronunciationPitch}
-              onChange={e => setPronunciationPitch(parseFloat(e.target.value))}
-              className='w-full'
+              onChange={(e) =>
+                setPronunciationPitch(parseFloat(e.target.value))
+              }
+              className="w-full"
             />
-            <div className='text-sm text-[var(--secondary-color)] text-center'>
+            <div className="text-sm text-[var(--secondary-color)] text-center">
               {pronunciationPitch}x
             </div>
           </div>
 
-          <h4 className='text-lg'>Pronunciation voice:</h4>
-          <div className='flex flex-col gap-2'>
-            <div className='flex gap-2 items-center'>
+          <h4 className="text-lg">Pronunciation voice:</h4>
+          <div className="flex flex-col gap-2">
+            <div className="flex gap-2 items-center">
               <select
                 className={clsx(buttonBorderStyles, 'p-2 flex-1')}
                 value={pronunciationVoiceName || currentVoice?.name || ''}
-                onChange={e => {
+                onChange={(e) => {
                   const name = e.target.value || null;
                   setPronunciationVoiceName(name);
-                  const match = availableVoices.find(v => v.name === name);
+                  const match = availableVoices.find((v) => v.name === name);
                   if (match) setVoice(match);
                 }}
               >
-                <option value=''>Auto (best available)</option>
-                {availableVoices.map(v => (
+                <option value="">Auto (best available)</option>
+                {availableVoices.map((v) => (
                   <option key={v.name} value={v.name}>
                     {v.name} ({v.lang})
                   </option>
@@ -325,7 +331,7 @@ const Behavior = () => {
                   playClick();
                   refreshVoices();
                 }}
-                title='Refresh voices'
+                title="Refresh voices"
               >
                 <RefreshCw size={18} />
               </button>
@@ -336,15 +342,15 @@ const Behavior = () => {
                   await speak('こんにちは', {
                     rate: pronunciationSpeed,
                     pitch: pronunciationPitch,
-                    volume: 0.8
+                    volume: 0.8,
                   });
                 }}
-                title='Test voice'
+                title="Test voice"
               >
                 <Play size={18} />
               </button>
             </div>
-            <div className='text-sm text-[var(--secondary-color)] text-center'>
+            <div className="text-sm text-[var(--secondary-color)] text-center">
               {currentVoice
                 ? `${currentVoice.name} • ${currentVoice.lang}`
                 : 'No voice selected'}
@@ -361,11 +367,11 @@ const Behavior = () => {
                   !/Edge/i.test(navigator.userAgent);
 
                 return (
-                  <div className='text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 p-3 rounded-lg border border-red-200 dark:border-red-800'>
-                    <strong className='block mb-2'>
+                  <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 p-3 rounded-lg border border-red-200 dark:border-red-800">
+                    <strong className="block mb-2">
                       ⚠️ Notice: No Japanese voices found
                     </strong>
-                    <p className='mb-2'>
+                    <p className="mb-2">
                       {isFirefox && (
                         <>
                           <strong>Firefox uses system voices</strong> - it
@@ -392,13 +398,13 @@ const Behavior = () => {
                         </>
                       )}
                     </p>
-                    <details className='mt-2'>
-                      <summary className='cursor-pointer font-semibold hover:underline'>
+                    <details className="mt-2">
+                      <summary className="cursor-pointer font-semibold hover:underline">
                         How to install Japanese voices:
                       </summary>
-                      <div className='mt-2 pl-4 space-y-2 text-xs'>
+                      <div className="mt-2 pl-4 space-y-2 text-xs">
                         {isFirefox && (
-                          <div className='mb-3 p-2 bg-yellow-50 dark:bg-yellow-900/20 rounded border border-yellow-200 dark:border-yellow-800'>
+                          <div className="mb-3 p-2 bg-yellow-50 dark:bg-yellow-900/20 rounded border border-yellow-200 dark:border-yellow-800">
                             <strong>⚠️ Firefox-specific:</strong> Firefox relies
                             on your operating system&apos;s voices. You must
                             install Japanese language packs in your OS, then
@@ -407,7 +413,7 @@ const Behavior = () => {
                         )}
                         <div>
                           <strong>Windows:</strong>
-                          <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <ol className="list-decimal list-inside ml-2 space-y-1">
                             <li>
                               Open Settings → Time &amp; Language → Language
                             </li>
@@ -421,7 +427,7 @@ const Behavior = () => {
                         </div>
                         <div>
                           <strong>macOS:</strong>
-                          <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <ol className="list-decimal list-inside ml-2 space-y-1">
                             <li>
                               Open System Settings → General → Language &amp;
                               Region
@@ -435,22 +441,22 @@ const Behavior = () => {
                         </div>
                         <div>
                           <strong>Linux (Ubuntu/Debian):</strong>
-                          <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <ol className="list-decimal list-inside ml-2 space-y-1">
                             <li>
                               Install speech-dispatcher:{' '}
-                              <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>
+                              <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
                                 sudo apt install speech-dispatcher
                               </code>
                             </li>
                             <li>
                               Install espeak with Japanese:{' '}
-                              <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>
+                              <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
                                 sudo apt install espeak espeak-data
                               </code>
                             </li>
                             <li>
                               Or install festival:{' '}
-                              <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>
+                              <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
                                 sudo apt install festival festvox-ja
                               </code>
                             </li>
@@ -459,7 +465,7 @@ const Behavior = () => {
                         </div>
                         <div>
                           <strong>Chrome/Edge:</strong>
-                          <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <ol className="list-decimal list-inside ml-2 space-y-1">
                             <li>
                               Chrome includes built-in Google TTS voices
                               (including Japanese) - no installation needed
@@ -475,23 +481,23 @@ const Behavior = () => {
                         </div>
                         <div>
                           <strong>Firefox:</strong>
-                          <ol className='list-decimal list-inside ml-2 space-y-1'>
+                          <ol className="list-decimal list-inside ml-2 space-y-1">
                             <li>
                               Type{' '}
-                              <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>
+                              <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
                                 about:config
                               </code>{' '}
                               in address bar
                             </li>
                             <li>
                               Search for{' '}
-                              <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>
+                              <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
                                 media.webspeech.synth.enabled
                               </code>
                             </li>
                             <li>
                               Ensure it&apos;s set to{' '}
-                              <code className='bg-gray-100 dark:bg-gray-800 px-1 rounded'>
+                              <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
                                 true
                               </code>
                             </li>
@@ -510,7 +516,7 @@ const Behavior = () => {
                 );
               })()}
             {availableVoices.length === 0 && (
-              <div className='text-sm text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20 p-3 rounded-lg border border-orange-200 dark:border-orange-800'>
+              <div className="text-sm text-orange-600 dark:text-orange-400 bg-orange-50 dark:bg-orange-900/20 p-3 rounded-lg border border-orange-200 dark:border-orange-800">
                 <strong>⚠️ Notice:</strong> No voices are available. Please
                 refresh voices or check your system and browser speech synthesis
                 settings. This may be due to the operating system (e.g.,
@@ -523,8 +529,8 @@ const Behavior = () => {
         </>
       )}
 
-      <h4 className='text-lg'>Crazy Mode (Experimental):</h4>
-      <div className='flex flex-row gap-4'>
+      <h4 className="text-lg">Crazy Mode (Experimental):</h4>
+      <div className="flex flex-row gap-4">
         <button
           className={clsx(
             buttonBorderStyles,
@@ -540,16 +546,61 @@ const Behavior = () => {
           }}
         >
           <span>
-            <span className='text-[var(--main-color)]'>
-              {useCrazyModeStore(state => state.isCrazyMode) && '\u2B24 '}
+            <span className="text-[var(--main-color)]">
+              {useCrazyModeStore((state) => state.isCrazyMode) && '\u2B24 '}
             </span>
-            {useCrazyModeStore(state => state.isCrazyMode) ? 'On' : 'Off'}
+            {useCrazyModeStore((state) => state.isCrazyMode) ? 'On' : 'Off'}
           </span>
-          {useCrazyModeStore(state => state.isCrazyMode) ? (
-            <Zap size={20} className='mb-0.5' />
+          {useCrazyModeStore((state) => state.isCrazyMode) ? (
+            <Zap size={20} className="mb-0.5" />
           ) : (
-            <ZapOff size={20} className='mb-0.5' />
+            <ZapOff size={20} className="mb-0.5" />
           )}
+        </button>
+      </div>
+      <h4 className="text-lg">Enable hover theme preview:</h4>
+      <div className="flex flex-row gap-4">
+        <button
+          className={clsx(
+            buttonBorderStyles,
+            'text-center text-lg',
+            'w-1/2 md:w-1/4 p-4',
+            'flex flex-row gap-1.5 justify-center items-end',
+            'text-[var(--secondary-color)]',
+            'flex-1 overflow-hidden'
+          )}
+          onClick={() => {
+            playClick();
+            setThemePreview(true);
+          }}
+        >
+          <span>
+            <span className="text-[var(--main-color)]">
+              {themePreview && '\u2B24 '}
+            </span>
+            on
+          </span>
+        </button>
+        <button
+          className={clsx(
+            buttonBorderStyles,
+            'text-center text-lg',
+            'w-1/2 md:w-1/4 p-4',
+            'flex flex-row gap-1.5 justify-center items-end',
+            'text-[var(--secondary-color)]',
+            'flex-1 overflow-hidden'
+          )}
+          onClick={() => {
+            playClick();
+            setThemePreview(false);
+          }}
+        >
+          <span>
+            <span className="text-[var(--main-color)]">
+              {!themePreview && '\u2B24 '}
+            </span>
+            off
+          </span>
         </button>
       </div>
 

--- a/features/Themes/components/Themes.tsx
+++ b/features/Themes/components/Themes.tsx
@@ -3,7 +3,7 @@ import { createElement, useEffect, useRef } from 'react';
 import themeSets, {
   applyTheme,
   applyThemeObject,
-  hexToHsl
+  hexToHsl,
 } from '@/features/Themes/data/themes';
 import usePreferencesStore from '@/features/Themes';
 import clsx from 'clsx';
@@ -28,11 +28,12 @@ const Themes = () => {
     cardColor: '#321441',
     borderColor: '#49215e',
     mainColor: '#ea70ad',
-    secondaryColor: '#ce89e6'
+    secondaryColor: '#ce89e6',
   });
 
-  const selectedTheme = usePreferencesStore(state => state.theme);
-  const setSelectedTheme = usePreferencesStore(state => state.setTheme);
+  const selectedTheme = usePreferencesStore((state) => state.theme);
+  const setSelectedTheme = usePreferencesStore((state) => state.setTheme);
+  const themePreview = usePreferencesStore((state) => state.themePreview);
 
   // Initialize with first theme to avoid hydration mismatch
   const [randomTheme, setRandomTheme] = useState(themeSets[2].themes[0]);
@@ -48,13 +49,13 @@ const Themes = () => {
   /* handleHover acts as a debouncer, so it applies the theme when the user stops on top of it.
    Without it, the theme would apply on every hover, causing lag.
  */
-  // const handleHover = (themeId: string) => {
-  //   if (isAdding) return;
-  //   if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
-  //   hoverTimeout.current = setTimeout(() => {
-  //     applyTheme(themeId);
-  //   }, 150);
-  // };
+  const handleHover = (themeId: string) => {
+    if (isAdding) return;
+    if (hoverTimeout.current) clearTimeout(hoverTimeout.current);
+    hoverTimeout.current = setTimeout(() => {
+      applyTheme(themeId);
+    }, 150);
+  };
 
   const handleCustomTheme = () => {
     // To keep the id same as the others themes (default)
@@ -67,7 +68,7 @@ const Themes = () => {
         cardColor: hexToHsl(customTheme.cardColor),
         borderColor: hexToHsl(customTheme.borderColor),
         mainColor: hexToHsl(customTheme.mainColor),
-        secondaryColor: hexToHsl(customTheme.secondaryColor)
+        secondaryColor: hexToHsl(customTheme.secondaryColor),
       });
 
       // setSelectedTheme(themeId);
@@ -93,8 +94,8 @@ const Themes = () => {
   }, []);
 
   return (
-    <div className='flex flex-col gap-6'>
-      <div className='flex gap-2'>
+    <div className="flex flex-col gap-6">
+      <div className="flex gap-2">
         <button
           className={clsx(
             'p-6 flex justify-center items-center gap-2 w-full md:w-1/2 flex-1 overflow-hidden',
@@ -110,7 +111,7 @@ const Themes = () => {
                 : randomTheme.cardColor,
             borderWidth:
               process.env.NODE_ENV === 'development' ? '2px' : undefined,
-            borderColor: randomTheme.borderColor
+            borderColor: randomTheme.borderColor,
           }}
           onClick={() => {
             playClick();
@@ -122,20 +123,20 @@ const Themes = () => {
             setSelectedTheme(randomTheme.id);
           }}
         >
-          <span className='mb-0.5'>
+          <span className="mb-0.5">
             {randomTheme.id === selectedTheme ? '\u2B24 ' : ''}
           </span>
           <Dice5
             style={{
-              color: randomTheme.secondaryColor
+              color: randomTheme.secondaryColor,
             }}
           />
           Random Theme
         </button>
       </div>
       {themeSets.map((themeSet, i) => (
-        <div key={i} className='flex flex-col gap-3'>
-          <h4 className='text-xl flex flex-row items-center gap-1.5'>
+        <div key={i} className="flex flex-col gap-3">
+          <h4 className="text-xl flex flex-row items-center gap-1.5">
             {createElement(themeSet.icon)}
             <span>{themeSet.name}</span>
           </h4>
@@ -144,7 +145,7 @@ const Themes = () => {
               'grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4'
             )}
           >
-            {themeSet.themes.map(currentTheme => (
+            {themeSet.themes.map((currentTheme) => (
               <label
                 key={currentTheme.id}
                 style={{
@@ -155,11 +156,11 @@ const Themes = () => {
                       : currentTheme.backgroundColor,
                   borderWidth:
                     process.env.NODE_ENV === 'development' ? '2px' : undefined,
-                  borderColor: currentTheme.borderColor
+                  borderColor: currentTheme.borderColor,
                 }}
                 onMouseEnter={() => {
                   setIsHovered(currentTheme.id);
-                  // handleHover(currentTheme.id);
+                  if (themePreview) handleHover(currentTheme.id);
                 }}
                 onMouseLeave={() => {
                   if (isAdding) return;
@@ -183,8 +184,8 @@ const Themes = () => {
                 }}
               >
                 <input
-                  type='radio'
-                  name='selectedTheme'
+                  type="radio"
+                  name="selectedTheme"
                   onChange={() => {
                     setSelectedTheme(currentTheme.id);
                     // @ts-expect-error gtag fix
@@ -198,15 +199,15 @@ const Themes = () => {
                         {
                           event_category: 'Theme Change',
                           event_label: currentTheme.id,
-                          value: 1
+                          value: 1,
                         }
                       );
                     }
                   }}
-                  className='hidden'
+                  className="hidden"
                 />
-                <span className='text-center text-lg flex items-center gap-1.5'>
-                  <span className='text-[var(--secondary-color)]'>
+                <span className="text-center text-lg flex items-center gap-1.5">
+                  <span className="text-[var(--secondary-color)]">
                     {currentTheme.id === selectedTheme ? '\u2B24 ' : ''}
                   </span>
                   {currentTheme.id === 'long'
@@ -220,7 +221,7 @@ const Themes = () => {
                                 ? i === 0
                                   ? currentTheme.mainColor
                                   : currentTheme.secondaryColor
-                                : undefined
+                                : undefined,
                           }}
                         >
                           {i > 0 && ' '}
@@ -236,8 +237,8 @@ const Themes = () => {
 
       {/* Custom Themes */}
       <div>
-        <div className='flex items-center justify-between mb-3'>
-          <h4 className='text-lg font-semibold'>Your Custom Themes</h4>
+        <div className="flex items-center justify-between mb-3">
+          <h4 className="text-lg font-semibold">Your Custom Themes</h4>
           {!isAdding && (
             <button
               onClick={() => setIsAdding(true)}
@@ -248,7 +249,7 @@ const Themes = () => {
                 'flex items-center gap-2'
               )}
             >
-              <Plus className='w-4 h-4' />
+              <Plus className="w-4 h-4" />
               New Theme
             </button>
           )}
@@ -261,16 +262,16 @@ const Themes = () => {
               'bg-[var(--card-color)] border-[var(--border-color)]'
             )}
           >
-            <div className='space-y-3'>
-              <div className='flex gap-3'>
+            <div className="space-y-3">
+              <div className="flex gap-3">
                 <input
-                  type='text'
-                  placeholder='* Theme name eg., Red Velvet or red-velvet'
+                  type="text"
+                  placeholder="* Theme name eg., Red Velvet or red-velvet"
                   value={customTheme.id}
-                  onChange={e =>
-                    setCustomTheme(prev => ({
+                  onChange={(e) =>
+                    setCustomTheme((prev) => ({
                       ...prev,
-                      id: e.target.value
+                      id: e.target.value,
                     }))
                   }
                   className={clsx(
@@ -280,14 +281,14 @@ const Themes = () => {
                   )}
                 />
               </div>
-              <div className='flex flex-wrap justify-around gap-3 items-center'>
-                <div className='flex items-center gap-2 flex-col'>
+              <div className="flex flex-wrap justify-around gap-3 items-center">
+                <div className="flex items-center gap-2 flex-col">
                   <input
-                    type='color'
+                    type="color"
                     value={customTheme.backgroundColor}
-                    onChange={e => {
+                    onChange={(e) => {
                       const value = e.target.value;
-                      setCustomTheme(prev => {
+                      setCustomTheme((prev) => {
                         const updated = { ...prev, backgroundColor: value };
                         applyThemeObject(updated);
                         return updated;
@@ -299,17 +300,17 @@ const Themes = () => {
                       'text-[var(--main-color)]'
                     )}
                   />
-                  <span className='text-sm text-[var(--secondary-color)]'>
+                  <span className="text-sm text-[var(--secondary-color)]">
                     Background Color
                   </span>
                 </div>
-                <div className='flex items-center gap-2  flex-col'>
+                <div className="flex items-center gap-2  flex-col">
                   <input
-                    type='color'
+                    type="color"
                     value={customTheme.cardColor}
-                    onChange={e => {
+                    onChange={(e) => {
                       const value = e.target.value;
-                      setCustomTheme(prev => {
+                      setCustomTheme((prev) => {
                         const updated = { ...prev, cardColor: value };
                         applyThemeObject(updated);
                         return updated;
@@ -321,17 +322,17 @@ const Themes = () => {
                       'text-[var(--main-color)]'
                     )}
                   />
-                  <span className='text-sm text-[var(--secondary-color)]'>
+                  <span className="text-sm text-[var(--secondary-color)]">
                     Card Color
                   </span>
                 </div>
-                <div className='flex items-center gap-2  flex-col'>
+                <div className="flex items-center gap-2  flex-col">
                   <input
-                    type='color'
+                    type="color"
                     value={customTheme.borderColor}
-                    onChange={e => {
+                    onChange={(e) => {
                       const value = e.target.value;
-                      setCustomTheme(prev => {
+                      setCustomTheme((prev) => {
                         const updated = { ...prev, borderColor: value };
                         applyThemeObject(updated);
                         return updated;
@@ -343,17 +344,17 @@ const Themes = () => {
                       'text-[var(--main-color)]'
                     )}
                   />
-                  <span className='text-sm text-[var(--secondary-color)]'>
+                  <span className="text-sm text-[var(--secondary-color)]">
                     Border Color
                   </span>
                 </div>
-                <div className='flex items-center gap-2  flex-col'>
+                <div className="flex items-center gap-2  flex-col">
                   <input
-                    type='color'
+                    type="color"
                     value={customTheme.mainColor}
-                    onChange={e => {
+                    onChange={(e) => {
                       const value = e.target.value;
-                      setCustomTheme(prev => {
+                      setCustomTheme((prev) => {
                         const updated = { ...prev, mainColor: value };
                         applyThemeObject(updated);
                         return updated;
@@ -365,17 +366,17 @@ const Themes = () => {
                       'text-[var(--main-color)]'
                     )}
                   />
-                  <span className='text-sm text-[var(--secondary-color)]'>
+                  <span className="text-sm text-[var(--secondary-color)]">
                     Main Color
                   </span>
                 </div>
-                <div className='flex items-center gap-2  flex-col'>
+                <div className="flex items-center gap-2  flex-col">
                   <input
-                    type='color'
+                    type="color"
                     value={customTheme.secondaryColor}
-                    onChange={e => {
+                    onChange={(e) => {
                       const value = e.target.value;
-                      setCustomTheme(prev => {
+                      setCustomTheme((prev) => {
                         const updated = { ...prev, secondaryColor: value };
                         applyThemeObject(updated);
                         return updated;
@@ -387,12 +388,12 @@ const Themes = () => {
                       'text-[var(--main-color)]'
                     )}
                   />
-                  <span className='text-sm text-[var(--secondary-color)]'>
+                  <span className="text-sm text-[var(--secondary-color)]">
                     Secondary Color
                   </span>
                 </div>
               </div>
-              <div className='flex gap-2'>
+              <div className="flex gap-2">
                 <button
                   onClick={handleCustomTheme}
                   className={clsx(
@@ -412,7 +413,7 @@ const Themes = () => {
                       cardColor: '#321441',
                       borderColor: '#49215e',
                       mainColor: '#ea70ad',
-                      secondaryColor: '#ce89e6'
+                      secondaryColor: '#ce89e6',
                     });
                     setIsAdding(false);
                   }}
@@ -425,20 +426,20 @@ const Themes = () => {
                   Cancel
                 </button>
               </div>
-              <p className='text-sm text-[var(--secondary-color)] text-center py-2'>
+              <p className="text-sm text-[var(--secondary-color)] text-center py-2">
                 Check the{' '}
                 <a
-                  className='text-[var(--main-color)] font-bold underline'
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  href='https://github.com/lingdojo/kana-dojo/blob/main/docs/UI_DESIGN.md#theming-system'
+                  className="text-[var(--main-color)] font-bold underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="https://github.com/lingdojo/kana-dojo/blob/main/docs/UI_DESIGN.md#theming-system"
                 >
                   UI_DESIGN
                 </a>{' '}
                 documentation for better understanding of the{' '}
-                <span className='text-[var(--main-color)]'>theming system</span>{' '}
+                <span className="text-[var(--main-color)]">theming system</span>{' '}
                 and{' '}
-                <span className='text-[var(--main-color)]'>accessibility</span>
+                <span className="text-[var(--main-color)]">accessibility</span>
               </p>
             </div>
           </div>
@@ -450,7 +451,7 @@ const Themes = () => {
               'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4'
             )}
           >
-            {themes.map(currentTheme => (
+            {themes.map((currentTheme) => (
               <label
                 key={currentTheme.id}
                 style={{
@@ -461,11 +462,11 @@ const Themes = () => {
                       : currentTheme.backgroundColor,
                   borderWidth:
                     process.env.NODE_ENV === 'development' ? '2px' : undefined,
-                  borderColor: currentTheme.borderColor
+                  borderColor: currentTheme.borderColor,
                 }}
                 onMouseEnter={() => {
                   setIsHovered(currentTheme.id);
-                  // handleHover(currentTheme.id);
+                  if (themePreview) handleHover(currentTheme.id);
                 }}
                 onMouseLeave={() => {
                   if (isAdding) return;
@@ -488,8 +489,8 @@ const Themes = () => {
                 }}
               >
                 <input
-                  type='radio'
-                  name='selectedTheme'
+                  type="radio"
+                  name="selectedTheme"
                   onChange={() => {
                     setSelectedTheme(currentTheme.id);
                     // @ts-expect-error gtag fix
@@ -503,16 +504,16 @@ const Themes = () => {
                         {
                           event_category: 'Theme Change',
                           event_label: currentTheme.id,
-                          value: 1
+                          value: 1,
                         }
                       );
                     }
                   }}
-                  className='hidden'
+                  className="hidden"
                 />
-                <div className='flex w-full justify-around items-center'>
-                  <span className='text-center text-lg flex items-center gap-1.5'>
-                    <span className='text-[var(--secondary-color)]'>
+                <div className="flex w-full justify-around items-center">
+                  <span className="text-center text-lg flex items-center gap-1.5">
+                    <span className="text-[var(--secondary-color)]">
                       {currentTheme.id === selectedTheme ? '\u2B24 ' : ''}
                     </span>
                     {currentTheme.id.split('-').map((themeNamePart, i) => (
@@ -524,7 +525,7 @@ const Themes = () => {
                               ? i === 0
                                 ? currentTheme.mainColor
                                 : currentTheme.secondaryColor
-                              : undefined
+                              : undefined,
                         }}
                       >
                         {i > 0 && ' '}
@@ -542,17 +543,17 @@ const Themes = () => {
                       setRandomTheme(randomTheme);
                       setSelectedTheme(randomTheme.id);
                     }}
-                    className='p-2 text-red-500 hover:bg-red-500 hover:text-[var(--card-color)] hover:bg-opacity-10 rounded transition-colors hover:cursor-pointer'
-                    title='Delete theme'
+                    className="p-2 text-red-500 hover:bg-red-500 hover:text-[var(--card-color)] hover:bg-opacity-10 rounded transition-colors hover:cursor-pointer"
+                    title="Delete theme"
                   >
-                    <Trash2 className='w-4 h-4' />
+                    <Trash2 className="w-4 h-4" />
                   </button>
                 </div>
               </label>
             ))}
           </fieldset>
         ) : (
-          <p className='text-sm text-[var(--secondary-color)] text-center py-8'>
+          <p className="text-sm text-[var(--secondary-color)] text-center py-8">
             No custom themes yet. Create one to get started!
           </p>
         )}

--- a/features/Themes/store/usePreferencesStore.ts
+++ b/features/Themes/store/usePreferencesStore.ts
@@ -33,38 +33,47 @@ interface PreferencesState {
 
   furiganaEnabled: boolean;
   setFuriganaEnabled: (enabled: boolean) => void;
+
+  //Theme preview
+  themePreview: boolean;
+  setThemePreview: (enabled: boolean) => void;
 }
 
 const usePreferencesStore = create<PreferencesState>()(
   persist(
-    set => ({
+    (set) => ({
       displayKana: false,
-      setDisplayKana: displayKana => set({ displayKana }),
+      setDisplayKana: (displayKana) => set({ displayKana }),
       theme: 'light',
-      setTheme: theme => set({ theme }),
+      setTheme: (theme) => set({ theme }),
       font: 'Zen Maru Gothic',
-      setFont: fontName => set({ font: fontName }),
+      setFont: (fontName) => set({ font: fontName }),
       silentMode: false,
-      setSilentMode: silent => set({ silentMode: silent }),
+      setSilentMode: (silent) => set({ silentMode: silent }),
       hotkeysOn: true,
-      setHotkeys: hotkeys => set({ hotkeysOn: hotkeys }),
+      setHotkeys: (hotkeys) => set({ hotkeysOn: hotkeys }),
 
       // Pronunciation settings
       pronunciationEnabled: true,
-      setPronunciationEnabled: enabled =>
+      setPronunciationEnabled: (enabled) =>
         set({ pronunciationEnabled: enabled }),
       pronunciationSpeed: 1.0,
-      setPronunciationSpeed: speed => set({ pronunciationSpeed: speed }),
+      setPronunciationSpeed: (speed) => set({ pronunciationSpeed: speed }),
       pronunciationPitch: 1.0,
-      setPronunciationPitch: pitch => set({ pronunciationPitch: pitch }),
+      setPronunciationPitch: (pitch) => set({ pronunciationPitch: pitch }),
       pronunciationVoiceName: null,
-      setPronunciationVoiceName: name => set({ pronunciationVoiceName: name }),
+      setPronunciationVoiceName: (name) =>
+        set({ pronunciationVoiceName: name }),
       furiganaEnabled: true,
-      setFuriganaEnabled: enabled => set({ furiganaEnabled: enabled })
+      setFuriganaEnabled: (enabled) => set({ furiganaEnabled: enabled }),
+
+      // Theme preview
+      themePreview: false,
+      setThemePreview: (enabled) => set({ themePreview: enabled }),
     }),
 
     {
-      name: 'theme-storage'
+      name: 'theme-storage',
     }
   )
 );


### PR DESCRIPTION
## 📝 Description

The feature remains the same, but I added a toggle to enable or disable it, since a user with epilepsy reported discomfort with the hover preview. This persists the preference in the store and lets users control the theme preview behavior.

## 🔗 Improves PR

PR #208 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [X] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [X] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## ✅ Pre-Submission Checklist

- [X] My code follows the project's code style and uses `cn()` utility where needed.
- [X] I have run the linter (`npm run lint`) and there are no new errors.
- [X] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [X] This PR is against the `main` branch.