### PR TITLE
content: add japanese proverb #15

### DIFF
--- a/public/japanese-proverbs.json
+++ b/public/japanese-proverbs.json
@@ -24,27 +24,22 @@
     "meaning": "Accomplishing two things with one action"
   },
   {
-  "japanese": "郷に入っては郷に従え",
-  "romaji": "Gou ni itte wa gou ni shitagae",
-  "english": "When in a village, follow the village customs",
-  "meaning": "When in Rome, do as the Romans do"
-},
-{
-  "japanese": "知らぬが仏",
-  "romaji": "Shiranu ga hotoke",
-  "english": "Not knowing is Buddha",
-  "meaning": "Ignorance is bliss"
-}
-  },
-  {
-  "japanese": "二兎を追う者は一兎をも得ず",
-  "romaji": "Ni to wo ou mono wa itto wo mo ezu",
-  "english": "One who chases two rabbits catches neither",
-  "meaning": "Focus on one thing at a time"
     "japanese": "郷に入っては郷に従え",
     "romaji": "Gou ni itte wa gou ni shitagae",
     "english": "When in a village, follow the village customs",
     "meaning": "When in Rome, do as the Romans do"
+  },
+  {
+    "japanese": "知らぬが仏",
+    "romaji": "Shiranu ga hotoke",
+    "english": "Not knowing is Buddha",
+    "meaning": "Ignorance is bliss"
+  },
+  {
+    "japanese": "二兎を追う者は一兎をも得ず",
+    "romaji": "Ni to wo ou mono wa itto wo mo ezu",
+    "english": "One who chases two rabbits catches neither",
+    "meaning": "Focus on one thing at a time"
   },
   {
     "japanese": "時は金なり",
@@ -69,5 +64,11 @@
     "romaji": "Anzuru yori umu ga yasushi",
     "english": "Giving birth is easier than worrying",
     "meaning": "Things are often easier done than worried about"
+  },
+  {
+    "japanese": "三人寄れば文殊の知恵",
+    "romaji": "Sannin yoreba monju no chie",
+    "english": "Three people together have the wisdom of Monju",
+    "meaning": "Two heads are better than one"
   }
 ]


### PR DESCRIPTION
## 📝 Description
added japanese proverb 15 as per #630. I noticed extra bracket near line 38 which is removed. Additionally there had been repeated entry of proverb which has been removed.

Follwing repeated entry has been removed **kindly see the screenshot**
```
{
    "japanese": "郷に入っては郷に従え",
    "romaji": "Gou ni itte wa gou ni shitagae",
    "english": "When in a village, follow the village customs",
    "meaning": "When in Rome, do as the Romans do"
 }
```

...

## 🔗 Related Issue

Closes #630 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)
Additional bracket, missing closing bracket and a repeated entry. this has been fixed.
<img width="823" height="710" alt="Screenshot 2026-01-17 141604" src="https://github.com/user-attachments/assets/1944d6d8-59a6-43e2-b5ce-a67fb3eefd60" />

...

## ✅ Pre-Submission Checklist

- [ ] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [ ] This PR is against the `main` branch.

## 📦 Additional Context

...