### PR TITLE
[FEATURE] : Reverse Typing for Kanji

### DIFF
--- a/features/Kanji/components/Game/Input.tsx
+++ b/features/Kanji/components/Game/Input.tsx
@@ -81,9 +81,13 @@ const KanjiInputGame = ({
     correctKanjiObj as IKanjiObj
   );
 
-  const targetChar = isReverse
-    ? correctKanjiObj?.kanjiChar
-    : correctKanjiObj?.meanings;
+const targetChar = isReverse
+  ? correctKanjiObj?.kanjiChar
+  : [
+      ...(correctKanjiObj?.meanings ?? []),
+      ...(correctKanjiObj?.kunyomi?.map(k => k.split(' ')[0]) ?? []),
+      ...(correctKanjiObj?.onyomi?.map(k => k.split(' ')[0]) ?? []),
+    ];
 
   const [displayAnswerSummary, setDisplayAnswerSummary] = useState(false);
   const [feedback, setFeedback] = useState(<>{'feedback ~'}</>);


### PR DESCRIPTION
## 📝 Description

Adds **Romaji support for Reverse Typing (Kanji → Input)** in the Kanji dojo.

Previously, reverse typing accepted only English meanings. This update allows **Romaji readings (Onyomi and Kunyomi)** to be accepted as valid answers.

⚠️ Currently enabled **only in Classic mode**.  
Blitz and Gauntlet modes are **not affected**.

---

## 🔗 Related Issue

Closes #280

---

## 🎯 Type of Change

- [x] `feat`: New feature

---

## 🧪 Testing

**Manual:**
- Verified in **Kanji dojo**
- Confirmed Onyomi and Kunyomi Romaji are accepted
- Confirmed meaning-based typing still works

---
<img width="948" height="496" alt="Screenshot 2025-12-29 233835" src="https://github.com/user-attachments/assets/4f0aaf43-d48f-41e7-a561-c5a5bcc59216" />
