### PR TITLE
feat(app): add Patch Notes page

### DIFF
--- a/app/[locale]/patch-notes/loading.tsx
+++ b/app/[locale]/patch-notes/loading.tsx
@@ -1,0 +1,5 @@
+import Loader from '@/shared/components/Skeletons/Loader';
+
+export default function PatchNotesLoaderPage() {
+  return <Loader />;
+}

--- a/app/[locale]/patch-notes/page.tsx
+++ b/app/[locale]/patch-notes/page.tsx
@@ -1,6 +1,5 @@
-import PatchNotes from '@/shared/components/PatchNotes';
+import PatchNotes from '@/features/PatchNotes/PatchNotes';
 
 export default function PatchNotesPage() {
   return <PatchNotes />;
 }
-

--- a/features/Academy/Legal/Privacy.tsx
+++ b/features/Academy/Legal/Privacy.tsx
@@ -1,8 +1,13 @@
 import PostWrapper from '@/shared/components/PostWrapper';
 import privacyPolicy from '@/shared/lib/legal/privacyPolicy';
+import ContentLayout from '@/shared/components/ContentLayout';
 
 const PrivacyPolicy = () => {
-  return <PostWrapper textContent={privacyPolicy} />;
+  return (
+    <ContentLayout>
+      <PostWrapper textContent={privacyPolicy} />
+    </ContentLayout>
+  );
 };
 
 export default PrivacyPolicy;

--- a/features/Academy/Legal/Security.tsx
+++ b/features/Academy/Legal/Security.tsx
@@ -1,8 +1,13 @@
 import PostWrapper from '@/shared/components/PostWrapper';
 import securityPolicy from '@/shared/lib/legal/securityPolicy';
+import ContentLayout from '@/shared/components/ContentLayout';
 
 const SecurityPolicy = () => {
-  return <PostWrapper textContent={securityPolicy} />;
+  return (
+    <ContentLayout>
+      <PostWrapper textContent={securityPolicy} />
+    </ContentLayout>
+  );
 };
 
 export default SecurityPolicy;

--- a/features/Academy/Legal/Terms.tsx
+++ b/features/Academy/Legal/Terms.tsx
@@ -1,8 +1,13 @@
+import ContentLayout from '@/shared/components/ContentLayout';
 import PostWrapper from '@/shared/components/PostWrapper';
 import termsOfService from '@/shared/lib/legal/termsOfService';
 
 const TermsOfService = () => {
-  return <PostWrapper textContent={termsOfService} />;
+  return (
+    <ContentLayout>
+      <PostWrapper textContent={termsOfService} />
+    </ContentLayout>
+  );
 };
 
 export default TermsOfService;

--- a/features/MainMenu/index.tsx
+++ b/features/MainMenu/index.tsx
@@ -12,7 +12,8 @@ import {
   Moon,
   Heart,
   Sparkle,
-  Keyboard
+  Keyboard,
+  GitBranch,
 } from 'lucide-react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons';
@@ -29,8 +30,8 @@ const MainMenu = () => {
   const [isMounted, setIsMounted] = useState(false);
   const isLG = useMediaQuery({ minWidth: 1024 });
 
-  const theme = usePreferencesStore(state => state.theme);
-  const setTheme = usePreferencesStore(state => state.setTheme);
+  const theme = usePreferencesStore((state) => state.theme);
+  const setTheme = usePreferencesStore((state) => state.setTheme);
 
   const { playClick } = useClick();
 
@@ -63,18 +64,18 @@ const MainMenu = () => {
     {
       name_en: 'Kana',
       name_ja: 'あ',
-      href: '/kana'
+      href: '/kana',
     },
     {
       name_en: 'Vocabulary',
       name_ja: '語',
-      href: '/vocabulary'
+      href: '/vocabulary',
     },
     {
       name_en: 'Kanji',
       name_ja: '字',
-      href: '/kanji'
-    }
+      href: '/kanji',
+    },
 
     // {
     //   name_en: 'Sentences',
@@ -86,7 +87,7 @@ const MainMenu = () => {
   const legalLinks = [
     { name: 'terms', href: '/terms', icon: ScrollText },
     { name: 'privacy', href: '/privacy', icon: Cookie },
-    { name: 'security', href: '/security', icon: FileLock2 }
+    { name: 'security', href: '/security', icon: FileLock2 },
     // { name: 'patch notes', href: '/patch-notes', icon: FileDiff }
   ];
 
@@ -102,8 +103,8 @@ const MainMenu = () => {
             <Decorations expandDecorations={expandDecorations} />
           )}
           <Button
-            variant='secondary'
-            size='icon'
+            variant="secondary"
+            size="icon"
             className={clsx(
               'fixed top-4 right-8 z-50 opacity-90',
               buttonBorderStyles,
@@ -111,14 +112,14 @@ const MainMenu = () => {
             )}
             onClick={() => {
               playClick();
-              setExpandDecorations(expandDecorations => !expandDecorations);
+              setExpandDecorations((expandDecorations) => !expandDecorations);
             }}
           >
             <Sparkle />
           </Button>
           <Button
-            variant='secondary'
-            size='icon'
+            variant="secondary"
+            size="icon"
             className={clsx(
               'fixed top-4 left-4 z-50 opacity-90',
               buttonBorderStyles,
@@ -128,7 +129,7 @@ const MainMenu = () => {
               playClick();
             }}
           >
-            <a href='https://monkeytype.com/' rel='noopener' target='_blank'>
+            <a href="https://monkeytype.com/" rel="noopener" target="_blank">
               <Keyboard />
             </a>
           </Button>
@@ -141,9 +142,9 @@ const MainMenu = () => {
           expandDecorations && 'hidden'
         )}
       >
-        <div className='flex flex-row justify-between items-center w-full px-1 gap-2'>
+        <div className="flex flex-row justify-between items-center w-full px-1 gap-2">
           <Banner />
-          <div className='flex flex-row justify-end gap-2 w-1/2 md:w-1/3'>
+          <div className="flex flex-row justify-end gap-2 w-1/2 md:w-1/3">
             {theme === 'dark' ? (
               <Moon
                 size={32}
@@ -185,7 +186,7 @@ const MainMenu = () => {
 
             <FontAwesomeIcon
               icon={faDiscord}
-              size='2x'
+              size="2x"
               className={clsx(
                 'hover:cursor-pointer duration-250 hover:scale-120',
                 'active:scale-100 active:duration-225',
@@ -199,7 +200,7 @@ const MainMenu = () => {
             />
             <FontAwesomeIcon
               icon={faGithub}
-              size='2x'
+              size="2x"
               className={clsx(
                 'hover:cursor-pointer duration-250 hover:scale-120',
                 'active:scale-100 active:duration-225',
@@ -252,12 +253,12 @@ const MainMenu = () => {
                   onClick={() => playClick()}
                 >
                   <span
-                    lang='ja'
-                    className='font-normal text-[var(--secondary-color)]'
+                    lang="ja"
+                    className="font-normal text-[var(--secondary-color)]"
                   >
                     {link.name_ja}
                   </span>
-                  <span lang='en' className=''>
+                  <span lang="en" className="">
                     {link.name_en}
                   </span>
                 </button>
@@ -278,7 +279,7 @@ const MainMenu = () => {
       </div>
       <div
         className={clsx(
-          'fixed bottom-3 flex flex-row gap-2',
+          'fixed bottom-3 flex flex-row sm:gap-2 gap-1',
           'max-md:bg-[var(--card-color)] rounded-xl z-50',
           'opacity-90',
           expandDecorations && 'hidden'
@@ -288,13 +289,21 @@ const MainMenu = () => {
           <Link
             href={link.href}
             key={i}
-            className='p-2 text-sm hover:cursor-pointer  rounded-2xl flex flex-row gap-1 items-center text-[var(--secondary-color)] hover:text-[var(--main-color)]'
+            className="p-2 text-sm hover:cursor-pointer  rounded-2xl flex flex-row gap-1 items-center text-[var(--secondary-color)] hover:text-[var(--main-color)]"
             onClick={() => playClick()}
           >
-            <link.icon className='size-4' />
+            <link.icon className="size-4" />
             <span>{link.name}</span>
           </Link>
         ))}
+        <Link
+          href="/patch-notes"
+          className="p-2 text-sm hover:cursor-pointer  rounded-2xl flex flex-row gap-1 items-center text-[var(--secondary-color)] hover:text-[var(--main-color)]"
+          onClick={() => playClick()}
+        >
+          <GitBranch className="size-4" />
+          <span>Patch Notes</span>
+        </Link>
       </div>
       {showBanner && (
         <NightlyBanner onSwitch={handleSwitch} onDismiss={handleDismiss} />

--- a/features/PatchNotes/PatchNotes.tsx
+++ b/features/PatchNotes/PatchNotes.tsx
@@ -1,0 +1,37 @@
+import ContentLayout from '@/shared/components/ContentLayout';
+import PostWrapper from '@/shared/components/PostWrapper';
+
+export interface Release {
+  id: number;
+  tag_name: string;
+  published_at: string;
+  body: string;
+}
+
+const PatchNotes = async () => {
+  const data = await fetch(
+    'https://api.github.com/repos/lingdojo/kana-dojo/releases?per_page=5'
+  );
+  const patches: Release[] = await data.json();
+
+  return (
+    <ContentLayout>
+      {patches && patches.length > 0 ? (
+        patches.map((release) => (
+          <PostWrapper
+            key={release.id}
+            textContent={release.body}
+            tag={release.tag_name}
+            date={release.published_at}
+          />
+        ))
+      ) : (
+        <div className="text-center py-10 text-[var(--secondary-color)]">
+          No releases available yet. Check back soon for updates!
+        </div>
+      )}
+    </ContentLayout>
+  );
+};
+
+export default PatchNotes;

--- a/shared/components/BackButton.tsx
+++ b/shared/components/BackButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useClick } from '@/shared/hooks';
+import { ChevronsLeft } from 'lucide-react';
+import { Link } from '@/core/i18n/routing';
+import clsx from 'clsx';
+import { buttonBorderStyles } from '@/shared/lib/styles';
+
+const BackButton = () => {
+  const { playClick } = useClick();
+
+  return (
+    <Link href="/" className="w-full md:w-1/3 lg:w-1/4">
+      <button
+        onClick={() => playClick()}
+        className={clsx(
+          buttonBorderStyles,
+          'py-4 px-16',
+          'w-full',
+          'flex items-center justify-center'
+        )}
+      >
+        <ChevronsLeft />
+      </button>
+    </Link>
+  );
+};
+
+export default BackButton;

--- a/shared/components/ContentLayout.tsx
+++ b/shared/components/ContentLayout.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import BackButton from './BackButton';
+import Banner from './Menu/Banner';
+
+const ContentLayout = ({ children }: { children: React.ReactNode }) => (
+  <div className="min-h-[100dvh] max-w-[100dvw] px-4 pb-10 sm:px-8 md:px-20 xl:px-66">
+    <Banner />
+    <BackButton />
+    {children}
+  </div>
+);
+
+export default ContentLayout;

--- a/shared/components/PatchNotes.tsx
+++ b/shared/components/PatchNotes.tsx
@@ -1,9 +1,0 @@
-import PostWrapper from '@/shared/components/PostWrapper';
-import patchNotes from '@/shared/lib/patchNotes';
-
-const PatchNotes = () => {
-  return <PostWrapper textContent={patchNotes} />;
-};
-
-export default PatchNotes;
-

--- a/shared/components/PostWrapper.tsx
+++ b/shared/components/PostWrapper.tsx
@@ -1,33 +1,31 @@
 'use client';
 
-import clsx from 'clsx';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import Banner from './Menu/Banner';
-import { buttonBorderStyles } from '@/shared/lib/styles';
-import { ChevronsLeft } from 'lucide-react';
-import { Link } from '@/core/i18n/routing';
-import { useClick } from '@/shared/hooks';
 
-const PostWrapper = ({ textContent }: { textContent: string }) => {
-  const { playClick } = useClick();
-
+const PostWrapper = ({
+  textContent,
+  tag,
+  date,
+}: {
+  textContent: string;
+  tag?: string;
+  date?: string;
+}) => {
   return (
-    <div className="min-h-[100dvh] max-w-[100dvw] px-4 pb-10 sm:px-8 md:px-20 xl:px-66">
-      <Banner />
-      <Link href="/" className="w-full md:w-1/3 lg:w-1/4">
-        <button
-          onClick={() => playClick()}
-          className={clsx(
-            buttonBorderStyles,
-            'py-4 px-16',
-            'w-full',
-            'flex items-center justify-center'
-          )}
-        >
-          <ChevronsLeft />
-        </button>
-      </Link>
+    <div>
+      {tag && date && (
+        <div className="my-2 flex justify-between items-center w-full">
+          <h1 className="text-3xl font-bold mt-4 pb-3">{tag}</h1>
+          <span className="my-1 leading-relaxed text-[var(--main-color)]">
+            {new Date(date).toLocaleDateString('en-GB', {
+              day: '2-digit',
+              month: 'short',
+              year: 'numeric',
+            })}
+          </span>
+        </div>
+      )}
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
@@ -59,7 +57,13 @@ const PostWrapper = ({ textContent }: { textContent: string }) => {
             />
           ),
           li: (props) => <li className="mb-1" {...props} />,
-          a: (props) => <a className="underline" {...props} />,
+          a: (props) => (
+            <a
+              target="_blank"
+              className="underline text-[var(--main-color)]"
+              {...props}
+            />
+          ),
 
           table: (props) => (
             <table


### PR DESCRIPTION
## 📝 Description

This feature provides users with easy access to patch notes containing information about new features, fixes, and updates in a clean, discoverable way. The link is located at the bottom of the home page (main menu) alongside the existing ToS, privacy, and security links.

It fetches releases from `https://api.github.com/repos/lingdojo/kana-dojo/releases?per_page=5`, with a fallback in case no releases have been made yet.

## 🔗 Related Issue

Closes #218 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [X] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [X] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 📸 Screenshots/Videos (if applicable)

The feature has been tested using MonkeyType releases, since Kanadojo currently has no releases.

https://github.com/user-attachments/assets/fbdf068c-5007-434c-9f26-7612c23d2776

## ✅ Pre-Submission Checklist

- [X] My code follows the project's code style and uses `cn()` utility where needed.
- [X] I have run the linter (`npm run lint`) and there are no new errors.
- [X] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [] I have updated the documentation (if applicable).
- [X] This PR is against the `main` branch.