### PR TITLE
fix(ui): reduce kana pick mode font size for 3 targets on mobile

### DIFF
--- a/features/Kana/components/Game/WordBuildingGame.tsx
+++ b/features/Kana/components/Game/WordBuildingGame.tsx
@@ -601,7 +601,10 @@ const WordBuildingGame = ({
           {/* Word Display */}
           <div className='flex flex-row items-center gap-1'>
             <motion.p
-              className='text-7xl sm:text-8xl'
+              className={clsx(
+                'sm:text-8xl',
+                !isReverse && wordData.wordChars.length === 3 ? 'text-6xl' : 'text-7xl'
+              )}
               initial={{ opacity: 0, y: -20 }}
               animate={{ opacity: 1, y: 0 }}
             >


### PR DESCRIPTION
markdown
## 📝 Description
Reduces the font size of target characters from `text-7xl` to `text-6xl` in Kana pick mode specifically when 3 characters are displayed. This change prevents visual overflow on mobile devices while maintaining the original size for other states.
- Applies only to normal mode (not reverse)
- Applies only when exactly 3 Kana characters are shown
## 🔗 Related Issue
Closes #572
## 🎯 Type of Change
- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates
## 🧪 How Has This Been Tested?
**Test Steps:**
1.  Open the **Kana** game.
2.  Select **Pick** mode.
3.  Ensure the mode is **Normal** (Kana targets displayed).
4.  Play until a scenario with exactly **3 target characters** appears.
5.  Verify that the font size on mobile view is reduced to `text-6xl`, preventing overflow.
**Manual Test Checklist:**
- [x] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Verified responsiveness on mobile viewport
## 📸 Screenshots/Videos (if applicable)
*(No visual changes for non-mobile or other modes)*
## ✅ Pre-Submission Checklist
- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.
## 📦 Additional Context
The fix solely targets the specific class logic in [WordBuildingGame.tsx](cci:7://file:///c:/Users/samue/Documents/GitHub/kana-dojo/features/Kana/components/Game/WordBuildingGame.tsx:0:0-0:0) to handle the 3-character case on mobile screens. No other logic is affected.