### PR TITLE
feat: add Yumemizu dark theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -215,9 +215,18 @@ const baseThemeSets: BaseThemeGroup[] = [
         backgroundColor: 'oklch(22.67% 0.0000 89.88 / 1)',
         mainColor: 'oklch(100.00% 0.0000 89.88 / 1)',
         secondaryColor: 'oklch(80.54% 0.0000 89.88 / 1)'
-      }
+      },
+   {
+  id: 'yumemizu',
+  backgroundColor: 'oklch(20.5% 0.012 288.7 / 1)',
+  mainColor: 'oklch(90.4% 0.216 274.7 / 1)',
+  secondaryColor: 'oklch(92.6% 0.173 338.0 / 1)',
+},
+
+
     ]
   },
+  
   {
     name: 'Light',
     icon: Sun,


### PR DESCRIPTION
📝 Description

Adds a new celestial dark theme — Yumemizu (夢水), inspired by surreal dreamwater and nebula gardens.
The theme introduces a visually distinct, high-contrast color combination using deep dreamwater blue, nebula teal-mint, and pale magical magenta.

This change only updates the theme configuration and does not modify any existing logic or themes.

🔗 Related Issue

Closes #313 

🎯 Type of Change

 fix: Bug fix (non-breaking change which fixes an issue)

 feat: New feature (non-breaking change which adds functionality)

 docs: Documentation update (e.g., this file, README)

 content: Content update (e.g., new kanji, vocab, or fonts in /static/)

 style: UI/Theme changes (e.g., Tailwind, CSS, new themes)

 refactor: Code refactor (no functional changes)

 test: Test update (adding missing tests or correcting existing tests)

 chore: Build, CI/CD, or dependency updates

🧪 How Has This Been Tested?

Test Steps:

Added the yumemizu theme object to the darkThemes array.

Launched the app locally.

Selected Yumemizu from the dark theme selector.

Manual Test Checklist:

 Tested in Kana dojo

 Tested in Kanji dojo

 Tested in Vocabulary dojo

 Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

📸 Screenshots/Videos (if applicable)

Not required — visual changes are limited to theme colors and selector preview.

✅ Pre-Submission Checklist

 My code follows the project's code style and uses cn() utility where needed.

 I have run the linter (npm run lint) and there are no new errors.

 My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/)
 format.

 I have updated the documentation (not required for this change).

 This PR is against the main branch.

📦 Additional Context

This theme was implemented exactly as described in the issue, without altering or removing any existing themes or configuration.📝 Description

Adds a new celestial dark theme — Yumemizu (夢水), inspired by surreal dreamwater and nebula gardens.
The theme introduces a visually distinct, high-contrast color combination using deep dreamwater blue, nebula teal-mint, and pale magical magenta.

This change only updates the theme configuration and does not modify any existing logic or themes.

🔗 Related Issue

Closes #YUMEMIZU_THEME (replace with actual issue number)

🎯 Type of Change

 fix: Bug fix (non-breaking change which fixes an issue)

 feat: New feature (non-breaking change which adds functionality)

 docs: Documentation update (e.g., this file, README)

 content: Content update (e.g., new kanji, vocab, or fonts in /static/)

 style: UI/Theme changes (e.g., Tailwind, CSS, new themes)

 refactor: Code refactor (no functional changes)

 test: Test update (adding missing tests or correcting existing tests)

 chore: Build, CI/CD, or dependency updates

🧪 How Has This Been Tested?

Test Steps:

Added the yumemizu theme object to the darkThemes array.

Launched the app locally.

Selected Yumemizu from the dark theme selector.

Manual Test Checklist:

 Tested in Kana dojo

 Tested in Kanji dojo

 Tested in Vocabulary dojo

 Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

📸 Screenshots/Videos (if applicable)

Not required — visual changes are limited to theme colors and selector preview.

✅ Pre-Submission Checklist

 My code follows the project's code style and uses cn() utility where needed.

 I have run the linter (npm run lint) and there are no new errors.

 My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/)
 format.

 I have updated the documentation (not required for this change).

 This PR is against the main branch.

📦 Additional Context

This theme was implemented exactly as described in the issue, without altering or removing any existing themes or configuration.