### PR TITLE
feat(theme): add Tsukimi Moon theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -264,31 +264,37 @@ const baseThemeSets: BaseThemeGroup[] = [
         id: 'natto-brown',
         backgroundColor: 'oklch(22.0% 0.032 60.0 / 1)',
         mainColor: 'oklch(58.0% 0.095 65.0 / 1)',
-        secondaryColor: 'oklch(70.0% 0.075 55.0 / 1)'
+        secondaryColor: 'oklch(70.0% 0.075 55.0 / 1)',
       },
       {
         id: 'ginkgo-gold',
         backgroundColor: 'oklch(23.0% 0.045 85.0 / 1)',
         mainColor: 'oklch(88.0% 0.170 95.0 / 1)',
-        secondaryColor: 'oklch(72.0% 0.135 75.0 / 1)'
+        secondaryColor: 'oklch(72.0% 0.135 75.0 / 1)',
       },
       {
         id: 'shaved-ice',
         backgroundColor: 'oklch(95.0% 0.025 215.0 / 1)',
         mainColor: 'oklch(60.0% 0.195 25.0 / 1)',
-        secondaryColor: 'oklch(65.0% 0.175 215.0 / 1)'
+        secondaryColor: 'oklch(65.0% 0.175 215.0 / 1)',
       },
       {
         id: 'cherry-cola',
         backgroundColor: 'oklch(18.0% 0.055 20.0 / 1)',
         mainColor: 'oklch(58.0% 0.195 25.0 / 1)',
-        secondaryColor: 'oklch(70.0% 0.145 50.0 / 1)'
+        secondaryColor: 'oklch(70.0% 0.145 50.0 / 1)',
       },
       {
         id: 'garden-bridge',
         backgroundColor: 'oklch(23.0% 0.045 150.0 / 1)',
         mainColor: 'oklch(60.0% 0.205 25.0 / 1)',
         secondaryColor: 'oklch(72.0% 0.145 145.0 / 1)',
+      },
+      {
+        id: 'tsukimi-moon',
+        backgroundColor: 'oklch(18.0% 0.028 255.0 / 1)',
+        mainColor: 'oklch(92.0% 0.020 95.0 / 1)',
+        secondaryColor: 'oklch(65.0% 0.105 270.0 / 1)',
       },
       {
         id: 'jpop-energy',
@@ -1277,7 +1283,7 @@ const baseThemeSets: BaseThemeGroup[] = [
         id: 'wind-god',
         backgroundColor: 'oklch(19.0% 0.045 175.0 / 1)',
         mainColor: 'oklch(82.0% 0.155 180.0 / 1)',
-        secondaryColor: 'oklch(72.0% 0.135 165.0 / 1)'
+        secondaryColor: 'oklch(72.0% 0.135 165.0 / 1)',
       },
     ],
   },


### PR DESCRIPTION
Adds the Tsukimi Moon dark theme.

Theme colors were verified visually via local UI screenshots.
<img width="1918" height="928" alt="Screenshot 2026-01-22 171159" src="https://github.com/user-attachments/assets/5fa4fb3b-3290-41d7-b5d9-730a496fc209" />


Closes #1464
