### PR TITLE
feat(themes): add 'Shion' dark theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -943,7 +943,13 @@ const baseThemeSets: BaseThemeGroup[] = [
         backgroundColor: 'oklch(22.0% 0.045 145.0 / 1)', // reef dusk
         mainColor: 'oklch(90.0% 0.208 150.0 / 1)', // coral green
         secondaryColor: 'oklch(82.0% 0.160 185.0 / 1)' // lagoon teal
-      }
+      },
+      {
+        id: 'shion',
+        backgroundColor: 'oklch(18.5% 0.030 270.0 / 1)',    // matte onyx
+        mainColor: 'oklch(75.0% 0.146 300.0 / 1)',           // refined violet
+        secondaryColor: 'oklch(58.8% 0.120 145.0 / 1)',      // woodland shadow
+      },
     ]
   },
   {


### PR DESCRIPTION
## 📝 Description

Add a minimal, high-accessibility dark theme named Shion (紫苑), inspired by the sophisticated violet asters of Japan's autumn.

## 🔗 Related Issue

Closes #419 
