### PR TITLE
feat: implement theme data and OKLCH color generation utilities.

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -695,6 +695,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         backgroundColor: 'oklch(19.00% 0.0220 260.00 / 1)',
         mainColor: 'oklch(76.00% 0.1100 40.00 / 1)',
         secondaryColor: 'oklch(65.00% 0.0400 148.00 / 1)'
+      },
+      {
+        id: 'kurokumo',
+        backgroundColor: 'oklch(17.0% 0.032 270.0 / 1)',
+        mainColor: 'oklch(87.0% 0.135 215.0 / 1)',
+        secondaryColor: 'oklch(74.0% 0.110 305.0 / 1)'
       }
     ]
   },


### PR DESCRIPTION
## 📝 Description

Added a new dark theme called **kurokumo** (黒雲 - "black clouds") to the Dark theme group. This theme is inspired by cinematic stormy Tokyo nights, featuring an inky blue-violet background with electric cyan highlights and violet-magenta accents.

The theme evokes the aesthetic of rain-slicked city streets, neon glow reflecting on black clouds, and the electric energy of Tokyo at night.

**Theme specifications:**
- **Background**: `oklch(17.0% 0.032 270.0 / 1)` - inky blue-violet storm night (17% lightness)
- **Main color**: `oklch(87.0% 0.135 215.0 / 1)` - electric cyan highlight (87% lightness)
- **Secondary color**: `oklch(74.0% 0.110 305.0 / 1)` - soft violet-magenta accent (74% lightness)

Card, border, and accent colors are automatically generated by the existing theme system.

## 🔗 Related Issue

Closes #259 

## 🎯 Type of Change

- [x] `feat`: New feature (non-breaking change which adds functionality)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Started development server with `npm run dev`
2. Navigated to Preferences page
3. Scrolled to Dark themes section
4. Selected kurokumo theme
5. Verified theme applies correctly across different pages
6. Checked text legibility and color contrast

**Manual Test Checklist:**

- [x] Theme appears in preferences UI under Dark category
- [x] Theme applies correctly with proper visual appearance
- [x] Text remains legible with high contrast between background and foreground
- [x] Theme persists across page navigation
- [x] No visual glitches or rendering issues

**Build & Lint:**
- [x] TypeScript compilation successful (`npm run build`)
- [x] No lint errors

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

This theme was added to the existing Dark theme group in [features/Preferences/data/themes.ts](cci:7://file:///c:/Users/SK%20VERMA/Desktop/KanaDojo/kanadojo/features/Preferences/data/themes.ts:0:0-0:0). The implementation follows the established pattern where only base colors (backgroundColor, mainColor, secondaryColor) are defined, and derived colors (cardColor, borderColor, accents) are automatically generated using the existing helper functions.

**Visual inspiration**: Stormy Tokyo nights, neon reflections on wet streets, electric city atmosphere, and the cinematic mood of black clouds with violet haze.

**Color theory**: The high contrast between the very dark background (17% lightness) and bright cyan main color (87% lightness) ensures excellent legibility while maintaining the moody aesthetic.