### PR TITLE
feat(theme): add neon sakura theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -242,6 +242,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     icon: Moon,
     themes: [
       {
+        id: 'neon-sakura',
+        backgroundColor: 'oklch(14% 0.04 310 / 1)',
+        mainColor: 'oklch(78% 0.23 340 / 1)',
+        secondaryColor: 'oklch(68% 0.18 285 / 1)'
+      },
+      {
         id: 'taikan',
         backgroundColor: 'oklch(21.2% 0.039 255.0 / 1)', // cosmic graphite
         mainColor: 'oklch(93.5% 0.235 122.0 / 1)', // radiant yellow-green


### PR DESCRIPTION
## 🎨 Neon Sakura Theme Color Refinement

### What changed
- Refined OKLCH color values for the **Neon Sakura** theme
- Improved contrast and neon balance on dark background
- Better visual harmony between primary and secondary accents

<img width="1070" height="773" alt="Screenshot 2026-01-13 193022" src="https://github.com/user-attachments/assets/79014443-d2b4-4cce-8bde-69a7b587cbe6" />
<img width="916" height="750" alt="Screenshot 2026-01-13 193030" src="https://github.com/user-attachments/assets/23e01662-f519-43b7-a015-70dd02973bd5" />

closes #423
