### PR TITLE
feat(content): add Japanese proverb (#575)

### DIFF
--- a/public/japanese-proverbs.json
+++ b/public/japanese-proverbs.json
@@ -182,5 +182,11 @@
   "romaji": "Kaeru no ko wa kaeru",
   "english": "A frog's child is a frog",
   "meaning": "Like father, like son"
-}
+  },
+  {
+    "japanese": "転ばぬ先の杖",
+    "romaji": "Korobanu saki no tsue",
+    "english": "A cane before falling",
+    "meaning": "Prevention is better than cure"
+  }
 ]


### PR DESCRIPTION
## Description

Added the traditional Japanese proverb **「転ばぬ先の杖」** (*Korobanu saki no tsue*) to the
`public/japanese-proverbs.json` file.

The proverb translates to **“A cane before falling”** and conveys the meaning:
**“Prevention is better than cure.”**

This change expands the existing collection of Japanese proverbs available in the app.

## Related Issue

Closes #575

## Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## How Has This Been Tested?

**Test Steps:**

1. Verified that `public/japanese-proverbs.json` contains valid JSON syntax.
2. Confirmed the new entry includes correct `japanese`, `romaji`, `english`, and `meaning` fields.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Verified the proverb appears correctly in the Proverbs section (random rotation/list view)

## Screenshots/Videos (if applicable)

N/A

## Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.
