### PR TITLE
feat(theme): add Kimono Silk theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -1087,6 +1087,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         mainColor: 'oklch(72.0% 0.195 220.0 / 1)',
         secondaryColor: 'oklch(68.0% 0.205 30.0 / 1)',
       },
+      {
+        id: 'kimono-silk',
+        backgroundColor: 'oklch(19.0% 0.048 320.0 / 1)',
+        mainColor: 'oklch(72.0% 0.155 330.0 / 1)',
+        secondaryColor: 'oklch(80.0% 0.125 60.0 / 1)',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Adds Kimono Silk theme to the Dark themes section
- Luxurious fabric-inspired palette with deep plum and silk accents

**Theme colors:**
- Background: `oklch(19.0% 0.048 320.0 / 1)` - deep silk
- Main: `oklch(72.0% 0.155 330.0 / 1)` - kimono pink
- Secondary: `oklch(80.0% 0.125 60.0 / 1)` - gold thread

Closes #1028