### PR TITLE
🎨 Add Harbor Fog color theme

### DIFF
--- a/data/community-content/community-themes.json
+++ b/data/community-content/community-themes.json
@@ -22,5 +22,11 @@
     "backgroundColor": "oklch(18.0% 0.030 20.0 / 1)",
     "mainColor": "oklch(82.0% 0.175 35.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.095 75.0 / 1)"
+  },
+  {
+    "id": "harbor-fog",
+    "backgroundColor": "oklch(22.0% 0.015 250.0 / 1)",
+    "mainColor": "oklch(76.0% 0.040 200.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.070 260.0 / 1)"
   }
 ]


### PR DESCRIPTION
Adds a new community color theme called 'Harbor Fog' with a soft, calming blue-gray palette.

Theme includes:
- backgroundColor: oklch(22.0% 0.015 250.0 / 1)
- mainColor: oklch(76.0% 0.040 200.0 / 1)  
- secondaryColor: oklch(65.0% 0.070 260.0 / 1)

Fits with the existing theme naming convention and provides a soothing aesthetic for users who prefer muted tones.

---
🤖 **Auto-linked:** Closes #3095