### PR TITLE
content: add new Japan fact about tea ceremony

### DIFF
--- a/public/japan-facts.json
+++ b/public/japan-facts.json
@@ -611,9 +611,7 @@
   "The Japanese term 'shuudan ishiki' (集団意識) refers to strong group consciousness — prioritizing harmony within the group.",  
   "The Japanese word 'nagori' (名残) describes the lingering feeling when a season is ending — like the last strawberries of spring.",
   "Japan’s 'shrine stamps' called 'goshuin' (御朱印) are calligraphy seals collected in special books by visitors.",
-  {
-    "fact": "В Японии существует традиция сезонных ветров, называемая «кадзэ-но тайори» (風の便り), когда изменения в природе сигнализируют о приходе фестиваля или сбора урожая."
-  }
-]
+  "В Японии существует традиция сезонных ветров, называемая «кадзэ-но тайори» (風の便り), когда изменения в природе сигнализируют о приходе фестиваля или сбора урожая."
+  «The Japanese tea ceremony ('chanoyu', 茶の湯) emphasizes harmony, respect, purity, and tranquility.»
 
 


### PR DESCRIPTION
This contribution adds a cultural fact about the traditional Japanese tea ceremony ('chanoyu', 茶の湯). The tea ceremony emphasizes harmony, respect, purity, and tranquility, and is an important cultural practice in Japan.  

Closes #<2525>