### PR TITLE
fix: pronunciation voice does not play when UI sound effects are turn…

### DIFF
--- a/shared/hooks/useJapaneseTTS.ts
+++ b/shared/hooks/useJapaneseTTS.ts
@@ -17,8 +17,11 @@ interface TTSState {
 }
 
 export const useJapaneseTTS = () => {
-  const { silentMode, pronunciationVoiceName, setPronunciationVoiceName } =
-    useAudioPreferences();
+  const {
+    pronunciationEnabled,
+    pronunciationVoiceName,
+    setPronunciationVoiceName,
+  } = useAudioPreferences();
   const [state, setState] = useState<TTSState>({
     isPlaying: false,
     isSupported: false,
@@ -169,7 +172,7 @@ export const useJapaneseTTS = () => {
         voice?: JapaneseVoice;
       },
     ) => {
-      if (!isClient || silentMode) {
+      if (!isClient || !pronunciationEnabled) {
         return Promise.resolve();
       }
 
@@ -324,7 +327,7 @@ export const useJapaneseTTS = () => {
         attemptSpeak();
       });
     },
-    [isClient, silentMode],
+    [isClient, pronunciationEnabled],
   );
 
   const stop = useCallback(() => {


### PR DESCRIPTION
## Pull Request: Fix pronunciation audio muted when UI sounds are disabled

### Problem
Previously, disabling "Play UI + feedback sound effects" incorrectly muted pronunciation audio as well. The `silentMode` setting (for UI sounds) was blocking the `speak()` function in `useJapaneseTTS`, preventing pronunciation playback even when "Enable pronunciation audio" was turned on.

## Related issue
Closes #1756

### Solution
Changed the `speak()` function to check `pronunciationEnabled` instead of `silentMode`. This ensures pronunciation audio respects its own dedicated setting and works independently from UI sound effects.

### Changes
- **Fixed Audio Check:** Updated `useJapaneseTTS.ts` to use `pronunciationEnabled` instead of `silentMode` in the `speak()` function
- **Independent Controls:** Pronunciation audio and UI sounds now work independently as intended
- **User Experience:** Users can now disable UI sounds while keeping pronunciation audio active