### PR TITLE
feat(theme): add Zen Stone color theme (#good-first-issue)

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -242,6 +242,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     icon: Moon,
     themes: [
       {
+        id: 'zen-stone',
+        backgroundColor: 'oklch(25.0% 0.015 260.0 / 1)',
+        mainColor: 'oklch(75.0% 0.035 90.0 / 1)',
+        secondaryColor: 'oklch(60.0% 0.025 80.0 / 1)'
+      },
+      {
         id: 'koi-pond',
         backgroundColor: 'oklch(20.0% 0.048 240.0 / 1)',
         mainColor: 'oklch(80.0% 0.175 55.0 / 1)',


### PR DESCRIPTION
## 📝 Description

Added the new **Zen Stone** theme to the Dark themes collection.
This theme features a polished river stone aesthetic with:
- **Background:** Dark polished stone (`oklch(25.0% 0.015 260.0 / 1)`)
- **Main Color:** Light river stone (`oklch(75.0% 0.035 90.0 / 1)`)
- **Secondary:** Soft blue-grey (`oklch(60.0% 0.025 80.0 / 1)`)

## 🔗 Related Issue

- Closes #497

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  Open the application settings/preferences.
2.  Navigate to the **Dark Themes** section.
3.  Select the **Zen Stone** theme.
4.  Verify that the background and accent colors update to the expected stone/river palette.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

## 📸 Screenshots/Videos (if applicable)

_N/A_

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

Implements the "Zen Stone" theme requested in #497.