### PR TITLE
feat(theme): add Mountain Cedar color theme (#1653)

### DIFF
--- a/features/Preferences/data/themes.ts
+++ b/features/Preferences/data/themes.ts
@@ -241,12 +241,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     isLight: false,
     themes: [
       {
-        {
-  id: 'maple-lacquer',
-  backgroundColor: 'oklch(17.0% 0.035 20.0 / 1)',
-  mainColor: 'oklch(65.0% 0.215 30.0 / 1)',
-  secondaryColor: 'oklch(78.0% 0.135 70.0 / 1)'
-},
+        id: 'maple-lacquer',
+        backgroundColor: 'oklch(17.0% 0.035 20.0 / 1)',
+        mainColor: 'oklch(65.0% 0.215 30.0 / 1)',
+        secondaryColor: 'oklch(78.0% 0.135 70.0 / 1)',
+      },
+      {
         id: 'light',
         backgroundColor: 'oklch(100.00% 0.0000 89.88 / 1)',
         mainColor: 'oklch(0.00% 0.0000 0.00 / 1)',
@@ -322,6 +322,12 @@ const baseThemeSets: BaseThemeGroup[] = [
     icon: Moon,
     isLight: false,
     themes: [
+      {
+        id: 'mountain-cedar',
+        backgroundColor: 'oklch(20.0% 0.020 150.0 / 1)',
+        mainColor: 'oklch(70.0% 0.105 145.0 / 1)',
+        secondaryColor: 'oklch(60.0% 0.055 110.0 / 1)',
+      },
       {
         id: 'shoji-glow',
         backgroundColor: 'oklch(94.0% 0.010 95.0 / 1)',


### PR DESCRIPTION
## Description

This PR adds a new dark theme called "Mountain Cedar" to the application, as requested in issue #1653. 
Additionally, this PR fixes a syntax error found in `features/Preferences/data/themes.ts` where the `maple-lacquer` theme was incorrectly nested within the base theme group.

## Related Issue

- Closes #1653

## Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## How Has This Been Tested?

**Test Steps:**

1.  Open the application locally (`npm run dev`).
2.  Navigate to the **Settings** / **Preferences** menu.
3.  Scroll to the **Theme** section.
4.  Select the **Dark** category (if not already selected).
5.  Locate and select the new **Mountain Cedar** theme.
6.  Verify that the application background, main colors, and secondary colors update to the expected OKLCH values.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

## Screenshots/Videos (if applicable)

*(No screenshots available as this is a code-only addition)*

## Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)
