### PR TITLE
docs(contributing): fix typo in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,14 +33,14 @@ Before you jump in, make sure your environment is ready:
 
 ```bash
 # 1. Fork the repo
-https://github.com/lingdojo/kanadojo/fork
+https://github.com/lingdojo/kana-dojo/fork
 
 # 2. Clone your fork
-git clone https://github.com/<your-username>/kanadojo.git
-cd kanadojo
+git clone https://github.com/<your-username>/kana-dojo.git
+cd kana-dojo
 
 # 3. Add the original repo as upstream (to stay in sync)
-git remote add upstream https://github.com/lingdojo/kanadojo.git
+git remote add upstream https://github.com/lingdojo/kana-dojo.git
 
 # 4. Install dependencies and start the dev server
 npm install && npm run dev


### PR DESCRIPTION
## 📝 Description
Fixed a small typo in the **CONTRIBUTING.md** to make the Quick Setup links and commad correct. The correction include replacing "kanadojo" with "kana-dojo" to ensure setup commands and url work correctly.
...

## 🔗 Related Issue

Closes #

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [x] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  run the commands in quick setup

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)

Older Quick setup
<img width="1322" height="416" alt="image" src="https://github.com/user-attachments/assets/c657d86c-a2af-42c0-aea7-5e3133ffc850" />

After fork when you try to clone, it is not recognised since there is difference in repo name.
<img width="933" height="98" alt="{6032CB22-0B0C-4909-805C-53641096225F}" src="https://github.com/user-attachments/assets/89e17dac-0760-4411-a5e5-6897fe361574" />

Since by default after fork repo name becomes kana-dojo that one works

...

## ✅ Pre-Submission Checklist

- [ ] My code follows the project's code style and uses `cn()` utility where needed.
- [ ] I have run the linter (`npm run lint`) and there are no new errors.
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [ ] This PR is against the `main` branch.

## 📦 Additional Context

...