### PR TITLE
feat(theme): add Ghost Parade color theme (#913)

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -242,6 +242,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     icon: Moon,
     themes: [
       {
+        id: 'ghost-parade',
+        backgroundColor: 'oklch(15.0% 0.045 310.0 / 1)',
+        mainColor: 'oklch(88.0% 0.065 285.0 / 1)',
+        secondaryColor: 'oklch(70.0% 0.145 340.0 / 1)'
+      },
+      {
         id: 'dragon-scale',
         backgroundColor: 'oklch(19.0% 0.055 165.0 / 1)',
         mainColor: 'oklch(68.0% 0.175 160.0 / 1)',


### PR DESCRIPTION
## Description

Added a new community-contributed color theme called **Ghost Parade**.  
This theme features a dark purple/pink palette inspired by *“Yokai spirits in the night”*, using the **OKLCH color space** to ensure vibrant, perceptually consistent colors across the UI.

## Related Issue

- Closes #913

## Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## How Has This Been Tested?

**Test Steps:**

1. Navigate to **Settings → Theme**.
2. Locate the **Dark themes** section.
3. Select the **Ghost Parade** theme.
4. Verify that the background updates to a dark violet shade and accent colors appear in the correct pink/purple tones.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

## Screenshots/Videos (if applicable)

> Please add a screenshot showing the Ghost Parade theme active.

## Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## Additional Context

**Theme Specs:**

- **ID:** `ghost-parade`  
- **Background:** `oklch(15.0% 0.045 310.0 / 1)`  
- **Main Color:** `oklch(88.0% 0.065 285.0 / 1)`  
- **Secondary:** `oklch(70.0% 0.145 340.0 / 1)`
