### PR TITLE
content: add volitional form grammar point

### DIFF
--- a/public/japanese-grammar.json
+++ b/public/japanese-grammar.json
@@ -27,5 +27,6 @@
   "〜たら is a conditional \"if/when\" that also expresses sequence.",
   "〜まま means \"as is\" or \"unchanged\".",
   "〜ので gives a reason in a polite or softer way than から.",
-  "〜たり〜たり lists representative actions, like \"do things like A and B\"."
+  "〜たり〜たり lists representative actions, like \"do things like A and B\".",
+  "〜おう/〜よう is the volitional form, used to say \"let's\" or \"I will\"."
 ]


### PR DESCRIPTION
## 📝 Description
Added explanation for the volitional form "〜おう/〜よう" (used for "let's" or "I will") to `public/japanese-grammar.json`.

## 🔗 Related Issue
Closes #2324 

## 🎯 Type of Change
- [x] `content`: Content update (new grammar point)

## 🧪 How Has This Been Tested?
- Ran `npm run dev` locally
- Checked that the new grammar note appears in the grammar section
- Verified JSON is valid (comma correct, no syntax errors)

## ✅ Pre-Submission Checklist
- [x] Only modified `public/japanese-grammar.json`
- [x] Commit message follows Conventional Commits
- [x] This PR is against the `main` branch

Ready for review — happy to add more grammar points! 頑張って！ 📖