### PR TITLE
feat: added yume-mori dark theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -701,6 +701,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         backgroundColor: 'oklch(17.0% 0.032 270.0 / 1)',
         mainColor: 'oklch(87.0% 0.135 215.0 / 1)',
         secondaryColor: 'oklch(74.0% 0.110 305.0 / 1)'
+      },
+      {
+        id: 'yume-mori',
+        backgroundColor: 'oklch(20.0% 0.040 190.0 / 1)',
+        mainColor:       'oklch(86.0% 0.140 180.0 / 1)', 
+        secondaryColor:  'oklch(74.0% 0.090 150.0 / 1)',  
       }
     ]
   },


### PR DESCRIPTION
## 📝 Description
Adds a new dark theme **yume-mori** to the Preferences theme set.
The theme is inspired by a dreamlike forest at night, using a deep teal background with mint-cyan and moss green accents.
Derived theme values are generated automatically by the existing theme system.
...

## 🔗 Related Issue

Closes #253 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**
1. Opened Preferences and navigated to the Dark themes section.
2. Selected the **yume-mori** theme and verified it applies correctly.

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)
<img width="1162" height="756" alt="Yume mori dark theme" src="https://github.com/user-attachments/assets/3f5c1af4-4edc-4119-993c-625855f8fd80" />

...

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

...