### PR TITLE
fix(BackToTop): attach scroll listener to ClientLayout container

### DIFF
--- a/shared/components/BackToTop.tsx
+++ b/shared/components/BackToTop.tsx
@@ -1,23 +1,33 @@
-"use client";
+'use client';
 import { useEffect, useState } from 'react';
 import { ChevronUp } from 'lucide-react';
 import { usePathname } from 'next/navigation';
+import clsx from 'clsx';
 
 export default function BackToTop() {
   const [visible, setVisible] = useState(false);
   const pathname = usePathname();
 
+  // target the container in ClientLayout
+  const container = document.querySelector(
+    '[data-scroll-restoration-id="container"]'
+  );
+
   useEffect(() => {
+    if (!container) return;
+
     const onScroll = () => {
       // Show after user scrolls down 300px
-      setVisible(window.scrollY > 300);
+      setVisible(container.scrollTop > 300);
     };
 
-    window.addEventListener('scroll', onScroll, { passive: true });
+    // attach scroll listener to the container, not window
+    container.addEventListener('scroll', onScroll, { passive: true });
     // Initial check
     onScroll();
 
-    return () => window.removeEventListener('scroll', onScroll);
+    return () => container.removeEventListener('scroll', onScroll);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Hide on top-level locale route (e.g. /en or /es) or root
@@ -29,7 +39,7 @@ export default function BackToTop() {
 
   const handleClick = () => {
     if (typeof window !== 'undefined') {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
+      container?.scrollTo({ top: 0, behavior: 'smooth' });
       // Move focus to body for keyboard users after scroll
       // (give the browser a tick so scrolling starts)
       setTimeout(() => {
@@ -43,15 +53,15 @@ export default function BackToTop() {
       aria-label="Back to top"
       title="Back to top"
       onClick={handleClick}
-      className={
-        'fixed z-[60] right-4 bottom-4 sm:right-6 sm:bottom-8 ' +
-        'inline-flex items-center justify-center rounded-full ' +
-        'p-3 shadow-lg transition-all duration-200 ' +
-        'bg-[var(--card-color)] text-[var(--main-color)] ' +
-        'hover:bg-[var(--border-color)] hover:scale-110 ' +
-        'focus:outline-none focus:ring-2 focus:ring-[var(--main-color)] focus:ring-offset-2 ' +
+      className={clsx(
+        'fixed z-[60] right-4 bottom-4 sm:right-6 sm:bottom-8 ',
+        'inline-flex items-center justify-center rounded-full ',
+        'p-3 shadow-lg transition-all duration-200 ',
+        'bg-[var(--card-color)] text-[var(--main-color)] ',
+        'hover:bg-[var(--border-color)] hover:scale-110 ',
+        'focus:outline-none focus:ring-2 focus:ring-[var(--main-color)] focus:ring-offset-2 ',
         'border-2 border-[var(--border-color)]'
-      }
+      )}
     >
       <ChevronUp size={24} strokeWidth={2.5} />
     </button>


### PR DESCRIPTION
## 📝 Description

The logic was correct, but it previously targeted 'window' instead of the container with its own overflowY and height

## 🔗 Related PR

PR #131

## 🎯 Type of Change

- [X] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

**Manual Test Checklist:**

- [X] Tested in **Kana** dojo
- [X] Tested in **Kanji** dojo
- [X] Tested in **Vocabulary** dojo
- [X] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [X] ... (add any other specific tests)

## ✅ Pre-Submission Checklist

- [X] My code follows the project's code style and uses `cn()` utility where needed.
- [X] I have run the linter (`npm run lint`) and there are no new errors.
- [X] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [X] This PR is against the `main` branch.