### PR TITLE
feat: add 'En' (焰) celestial theme to dark group (#262)

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -725,6 +725,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         backgroundColor: 'oklch(17.0% 0.031 260.0 / 1)',
         mainColor: 'oklch(89.0% 0.053 260.0 / 1)',
         secondaryColor: 'oklch(74.0% 0.170 295.0 / 1)'
+      },
+      {
+        id: 'en',
+        backgroundColor: 'oklch(14.5% 0.036 267.0 / 1)',
+        mainColor: 'oklch(91.0% 0.042 253.0 / 1)',
+        secondaryColor: 'oklch(81.0% 0.170 355.0 / 1)'
       }
     ]
   },


### PR DESCRIPTION
## 📝 Description

This PR introduces a new celestial-themed dark mode called **"En" (焰)**. 

"En" (meaning 'flare' or 'celestial flame') provides a sleek, high-contrast interface inspired by cosmic flares. It uses a custom OKLCH palette specifically selected for both aesthetic radiance and full WCAG AA accessibility.

**Palette Details:**
- **Background:** Cosmic obsidian — `oklch(14.5% 0.036 267.0 / 1)`
- **Main Color:** Stellar silver-blue — `oklch(91.0% 0.042 253.0 / 1)`
- **Secondary Color:** Magenta solar flare — `oklch(81.0% 0.170 355.0 / 1)`

## 🔗 Related Issue

Closes #262

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Navigate to the Theme selection menu.
2. Locate the "En" theme within the **Dark** theme group.
3. Apply the theme and verify the background and accent colors.
4. Confirm text legibility across various dojos and game modes.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Verified WCAG AA contrast ratios for the new palette.

## 📸 Screenshots/Videos (if applicable)

<img width="864" height="621" alt="enThemeSelection" src="https://github.com/user-attachments/assets/6bfd0b9a-e837-4a86-bd5e-9b25bc5adf62" />
<img width="911" height="546" alt="enTheme" src="https://github.com/user-attachments/assets/a556d044-35ce-4610-a541-cbb98508d8e7" />
<img width="787" height="602" alt="enThemeKanji" src="https://github.com/user-attachments/assets/1b05dca8-301a-4da5-aa9b-76de13ec65a1" />

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

The theme was added to the `Dark` category in `features/Preferences/data/themes.ts`. All derived colors (card backgrounds, borders, and hover accents) are automatically generated by the theme engine's utility functions, maintaining consistency with the overall design system.