### PR TITLE
Content: Add Japan Fact #27

### DIFF
--- a/public/japan-facts.json
+++ b/public/japan-facts.json
@@ -481,5 +481,6 @@
   "There's a Japanese festival called 'Hadaka Matsuri' where thousands of nearly naked men compete to catch lucky charms thrown by priests.",
   "Japan has a 'Black Company' award given to employers with the worst working conditions - a form of public shaming for labor violations.",
   "Japanese business cards (meishi) are exchanged with both hands and a bow - placing one in your pocket immediately is considered disrespectful.",
-  "Japanese toilet seats often have built-in bidets with heated seats, air dryers, and sound effects to mask embarrassing noises."
+  "Japanese toilet seats often have built-in bidets with heated seats, air dryers, and sound effects to mask embarrassing noises.",
+  "Japanese addresses are based on blocks rather than streets - buildings are numbered by the order they were built, not their location."
 ]


### PR DESCRIPTION
## Summary
- add Japan Fact 27 about block-based address numbering to the public facts list

## Rationale
Fulfills the requested community fact addition and keeps the facts JSON up to date.

## Changes
- append the new fact to `public/japan-facts.json`

## Test Plan
- Tested locally

Closes #660
