### PR TITLE
content: add new grammar point

### DIFF
--- a/public/japanese-grammar.json
+++ b/public/japanese-grammar.json
@@ -13,5 +13,6 @@
   "〜つもり expresses intent, like I plan to do something.",
   "〜です/〜ます for polite statements; it's the standard polite ending for everyday conversation.",
   "〜ません is the polite negative form of verbs, used to say something doesn't happen.",
-  "\"〜たい\" attaches to a verb stem to express \"want to do\" something."
+  "\"〜たい\" attaches to a verb stem to express \"want to do\" something.",
+  "〜てしまう can show completion or regret about an action."
 ]


### PR DESCRIPTION
# 📝 Description

Added a new grammar point to `public/japanese-grammar.json`:

> "〜てしまう" can show completion or regret about an action.

The grammar string was appended to the end of the array with proper comma placement to maintain valid JSON formatting.

---

## 🔗 Related Issue

Closes #1930 

---

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates


---

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Opened `public/japanese-grammar.json`
2. Added the grammar string before the closing `]`
3. Ensured a comma was added after the previous last item
4. Confirmed JSON structure remains valid
5. Ran the project locally to verify no runtime errors

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

---

## 📸 Screenshots/Videos (if applicable)

N/A – Content-only update (JSON grammar list)

---

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

---

## 📦 Additional Context

This is a small community contribution adding a commonly used grammar structure.
"〜てしまう" is important for expressing both completion and regret, making it valuable for learners at early-intermediate levels.