### PR TITLE
feat(theme): add Bamboo Mist theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -242,6 +242,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     icon: Moon,
     themes: [
       {
+        id: 'bamboo-mist',
+        backgroundColor: 'oklch(24.0% 0.032 150.0 / 1)',
+        mainColor: 'oklch(78.0% 0.145 145.0 / 1)',
+        secondaryColor: 'oklch(68.0% 0.085 130.0 / 1)'
+      },
+      {
         id: 'neon-sakura',
         backgroundColor: 'oklch(14% 0.04 310 / 1)',
         mainColor: 'oklch(78% 0.23 340 / 1)',
@@ -265,7 +271,6 @@ const baseThemeSets: BaseThemeGroup[] = [
         mainColor: 'oklch(90.4% 0.216 274.7 / 1)',
         secondaryColor: 'oklch(92.6% 0.173 338.0 / 1)'
       },
-
       {
         id: 'kuromizu',
         backgroundColor: 'oklch(10.6% 0.034 248.0 / 1)',


### PR DESCRIPTION
## 📝 Description

Added Bamboo Mist theme.

## 🔗 Related Issue

Closes #426 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [X] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. I ran `npm run dev`.
2. I clicked themes and selected the newly added Bamboo Mist theme.
3. I checked menus and interfaces to make sure the theme looks alright.
4. Then I went and tested it on Kana, Kanji and Vocabulary.
5. The theme looks good.

**Manual Test Checklist:**

- [X] Tested in **Kana** dojo
- [X] Tested in **Kanji** dojo
- [X] Tested in **Vocabulary** dojo
- [X] Tested in all menus (including documentation)
- [X] Tested in "All experiments"
- [x] Tested in preferences

## 📸 Screenshots/Videos (if applicable)

<img width="2560" height="1374" alt="image" src="https://github.com/user-attachments/assets/57af8833-2e9a-41dd-97ff-be3410c54f18" />

## ✅ Pre-Submission Checklist

- [X] My code follows the project's code style and uses `cn()` utility where needed.
- [X] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits]. (https://www.conventionalcommits.org/) format (saw that after committing, sorry for that, I learned from it though. It should have been `feat: add Bamboo Mist theme`).
- [X] I have updated the documentation (if applicable).
- [X] This PR is against the `main` branch.

## 📦 Additional Context

Theme looks good. Greens and shadows look noticeable. Contrast is low though, may not suit color-blinded people.