### PR TITLE
content: add grammar point explanation

### DIFF
--- a/public/japanese-grammar.json
+++ b/public/japanese-grammar.json
@@ -26,5 +26,6 @@
   ""〜ようと思う" expresses a decision made at the moment of speaking.",
   ""〜なら" means "if" or "in the case of" and often gives advice.",
   ""〜たら" is a conditional "if/when" that also expresses sequence.",
-  ""〜まま" means "as is" or "unchanged"."
+  ""〜まま" means "as is" or "unchanged".",
+  ""〜ので" gives a reason in a polite or softer way than "から"."
 ]


### PR DESCRIPTION
## 📝 Description
Added a concise explanation for the grammar point "〜ので" (softer/polite reason vs "から") to `public/japanese-grammar.json`.

## 🔗 Related Issue
Closes #2214

## 🎯 Type of Change
- [x] `content`: Content update (new grammar point)

## 🧪 How Has This Been Tested?
- Ran `npm run dev`
- Confirmed the new grammar string appears in the grammar section/trivia without JSON errors
- Checked syntax: comma added correctly

## ✅ Pre-Submission Checklist
- [x] Only modified `public/japanese-grammar.json`
- [x] Commit follows Conventional Commits
- [x] This PR is against the `main` branch

Ready for review — happy to add more grammar points if this merges smoothly! 頑張って！ 📖