### PR TITLE
Add Kuromizu: Japanese-Inspired Celestial Dark Theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -241,6 +241,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     icon: Moon,
     themes: [
       {
+        id: 'kuromizu',
+        backgroundColor: 'oklch(10.6% 0.034 248.0 / 1)',
+        mainColor: 'oklch(74.8% 0.182 305.5 / 1)',     
+        secondaryColor: 'oklch(82.5% 0.132 187.0 / 1)'  
+      },
+      {
         id: 'monkeytype',
         backgroundColor: 'oklch(33.94% 0.0062 248.01 / 1)',
         mainColor: 'oklch(81.03% 0.1625 94.11 / 1)',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kanadojo",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kanadojo",
-      "version": "0.1.10",
+      "version": "0.1.12",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
@@ -10456,17 +10456,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-mdx-remote": {


### PR DESCRIPTION
# Add Kuromizu Celestial Dark Theme

## Summary
This PR adds a new Japanese-inspired celestial dark theme called **Kuromizu (黒水)** to the dark theme collection.

Kuromizu is designed around a deep, aquatic night aesthetic with luminous accent colors, providing a distinctive visual option while maintaining strong readability and WCAG AA-compliant contrast.

## What’s included
- New dark theme: **Kuromizu**
  - Obsidian blue background
  - Fluorite lake violet primary color
  - Solar kelp teal secondary accent
- Theme is added to the existing `themes.ts` dark group
- No existing themes modified
- No new fields or structural changes

## Visual changes
Screenshots below show Kuromizu applied across:
- Theme selector
- Primary UI surfaces
- Accent and highlight elements
<img width="1918" height="906" alt="Screenshot 2025-12-28 191109" src="https://github.com/user-attachments/assets/99e880a5-ee52-42a8-a9f1-e52d508624bd" />
<img width="911" height="779" alt="Screenshot 2025-12-28 191121" src="https://github.com/user-attachments/assets/30327fb1-4ce5-4b24-9753-c191f8f4d81a" />



## Accessibility
- Color contrast validated for dark-mode usage  
- Designed to meet **WCAG AA** contrast requirements

## Testing
1. Run the application
2. Open the theme selector
3. Select **Kuromizu**
4. Verify appearance across main UI views

## Related
Closes #288