### PR TITLE
Add 'shoji-glow' theme and update 'seaside-udon'

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -317,6 +317,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     isLight: false,
     themes: [
       {
+       id: 'shoji-glow',
+       backgroundColor: 'oklch(94.0% 0.010 95.0 / 1)',
+       mainColor: 'oklch(45.0% 0.075 65.0 / 1)',
+       secondaryColor: 'oklch(60.0% 0.045 30.0 / 1)'
+      },
+      {
         id: 'seaside-udon',
         backgroundColor: 'oklch(92.0% 0.015 210.0 / 1)',
         mainColor: 'oklch(60.0% 0.130 215.0 / 1)',
@@ -327,11 +333,11 @@ const baseThemeSets: BaseThemeGroup[] = [
         backgroundColor: 'oklch(20.0% 0.048 240.0 / 1)',
         mainColor: 'oklch(80.0% 0.175 55.0 / 1)',
         secondaryColor: 'oklch(70.0% 0.130 220.0 / 1)'},{
-  id: 'seaside-udon',
-  backgroundColor: 'oklch(92.0% 0.015 210.0 / 1)',
-  mainColor: 'oklch(60.0% 0.130 215.0 / 1)',
-  secondaryColor: 'oklch(85.0% 0.155 95.0 / 1)'
-},
+        id: 'seaside-udon',
+        backgroundColor: 'oklch(92.0% 0.015 210.0 / 1)',
+        mainColor: 'oklch(60.0% 0.130 215.0 / 1)',
+        secondaryColor: 'oklch(85.0% 0.155 95.0 / 1)'
+      },
       {
         id: 'tsuyu-drizzle',
         backgroundColor: 'oklch(22.0% 0.015 250.0 / 1)',


### PR DESCRIPTION
Added a new theme 'shoji-glow' with specific color properties and adjusted the existing 'seaside-udon' theme structure.

#1531 

---
🤖 **Auto-linked:** Closes #1531