### PR TITLE
content: add new japanese proverb

### DIFF
--- a/data/community-content/japanese-proverbs.json
+++ b/data/community-content/japanese-proverbs.json
@@ -504,4 +504,11 @@
   "english": "A frog in a well doesn’t know the ocean",
   "meaning": "Limited experience limits perspective"
 }
+,
+{
+  "japanese": "口は禍の元",
+  "romaji": "Kuchi wa wazawai no moto",
+  "english": "The mouth is the source of misfortune",
+  "meaning": "Careless words cause trouble"
+}
 ]


### PR DESCRIPTION
## Description

Adds a new Japanese proverb to the collection:

| Japanese | Romaji | English |
|----------|--------|---------|
| **口は禍の元** | Kuchi wa wazawai no moto | The mouth is the source of misfortune |

> 💡 **Meaning:** Careless words cause trouble

## Related Issue

Closes #2989

## Changes

- Added proverb to `data/community-content/japanese-proverbs.json`