### PR TITLE
feat: add Tsurara color theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -755,6 +755,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         backgroundColor: 'oklch(14.5% 0.046 278.0 / 1)',
         mainColor: 'oklch(94.0% 0.072 92.0 / 1)',
         secondaryColor: 'oklch(81.0% 0.180 328.0 / 1)'
+      },
+      {
+        id: 'tsurara',
+        backgroundColor: 'oklch(13.0% 0.041 290.0 / 1)',
+        mainColor: 'oklch(88.0% 0.222 192.0 / 1)',
+        secondaryColor: 'oklch(90.5% 0.207 28.0 / 1)'
       }
     ]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10458,6 +10458,17 @@
         }
       }
     },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
+      "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next-mdx-remote": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/next-mdx-remote/-/next-mdx-remote-5.0.0.tgz",


### PR DESCRIPTION
## Summary
- Add new dark theme 'Tsurara' (氷柱, icicle) to the Dark themes group
- Uses the exact OKLCH color values specified in the issue

## Theme Colors
- **Background:** `oklch(13.0% 0.041 290.0 / 1)` - Cosmic frost indigo
- **Main Color:** `oklch(88.0% 0.222 192.0 / 1)` - Radiant comet teal
- **Secondary Color:** `oklch(90.5% 0.207 28.0 / 1)` - Ethereal fire opal magenta

## Test Plan
- [ ] Theme appears in Dark themes group
- [ ] Colors render correctly
- [ ] WCAG contrast requirements met

Closes #291