### PR TITLE
content: add new japanese proverb

### DIFF
--- a/data/community-content/japanese-proverbs.json
+++ b/data/community-content/japanese-proverbs.json
@@ -511,4 +511,11 @@
   "english": "The mouth is the source of misfortune",
   "meaning": "Careless words cause trouble"
 }
+,
+{
+  "japanese": "明日は明日の風が吹く",
+  "romaji": "Ashita wa ashita no kaze ga fuku",
+  "english": "Tomorrow’s wind will blow tomorrow",
+  "meaning": "Don’t worry too much about the future"
+}
 ]


### PR DESCRIPTION
### **Description**
Adds a new traditional Japanese proverb to the japanese-proverbs.json content file.
The entry includes the original Japanese text, romaji reading, English translation, and a brief meaning to help learners understand its message.
###  **Related Issue**
Closes #3032 
### **Type of Change**
Content update
###  **Testing**
Verified that data/community-content/japanese-proverbs.json remains valid JSON after the update.
Confirmed the new proverb follows the existing data structure.
###  **Additional Context**
The proverb 「明日は明日の風が吹く」 conveys the idea of not worrying excessively about the future.