### PR TITLE
Fix formatting in japanese-grammar.json

### DIFF
--- a/public/japanese-grammar.json
+++ b/public/japanese-grammar.json
@@ -40,5 +40,6 @@
   "\"〜ように\" can express purpose, like \"in order to\" or \"so that\".",
   "〜ことにする expresses a decision, like \"decide to\".",
   "〜ことができる expresses ability, like \"can do\".",
-  "\"〜にくい\" attaches to verb stems to mean \"hard to do\"."
+  "\"〜にくい\" attaches to verb stems to mean \"hard to do\".",
+  ""〜というより" means "rather than" or "more like"."
 ]


### PR DESCRIPTION
Added grammar string ""〜というより" means "rather than" or "more like"."

## 📝 Description

...

## 🔗 Related Issue

Closes #

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)

...

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [ ] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

...
