### PR TITLE
feat(theme): add Shinkansen Speed theme

### DIFF
--- a/data/community-content/community-themes.json
+++ b/data/community-content/community-themes.json
@@ -100,5 +100,11 @@
     "backgroundColor": "oklch(92.0% 0.025 140.0 / 1)",
     "mainColor": "oklch(55.0% 0.180 140.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.120 80.0 / 1)"
+  },
+  {
+    "id": "shinkansen-speed",
+    "backgroundColor": "oklch(22.0% 0.035 240.0 / 1)",
+    "mainColor": "oklch(90.0% 0.085 220.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.185 25.0 / 1)"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds the new "Shinkansen Speed" community theme as specified in issue requirements
- Theme features a bullet train inspired color palette with deep blue background and warm orange-red accent

## Changes
- Added `shinkansen-speed` theme to `data/community-content/community-themes.json`

## Theme Details
| Property | Value |
|----------|-------|
| **ID** | `shinkansen-speed` |
| **Background** | `oklch(22.0% 0.035 240.0 / 1)` |
| **Main Color** | `oklch(90.0% 0.085 220.0 / 1)` |
| **Secondary** | `oklch(65.0% 0.185 25.0 / 1)` |

Closes #3397

---
Generated with [Claude Code](https://claude.com/claude-code)