### PR TITLE
feat(themes): add Akebono dark theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -937,6 +937,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         mainColor: 'oklch(78.0% 0.155 140.0 / 1)',         // moss green
         secondaryColor: 'oklch(65.0% 0.110 190.0 / 1)',    // twilight leaf
       },
+      {
+        id: 'akebono',
+        backgroundColor: 'oklch(18.0% 0.030 280.0 / 1)',   // shadowed indigo
+        mainColor: 'oklch(94.0% 0.160 25.0 / 1)',           // pale sunrise pink
+        secondaryColor: 'oklch(88.0% 0.140 305.0 / 1)',     // spring mist violet
+      },
 
     ]
   },


### PR DESCRIPTION
## Summary
- Adds the 'Akebono' (dawn) dark theme as specified in the issue
- Color palette inspired by sunrise tones

## Changes
Added to `features/Preferences/data/themes.ts`:
- **id**: `akebono`
- **backgroundColor**: `oklch(18.0% 0.030 280.0 / 1)` (shadowed indigo)
- **mainColor**: `oklch(94.0% 0.160 25.0 / 1)` (pale sunrise pink)
- **secondaryColor**: `oklch(88.0% 0.140 305.0 / 1)` (spring mist violet)

## Test plan
- [x] TypeScript compiles without errors
- [ ] Theme is selectable in dark themes selector
- [ ] Colors render correctly in the app

Fixes #398