### PR TITLE
feat(theme): add Samurai Steel theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -242,6 +242,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     icon: Moon,
     themes: [
       {
+        id: 'samurai-steel',
+        backgroundColor: 'oklch(18.0% 0.022 250.0 / 1)',
+        mainColor: 'oklch(80.0% 0.055 240.0 / 1)',
+        secondaryColor: 'oklch(65.0% 0.170 15.0 / 1)'
+      },
+      {
         id: 'ghost-parade',
         backgroundColor: 'oklch(15.0% 0.045 310.0 / 1)',
         mainColor: 'oklch(88.0% 0.065 285.0 / 1)',


### PR DESCRIPTION
Closes #507

## 📝 Description

Added the new "Samurai Steel" color theme to the Dark themes collection as requested. This theme features a "cold gleam of a folded katana blade" aesthetic with specific OKLCH color values.

## 🔗 Related Issue

Closes #507

## 🎯 Type of Change

- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  Open the application and navigate to **Preferences**.
2.  Scroll to the **Theme** section.
3.  Select the **Samurai Steel** theme under the "Dark" category.
4.  Verified that the background, main, and secondary colors matched the visual requirements.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

## 📸 Screenshots/Videos (if applicable)

N/A - Visual theme addition.

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

Implemented values:
-   ID: `samurai-steel`
-   Background: `oklch(18.0% 0.022 250.0 / 1)`
-   Main Color: `oklch(80.0% 0.055 240.0 / 1)`
-   Secondary: `oklch(65.0% 0.170 15.0 / 1)`