### PR TITLE
content: add japan fact #63

### DIFF
--- a/public/japan-facts.json
+++ b/public/japan-facts.json
@@ -506,5 +506,6 @@
   "Japan has the world's oldest population - one in three Japanese citizens is over 60 years old, and the ratio is increasing.",
   "The Japanese concept 'kintsugi' (金継ぎ) repairs broken pottery with gold, making the piece more valuable by highlighting its history.",
   "Japan has an island called Okunoshima overrun by friendly wild rabbits - formerly a secret chemical weapons manufacturing site.",
-  "Japan's crime rate is so low that police often spend time helping lost tourists and giving directions."
+  "Japan's crime rate is so low that police often spend time helping lost tourists and giving directions.",
+  "There's a Japanese word 'aware' (哀れ) that originally just meant 'ah!' - an exclamation that evolved to represent deep emotion."
 ]


### PR DESCRIPTION
## Summary
Adds Japan Fact #63 about the word 'aware' (哀れ) to the facts collection.

### The Fact
> There's a Japanese word 'aware' (哀れ) that originally just meant 'ah!' - an exclamation that evolved to represent deep emotion.

Closes #1007