### PR TITLE
feat(kanji reverse typing): add reverse typing in blitz and gauntlet

### DIFF
--- a/features/Kanji/components/Blitz.tsx
+++ b/features/Kanji/components/Blitz.tsx
@@ -43,10 +43,12 @@ export default function BlitzKanji() {
     inputPlaceholder: 'Type the meaning...',
     modeDescription: 'Mode: Type (See kanji → Type meaning)',
     checkAnswer: (question, answer, isReverse) => {
-      if (isReverse) {
-        // Reverse: answer should be the kanji character
-        return answer.trim() === question.kanjiChar;
-      }
+      if (!isReverse) {
+        // Reverse: answer should be the kanji character or kunyomi or onyomi
+        return (answer.trim() === question.kanjiChar ||  question.kunyomi.some(k => k.split(' ')[0] === answer)||question.onyomi.some(k => k.split(' ')[0] === answer)||question.meanings.some(
+        meaning => answer.toLowerCase() === meaning.toLowerCase()
+      ));
+    }
       // Normal: answer should match any meaning
       return question.meanings.some(
         meaning => answer.toLowerCase() === meaning.toLowerCase()

--- a/features/Kanji/components/Gauntlet.tsx
+++ b/features/Kanji/components/Gauntlet.tsx
@@ -42,10 +42,12 @@ const GauntletKanji: React.FC<GauntletKanjiProps> = ({ onCancel }) => {
     renderQuestion: (question, isReverse) =>
       isReverse ? question.meanings[0] : question.kanjiChar,
     checkAnswer: (question, answer, isReverse) => {
-      if (isReverse) {
-        // Reverse: answer should be the kanji character
-        return answer.trim() === question.kanjiChar;
-      }
+      if (!isReverse) {
+        // Reverse: answer should be the kanji character or kunyomi or onyomi
+        return (answer.trim() === question.kanjiChar ||  question.kunyomi.some(k => k.split(' ')[0] === answer)||question.onyomi.some(k => k.split(' ')[0] === answer)||question.meanings.some(
+        meaning => answer.toLowerCase() === meaning.toLowerCase()
+      ));
+    }
       // Normal: answer should match any meaning
       return question.meanings.some(
         meaning => answer.toLowerCase() === meaning.toLowerCase()


### PR DESCRIPTION
## 📝 Description

Adds **Romaji support for Reverse Typing (Kanji → Input)** in the Kanji dojo.

Previously, reverse typing accepted only English meanings. This update allows **Romaji readings (Onyomi and Kunyomi)** to be accepted as valid answers, alongside meanings.

Reverse typing is now supported across all modes:
- Classic
- Blitz
- Gauntlet

---

## 🔗 Related Issue

Closes #280

---

## 🎯 Type of Change

- `feat`: New feature

---

## 🧪 Testing

**Manual testing:**
- Verified Reverse Typing in Kanji dojo
- Confirmed Onyomi Romaji is accepted
- Confirmed Kunyomi Romaji is accepted
- Confirmed meaning-based typing still works
- Verified behavior in Classic, Blitz, and Gauntlet modes
