### PR TITLE
content: add japanese proverb #10

### DIFF
--- a/public/japanese-proverbs.json
+++ b/public/japanese-proverbs.json
@@ -24,21 +24,27 @@
     "meaning": "Accomplishing two things with one action"
   },
   {
-  "japanese": "郷に入っては郷に従え",
-  "romaji": "Gou ni itte wa gou ni shitagae",
-  "english": "When in a village, follow the village customs",
-  "meaning": "When in Rome, do as the Romans do"
+    "japanese": "郷に入っては郷に従え",
+    "romaji": "Gou ni itte wa gou ni shitagae",
+    "english": "When in a village, follow the village customs",
+    "meaning": "When in Rome, do as the Romans do"
   },
   {
-  "japanese": "時は金なり",
-  "romaji": "Toki wa kane nari",
-  "english": "Time is money",
-  "meaning": "Time is valuable and should not be wasted"
+    "japanese": "時は金なり",
+    "romaji": "Toki wa kane nari",
+    "english": "Time is money",
+    "meaning": "Time is valuable and should not be wasted"
   },
   {
-  "japanese": "百聞は一見に如かず",
-  "romaji": "Hyakubun wa ikken ni shikazu",
-  "english": "Hearing a hundred times is not as good as seeing once",
-  "meaning": "Seeing is believing"
-}
+    "japanese": "百聞は一見に如かず",
+    "romaji": "Hyakubun wa ikken ni shikazu",
+    "english": "Hearing a hundred times is not as good as seeing once",
+    "meaning": "Seeing is believing"
+  },
+  {
+    "japanese": "転ばぬ先の杖",
+    "romaji": "Korobanu saki no tsue",
+    "english": "A cane before falling",
+    "meaning": "Prevention is better than cure"
+  }
 ]


### PR DESCRIPTION
## 📝 Description

Added a new traditional Japanese proverb to the community proverbs collection.  
This update introduces **転ばぬ先の杖 (Korobanu saki no tsue)**, helping learners understand a common expression emphasizing preparedness and prevention.

The proverb was appended to `public/japanese-proverbs.json` following the existing format.

## 🔗 Related Issue

Closes #10

## 🎯 Type of Change

- [ ] `fix`
- [ ] `feat`
- [ ] `docs`
- [x] `content`
- [ ] `style`
- [ ] `refactor`
- [ ] `test`
- [ ] `chore`

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Opened `public/japanese-proverbs.json`
2. Verified JSON syntax and structure after adding the new proverb entry
3. Confirmed the file parses correctly with no trailing or missing commas

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Not applicable (content-only JSON update)

## 📸 Screenshots/Videos (if applicable)

N/A – content-only update.

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

This is a small, beginner-friendly content contribution intended to expand the Japanese proverbs dataset for learners.
