### PR TITLE
feat(theme): add Sumo Strength theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -248,6 +248,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         secondaryColor: 'oklch(70.0% 0.145 340.0 / 1)'
       },
       {
+        id: 'sumo-strength',
+        backgroundColor: 'oklch(20.0% 0.022 35.0 / 1)',
+        mainColor: 'oklch(72.0% 0.065 75.0 / 1)',
+        secondaryColor: 'oklch(60.0% 0.185 20.0 / 1)'
+      },
+      {
         id: 'dragon-scale',
         backgroundColor: 'oklch(19.0% 0.055 165.0 / 1)',
         mainColor: 'oklch(68.0% 0.175 160.0 / 1)',


### PR DESCRIPTION
Closes #901

## 📝 Description

Added the new "Sumo Strength" color theme to the Dark themes collection. This theme embodies "power and tradition in the ring" with a distinct OKLCH color palette.

## 🔗 Related Issue

Closes #901

## 🎯 Type of Change

- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  Open the application and navigate to **Preferences**.
2.  Scroll to the **Theme** section.
3.  Select the **Sumo Strength** theme under the "Dark" category.
4.  Verified that the background, main, and secondary colors reflected the design specs.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

## 📸 Screenshots/Videos (if applicable)

N/A - Theme configuration update.

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

Implemented values:
-   ID: `sumo-strength`
-   Background: `oklch(20.0% 0.022 35.0 / 1)`
-   Main Color: `oklch(72.0% 0.065 75.0 / 1)`
-   Secondary: `oklch(60.0% 0.185 20.0 / 1)`