### PR TITLE
content: add japan fact #89

### DIFF
--- a/public/japan-facts.json
+++ b/public/japan-facts.json
@@ -511,7 +511,7 @@
   "Japan's crime rate is so low that police often spend time helping lost tourists and giving directions.",
   "There's a Japanese word 'aware' (哀れ) that originally just meant 'ah!' - an exclamation that evolved to represent deep emotion.",
   "The word 'mottainai' (もったいない) expresses deep regret over waste - a concept that sparked modern recycling movements worldwide.",
-  "Japan's vending machines have earthquake sensors that automatically release free drinks during major earthquakes as emergency supplies."
+  "Japan's vending machines have earthquake sensors that automatically release free drinks during major earthquakes as emergency supplies.",
   "Japanese blood donation has such high demand that mobile donation buses give out snacks, drinks, and lottery tickets as thanks.",
   "There's a Japanese practice called 'kuuki wo yomu' (空気を読む) - reading the air - understanding unspoken social cues.",
   "Japan has a shrine where you can pray for better Wi-Fi signal - the Kanda Myojin Shrine in Tokyo blesses electronics.",
@@ -530,6 +530,6 @@
   "Japan has the world's shortest escalator - only 5 steps tall (83.4 cm) at More's Department Store in Kawasaki.",
   "Japan has had the same family on the Chrysanthemum Throne for over 2,600 years - the world's oldest continuous hereditary monarchy.",
   "There's a Japanese word 'dokkiri' (ドッキリ) for the heart-pounding shock of surprise - now the name of prank TV shows.",
-  "Japan has a 'Hotel for the Deceased' where families can spend one more night with loved ones before cremation."
+  "Japan has a 'Hotel for the Deceased' where families can spend one more night with loved ones before cremation.",
+  "The concept of 'kawaisa' (可愛さ) or cuteness is so culturally important that it influences everything from government mascots to warning signs."
 ]
-


### PR DESCRIPTION
Closes #1266

## 📝 Description

Added a new interesting fact about the concept of 'kawaisa' (可愛さ) to the Japan facts collection. This fact highlights the cultural importance of cuteness in Japan, influencing everything from government mascots to warning signs.

Additionally, fixed a pre-existing syntax error (missing comma at line 514) in [public/japan-facts.json](cci:7://file:///Users/greg/Documents/kana-dojo/public/japan-facts.json:0:0-0:0) to ensure the file is valid JSON.

## 🔗 Related Issue

Closes #1266

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  Validated [public/japan-facts.json](cci:7://file:///Users/greg/Documents/kana-dojo/public/japan-facts.json:0:0-0:0) using `jq` to ensure the JSON structure is correct: `jq . public/japan-facts.json > /dev/null`.
2.  Manually inspected the end of the file to verify the new fact was appended correctly with proper formatting.

**Manual Test Checklist:**

- [x] Tested in **Japan Facts** section (verified JSON validity)
- [ ] ...

## 📸 Screenshots/Videos (if applicable)

*(N/A for JSON content update)*

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run the linter (`npm run lint`) and there are no new errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

The missing comma fixed at line 514 was:
`"Japan's vending machines have earthquake sensors that automatically release free drinks during major earthquakes as emergency supplies."`
It now correctly ends with a comma.