### PR TITLE
Add Japan Fact #5

### DIFF
--- a/public/japan-facts.json
+++ b/public/japan-facts.json
@@ -459,6 +459,6 @@
   "There's a traditional Japanese card game called 'karuta' where players race to grab matching cards based on a poem or proverb being read aloud—speed, memory, and reflexes all count!",
   "Japan has a word 'kuchisabishii' (口寂しい) that literally means 'lonely mouth' - the feeling of eating when you're not hungry, just because your mouth wants something to do.",
   "There's a Japanese practice called 'inemuri' (居眠り) - sleeping while present - where napping in public or at work is seen as a sign of dedication rather than laziness.",
-    "In Japan, blood types are believed to determine personality traits similar to zodiac signs in the West. Type A is organized and careful, Type B is creative and passionate, Type O is confident and leader-like, and Type AB is rational and cool."
-  
+  "In Japan, blood types are believed to determine personality traits similar to zodiac signs in the West. Type A is organized and careful, Type B is creative and passionate, Type O is confident and leader-like, and Type AB is rational and cool.",
+  "Japan's Aokigahara forest, also called the Sea of Trees, is so dense that GPS devices and compasses often malfunction due to the iron-rich volcanic soil."
 ]


### PR DESCRIPTION
Closes #439

Adds Japan Fact # 5 "Japan's Aokigahara forest, also called the Sea of Trees, is so dense that GPS devices and compasses often malfunction due to the iron-rich volcanic soil." to public/japan-facts.json file.