### PR TITLE
feat(theme): add Suisen (水仙) dark theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -705,21 +705,27 @@ const baseThemeSets: BaseThemeGroup[] = [
       {
         id: 'yume-mori',
         backgroundColor: 'oklch(20.0% 0.040 190.0 / 1)',
-        mainColor:       'oklch(86.0% 0.140 180.0 / 1)', 
-        secondaryColor:  'oklch(74.0% 0.090 150.0 / 1)',  
+        mainColor: 'oklch(86.0% 0.140 180.0 / 1)',
+        secondaryColor: 'oklch(74.0% 0.090 150.0 / 1)'
       },
       {
-       id: 'yozakura',
-       backgroundColor: 'oklch(22.0% 0.030 315.0 / 1)',
-       mainColor:       'oklch(86.5% 0.135 331.0 / 1)',  
-       secondaryColor:  'oklch(72.0% 0.070 320.0 / 1)', 
+        id: 'yozakura',
+        backgroundColor: 'oklch(22.0% 0.030 315.0 / 1)',
+        mainColor: 'oklch(86.5% 0.135 331.0 / 1)',
+        secondaryColor: 'oklch(72.0% 0.070 320.0 / 1)'
       },
       {
-      id: 'kyoto-lanterns',
-      backgroundColor: 'oklch(22.10% 0.0310 265.00 / 1)', 
-      mainColor:        'oklch(78.90% 0.1820 50.00 / 1)',     
-      secondaryColor:   'oklch(84.20% 0.1200 90.00 / 1)',     
+        id: 'kyoto-lanterns',
+        backgroundColor: 'oklch(22.10% 0.0310 265.00 / 1)',
+        mainColor: 'oklch(78.90% 0.1820 50.00 / 1)',
+        secondaryColor: 'oklch(84.20% 0.1200 90.00 / 1)'
       },
+      {
+        id: 'suisen',
+        backgroundColor: 'oklch(17.0% 0.031 260.0 / 1)',
+        mainColor: 'oklch(89.0% 0.053 260.0 / 1)',
+        secondaryColor: 'oklch(74.0% 0.170 295.0 / 1)'
+      }
     ]
   },
   {


### PR DESCRIPTION
## 📝 Description

This PR adds a new dark theme called **Suisen (水仙)**. It is a deep, tranquil dark theme inspired by the narcissus flower, utilizing a refined OKLCH color palette. 

- Added `suisen` theme definition to `features/Preferences/data/themes.ts`.
- The theme features a deep indigo-charcoal background with soft teal and lavender accents for high readability in low-light environments.

## 🔗 Related Issue

Closes # 271

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Navigate to the Preferences/Theme settings.
2. Select the "Suisen" theme from the Dark category.
3. Verify that all UI elements (cards, buttons, borders) are using the correct generated accent colors.
4. Verify accessibility and contrast during gameplay.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Verified theme persistence after reload.

## 📸 Screenshots/Videos (if applicable)
<img width="1096" height="373" alt="newTheme" src="https://github.com/user-attachments/assets/04b8c0ed-44d7-4943-8cf4-8e73ba33d749" />
<img width="865" height="451" alt="newThemeDisplay" src="https://github.com/user-attachments/assets/5ce95d77-c250-49f9-83ff-8d199105457d" />


## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

The color values were carefully chosen using OKLCH to ensure that the generated card and border colors maintain consistent contrast ratios compared to the other themes in the "Dark" category.