### PR TITLE
feat(theme): add Konbini Light theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -1201,6 +1201,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         mainColor: 'oklch(82.0% 0.155 85.0 / 1)',
         secondaryColor: 'oklch(65.0% 0.180 30.0 / 1)'
       },
+      {
+        id: 'konbini-light',
+        backgroundColor: 'oklch(96.0% 0.015 210.0 / 1)',
+        mainColor: 'oklch(55.0% 0.185 200.0 / 1)',
+        secondaryColor: 'oklch(60.0% 0.155 25.0 / 1)'
+      },
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Adds new Konbini Light theme to the Dark themes section
- Inspired by 24-hour convenience store glow

### Theme Colors
- **Background**: `oklch(96.0% 0.015 210.0 / 1)` - bright fluorescent white
- **Main**: `oklch(55.0% 0.185 200.0 / 1)` - cool teal
- **Secondary**: `oklch(60.0% 0.155 25.0 / 1)` - warm coral accent

Closes #897