### PR TITLE
feat(crazy-mode): persist state to fix reload reset issue

### DIFF
--- a/features/CrazyMode/store/useCrazyModeStore.ts
+++ b/features/CrazyMode/store/useCrazyModeStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { themes } from '@/features/Themes';
 import fonts from '@/features/Themes/data/fonts';
 import { Random } from 'random-js';
+import { persist } from 'zustand/middleware';
 
 interface CrazyModeState {
   isCrazyMode: boolean;
@@ -13,12 +14,14 @@ interface CrazyModeState {
 
 const random = new Random();
 
-const useCrazyModeStore = create<CrazyModeState>((set, get) => ({
-  isCrazyMode: false,
-  activeThemeId: null,
-  activeFontName: null,
+const useCrazyModeStore = create<CrazyModeState>()(
+  persist(
+    (set, get) => ({
+    isCrazyMode: false,
+    activeThemeId: null,
+    activeFontName: null,
 
-  toggleCrazyMode: () => {
+    toggleCrazyMode: () => {
     const wasActive = get().isCrazyMode;
     if (!wasActive) {
       // Turning ON: Trigger immediate randomization
@@ -28,9 +31,9 @@ const useCrazyModeStore = create<CrazyModeState>((set, get) => ({
       // Turning OFF: Reset active values
       set({ isCrazyMode: false, activeThemeId: null, activeFontName: null });
     }
-  },
+    },
 
-  randomize: () => {
+    randomize: () => {
     // Flatten themes to get all available theme IDs
     const allThemes = themes.flatMap(group => group.themes);
     const randomTheme = allThemes[random.integer(0, allThemes.length - 1)];
@@ -41,7 +44,10 @@ const useCrazyModeStore = create<CrazyModeState>((set, get) => ({
       activeThemeId: randomTheme.id,
       activeFontName: randomFont.name
     });
-  }
-}));
+    }
+  }),
+  {
+    name: 'local-storage'
+  }));
 
 export default useCrazyModeStore;

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1206,6 +1207,7 @@
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -2826,6 +2828,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.0.tgz",
       "integrity": "sha512-UaicktuQI+9UKyA4njtDOGBD/67t8YEBt2xdfqu8+gP9hqPUPsiXlNPcpS2gVdjmis5GKPG3fCxbQLVgxsQZ8w==",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2835,6 +2838,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
       "integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
       "devOptional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2891,6 +2895,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -3511,6 +3516,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3907,6 +3913,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -4652,6 +4659,7 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4849,6 +4857,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7635,6 +7644,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.2.tgz",
       "integrity": "sha512-H8Otr7abj1glFhbGnvUt3gz++0AF1+QoCXEBmd/6aKbfdFwrn0LpA836Ed5+00va/7HQSDD+mOoVhn3tNy3e/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.2",
         "@swc/helpers": "0.5.15",
@@ -8097,6 +8107,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -8201,6 +8212,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8209,6 +8221,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -9162,6 +9175,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9376,6 +9390,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## 📝 Description

Added persistence to the Crazy Mode Zustand store.  
Previously, Crazy Mode turned off after a full page reload because the store was not persisted.  
This PR wraps the store in `persist` so that:

- `isCrazyMode`
- `activeThemeId`
- `activeFontName`

are saved in `localStorage` and restored on reload.  
Crazy Mode now stays active until the user turns it off manually.

## 🔗 Related Issue

Closes #

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Enable Crazy Mode in Settings → Behavior  
2. Observe theme + font randomization  
3. Refresh the page  
4. Confirm Crazy Mode remains enabled  
5. Confirm theme + font remain the same  
6. Disable Crazy Mode  
7. Confirm state resets correctly

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

## 📸 Screenshots/Videos (if applicable)

_No UI changes — logic only._

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the Conventional Commits format.
- [ ] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

This improves Crazy Mode's reliability by ensuring it doesn't unexpectedly turn off after a reload. The persistence layer does not affect user theme preferences or global settings.
