### PR TITLE
Add two unusual but true Japanese facts

### DIFF
--- a/public/japan-facts.json
+++ b/public/japan-facts.json
@@ -463,5 +463,7 @@
   "Japanese department stores have roof-top gardens and even beehives, where local honey is harvested and sometimes sold downstairs!",
   "There's a spring festival in Japan called 'Hanami' where people picnic under blooming cherry blossom trees. Some companies allow time off specifically for blossom viewing!",
   "Nearby Osaka there is a Nintendo themed Park named 'Super Nintendo World'. Guests are welcomed passing trough a Super Mario style green pipe. There are some challenges and hidden secrets inside the park. Mamma Mia!",
-  "During 2020 Tokyo olympics (posponed beyond scheduled date due to covid-19) eight anime characters where chosen as 'Anime Ambassadors'. Goku, Naruto, Sailor Moon and Luffy."
+  "During 2020 Tokyo olympics (posponed beyond scheduled date due to covid-19) eight anime characters where chosen as 'Anime Ambassadors'. Goku, Naruto, Sailor Moon and Luffy.",
+  "Mount Fuji is still an active volcano, last erupting in 1707! It's considered sacred, and climbing season only runs July through early September.",
+  "There's a traditional Japanese card game called 'karuta' where players race to grab matching cards based on a poem or proverb being read aloud—speed, memory, and reflexes all count!"
 ]


### PR DESCRIPTION
### What does this PR do?
Adds two unusual but true cultural facts about Japan to `public/japan-facts.json`.

### Changes made
- Added a fact about Mount Fuji being an active volcano
- Added a fact about the traditional Japanese card game *karuta*

### Notes
- No existing facts were modified or removed
- Changes follow the existing JSON format
- This is a small, content-only update

Closes #418 
