### PR TITLE
content: add japan fact #68

### DIFF
--- a/public/japan-facts.json
+++ b/public/japan-facts.json
@@ -508,5 +508,6 @@
   "Japan has an island called Okunoshima overrun by friendly wild rabbits - formerly a secret chemical weapons manufacturing site.",
   "Japan's crime rate is so low that police often spend time helping lost tourists and giving directions.",
   "There's a Japanese word 'aware' (哀れ) that originally just meant 'ah!' - an exclamation that evolved to represent deep emotion.",
-  "The word 'mottainai' (もったいない) expresses deep regret over waste - a concept that sparked modern recycling movements worldwide."
+  "The word 'mottainai' (もったいない) expresses deep regret over waste - a concept that sparked modern recycling movements worldwide.",
+  "Japan pioneered the concept of 'mukbang' content but calls it 'tabehoudai' (food challenge) which predates Korean streaming."
 ]


### PR DESCRIPTION
Adds Japan Fact #68 - Japan pioneered 'tabehoudai' (food challenge) content before Korean mukbang.

Closes #1053