### PR TITLE
feat(theme): add Plaza Snow theme

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -1279,6 +1279,12 @@ const baseThemeSets: BaseThemeGroup[] = [
         mainColor: 'oklch(65.0% 0.215 30.0 / 1)',
         secondaryColor: 'oklch(78.0% 0.135 70.0 / 1)',
       },
+      {
+        id: 'plaza-snow',
+        backgroundColor: 'oklch(97.0% 0.006 240.0 / 1)',
+        mainColor: 'oklch(40.0% 0.035 260.0 / 1)',
+        secondaryColor: 'oklch(65.0% 0.120 220.0 / 1)',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Plaza Snow Theme – Pull Request

This PR introduces a new color theme called **Plaza Snow** to KanaDojo.

---

## What was added

* **Theme ID:** `plaza-snow`
* **Background:** `oklch(97.0% 0.006 240.0 / 1)`
* **Main color:** `oklch(40.0% 0.035 260.0 / 1)`
* **Secondary color:** `oklch(65.0% 0.120 220.0 / 1)`

The theme has been added to the **Dark themes** section in:

`features/Preferences/data/themes.ts`

It follows the existing structure and formatting conventions used in the project.

---

---
🤖 **Auto-linked:** Closes #1611