### PR TITLE
fix(kana): fix Enter key not working after wrong answer on mobile (#1…

### DIFF
--- a/features/Kana/components/Game/Input.tsx
+++ b/features/Kana/components/Game/Input.tsx
@@ -173,16 +173,6 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
     setCorrectChar(newChar);
   }, [isReady, isReverse, selectedRomaji, selectedKana, correctChar]);
 
-  const handleEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (
-      e.key === 'Enter' &&
-      inputValue.trim().length &&
-      bottomBarState !== 'correct'
-    ) {
-      handleCheck();
-    }
-  };
-
   const handleCheck = () => {
     if (inputValue.trim().length === 0) return;
 
@@ -311,7 +301,9 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
         onKeyDown={e => {
           if (e.key === 'Enter') {
             e.preventDefault();
-            handleEnter(e);
+            if (inputValue.trim().length > 0 && bottomBarState !== 'correct') {
+              handleCheck();
+            }
           }
         }}
       />


### PR DESCRIPTION
…960)

## 📝 Description
Fixed an issue where the Enter key didn't work correctly after submitting a wrong answer on mobile devices.

The handleEnter function was capturing inputValue and bottomBarState in a closure, which could reference stale (outdated) values when called from the onKeyDown event handler.

The fix inlines the condition check directly in the onKeyDown handler so it always uses the current state values.
...

## 🔗 Related Issue

Closes #1960

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Go to Kana → Select some characters → Start training → Select "Type" mode
2. Enter a wrong answer (e.g., `kyo` instead of `byo`)
3. Press Enter to submit — the correct answer is shown in the bottom left
4. Enter the correct answer shown in the bottom left
5. Press Enter to submit — the message "Nicely done!" should now appear

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Tested on mobile (iPhone Chrome)

## 📸 Screenshots/Videos (if applicable)

...

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context
Note: You may need to clear your browser cache for the fix to take effect.

Testing tip for mobile: On mobile devices, the virtual keyboard may auto-correct or auto-complete your input when you press the Check button. Make sure to disable auto-correction or carefully verify your input before submitting.

...
