### PR TITLE
feat(theme): add Hanami Picnic theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -260,6 +260,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         mainColor: 'oklch(62.0% 0.175 155.0 / 1)',
         secondaryColor: 'oklch(85.0% 0.095 95.0 / 1)',
       },
+      {
+        id: 'hanami-picnic',
+        backgroundColor: 'oklch(96.0% 0.018 20.0 / 1)',
+        mainColor: 'oklch(70.0% 0.165 350.0 / 1)',
+        secondaryColor: 'oklch(78.0% 0.120 135.0 / 1)',
+      },
     ],
   },
   {
@@ -276,7 +282,7 @@ const baseThemeSets: BaseThemeGroup[] = [
         id: 'umami-miso',
         backgroundColor: 'oklch(22.0% 0.028 55.0 / 1)',
         mainColor: 'oklch(72.0% 0.095 65.0 / 1)',
-        secondaryColor: 'oklch(60.0% 0.125 30.0 / 1)'
+        secondaryColor: 'oklch(60.0% 0.125 30.0 / 1)',
       },
       {
         id: 'natto-brown',


### PR DESCRIPTION
## Summary
Add a new color theme "Hanami Picnic" inspired by sakura petals, bento cloth, and spring air.

| Property | Value |
|----------|-------|
| **ID** | `hanami-picnic` |
| **Background** | `oklch(96.0% 0.018 20.0 / 1)` |
| **Main Color** | `oklch(70.0% 0.165 350.0 / 1)` |
| **Secondary** | `oklch(78.0% 0.120 135.0 / 1)` |

Closes #1516

## Test plan
- [x] Code passes `npm run check`
- [ ] Theme displays correctly in the theme picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)