### PR TITLE
Misc cleanups: fix CrazyMode runtime error

### DIFF
--- a/features/CrazyMode/store/useCrazyModeStore.ts
+++ b/features/CrazyMode/store/useCrazyModeStore.ts
@@ -42,11 +42,11 @@ const useCrazyModeStore = create<CrazyModeState>()(
         const allThemes = themeSets.flatMap(group => group.themes);
         const randomTheme = allThemes[random.integer(0, allThemes.length - 1)];
 
-        const randomFont = fonts[random.integer(0, fonts.length - 1)];
+        const randomFont = fonts.length > 0 ? fonts[random.integer(0, fonts.length - 1)] : null;
 
         set({
           activeThemeId: randomTheme.id,
-          activeFontName: randomFont.name
+          activeFontName: randomFont?.name ?? null
         });
       }
     }),


### PR DESCRIPTION
## 📝 Description

Fixes a runtime `TypeError` in **CrazyMode** caused by attempting to access `.name` on an undefined font when the `fonts` array is empty in development.