### PR TITLE
docs(readme): add Japanese README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ The README is available in multiple languages:
 - [Türkçe](./translations/README.tr.md)
 - [Tiếng Việt](./translations/README.vi.md)
 - [Bahasa Indonesia](./translations/README.id.md)
+- [日本語](./translations/README.ja.md)
 - [中文（简体）](./translations/README.zh-CN.md)
 - [中文（繁體）](./translations/README.zh-tw.md)
 - [Українська](./translations/README.ua.md)

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -1,0 +1,128 @@
+<div id="top"></div>
+
+# KanaDojo かな道場
+
+<div align="center">
+
+![KanaDojo Banner](https://github.com/user-attachments/assets/b7931764-be5e-43c7-b1b3-9d2568b2fecf)
+
+**Monkeytypeにインスパイアされた、美しくミニマルでカスタマイズ可能な日本語学習プラットフォーム**
+
+[![Live Demo](https://img.shields.io/badge/demo-kanadojo.com-blue?style=for-the-badge)](https://kanadojo.com)
+[![DeepWiki](https://img.shields.io/badge/docs-DeepWiki-purple?style=for-the-badge)](https://deepwiki.com/lingdojo/kana-dojo)
+[![Good First Issues](https://img.shields.io/github/issues-search/lingdojo/kana-dojo?query=is%3Aissue+is%3Aopen+label%3A%22good%20first%20issue%22&style=for-the-badge&label=good%20first%20issues&color=brightgreen)](https://github.com/lingdojo/kana-dojo/issues?q=is%3Aissue+is%3Aopen+label%3A%22good%20first%20issue%22)
+[![License](https://img.shields.io/badge/license-AGPL--v3-blue?style=for-the-badge)](LICENSE.md)
+[![Next.js](https://img.shields.io/badge/Next.js-15-black?style=for-the-badge&logo=next.js)](https://nextjs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.3-blue?style=for-the-badge&logo=typescript)](https://typescriptlang.org/)
+[![Vitest](https://img.shields.io/badge/Tests-Vitest-yellow?style=for-the-badge)](https://vitest.dev/)
+[![AGPL-3.0](https://img.shields.io/badge/open-source-green?style=for-the-badge)](https://www.gnu.org/licenses/agpl-3.0)
+
+---
+
+## バッジ（フォーク用）
+
+このプロジェクトをフォークする場合は、ご自身のREADMEに以下のバッジを追加してください。
+
+```markdown
+[![CI](https://github.com/YOUR_USERNAME/kana-dojo/actions/workflows/pr-check.yml/badge.svg)](https://github.com/YOUR_USERNAME/kana-dojo/actions)
+[![Issues](https://img.shields.io/github/issues/YOUR_USERNAME/kana-dojo)](https://github.com/YOUR_USERNAME/kana-dojo/issues)
+[![Pull Requests](https://img.shields.io/github/issues-pr/YOUR_USERNAME/kana-dojo)](https://github.com/YOUR_USERNAME/kana-dojo/pulls)
+[![Contributors](https://img.shields.io/github/contributors/YOUR_USERNAME/kana-dojo)](https://github.com/YOUR_USERNAME/kana-dojo/graphs/contributors)
+```
+
+[ライブデモ](https://kanadojo.com) · [ドキュメント](./docs/) · [貢献方法](./CONTRIBUTING.md)
+
+</div>
+
+## 概要
+
+KanaDojoは、ひらがな、カタカナ、漢字、語彙を楽しく直感的に学べる、魅力的なウェブベースの日本語学習プラットフォームです。美しいデザインとカスタマイズ性、学習効率に重点を置いて構築されており、あらゆるレベルの日本語学習者に没入型トレーニング環境を提供します。
+
+## 主な機能
+
+- **3つのトレーニング道場** — かな（ひらがな・カタカナ）、漢字（JLPT N5-N1）、語彙
+- **4つのゲームモード** — 選択問題、逆選択問題、入力問題、逆入力問題
+- **100以上のテーマ** — 28種類の日本語フォントと、美しいライト・ダークテーマ
+- **進捗管理** — 統計データ、連続学習日数、80以上の実績バッジ
+- **完全レスポンシブ対応** — デスクトップ、タブレット、モバイルでシームレスに動作
+
+## クイックスタート
+
+```bash
+git clone https://github.com/lingdojo/kanadojo.git
+cd kanadojo
+npm install
+npm run dev
+```
+
+[http://localhost:3000](http://localhost:3000) を開き、学習を開始しましょう。
+
+> **問題が発生しましたか？** [トラブルシューティングガイド](./docs/TROUBLESHOOTING.md) をご覧ください。
+
+## スクリーンショット
+
+<div align="center">
+
+### ホーム画面
+
+![Home](https://github.com/user-attachments/assets/cac78e72-4d31-43e8-8160-104c431e55be)
+
+### トレーニング画面
+
+![Training](https://github.com/user-attachments/assets/053020ef-77c7-492b-b8db-c381d1ec7db8)
+
+### テーマとカスタマイズ
+
+![Themes](https://github.com/user-attachments/assets/f664a280-0344-4ff9-8639-83f9c1c4223b)
+
+</div>
+
+## ドキュメント
+
+| ドキュメント                                     | 説明                                   |
+| ------------------------------------------------ | -------------------------------------- |
+| [アーキテクチャ](./docs/ARCHITECTURE.md)         | プロジェクト構造、パターン、規約       |
+| [UIデザイン](./docs/UI_DESIGN.md)                | テーマ、スタイリング、コンポーネント   |
+| [翻訳ガイド](./docs/TRANSLATION_GUIDE.md)        | 多言語化への参加方法                       |
+| [トラブルシューティング](./docs/TROUBLESHOOTING.md) | よくある問題と解決策                   |
+| [全ドキュメント一覧](./docs/)                        | 全てのドキュメント                 |
+
+## 技術スタック
+
+Next.js 15 · React 19 · TypeScript · Tailwind CSS · shadcn/ui · Zustand · Framer Motion
+
+> 技術情報の詳細は [アーキテクチャドキュメント](./docs/ARCHITECTURE.md) をご覧ください。
+
+## 貢献（コントリビューション）について
+
+皆さまからの貢献を歓迎します！バグ修正、機能追加、ドキュメントの改善、翻訳など、どのような形でも大歓迎です。まずは [CONTRIBUTING.md](./CONTRIBUTING.md) をご確認ください。
+
+## スター数の推移
+
+<div align="center">
+
+[![Star History Chart](https://api.star-history.com/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.com/#lingdojo/kana-dojo&Date)
+
+</div>
+
+## ライセンス
+
+このプロジェクトはAGPL 3.0ライセンスの下で公開されています。詳細は [LICENSE.md](./LICENSE.md) をご覧ください。
+
+## リンク
+
+- **ウェブサイト**: [kanadojo.com](https://kanadojo.com)
+- **リポジトリ**: [github.com/lingdojo/kanadojo](https://github.com/lingdojo/kanadojo)
+- **メール**: dev@kanadojo.com
+
+---
+
+<div align="center">
+
+**世界中の日本語学習者のために ❤️**
+
+がんばって！(Ganbatte! — Do your best!)
+
+[⬆ トップに戻る](#top)
+
+</div>


### PR DESCRIPTION
## 📝 Description

Adds Japanese translation of README.

## 🔗 Related Issue

Closes #98

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [x] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

N/A

## 📸 Screenshots/Videos (if applicable)

N/A

## ✅ Pre-Submission Checklist

- [ ] My code follows the project's code style and uses `cn()` utility where needed.
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

N/A
