### PR TITLE
feat(theme): add Arcade Classic theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -1201,6 +1201,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         mainColor: 'oklch(82.0% 0.155 85.0 / 1)',
         secondaryColor: 'oklch(65.0% 0.180 30.0 / 1)'
       },
+      {
+        id: 'arcade-classic',
+        backgroundColor: 'oklch(13.0% 0.035 290.0 / 1)',
+        mainColor: 'oklch(88.0% 0.195 115.0 / 1)',
+        secondaryColor: 'oklch(82.0% 0.175 350.0 / 1)'
+      },
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Adds new Arcade Classic color theme to the Dark themes section
- Retro arcade aesthetic with deep purple and bright neon accents

### Theme Colors
- **Background**: `oklch(13.0% 0.035 290.0 / 1)` - deep arcade purple-black
- **Main**: `oklch(88.0% 0.195 115.0 / 1)` - bright lime green
- **Secondary**: `oklch(82.0% 0.175 350.0 / 1)` - hot pink

Closes #988