### PR TITLE
content: add new japan fact

### DIFF
--- a/data/community-content/japan-facts.json
+++ b/data/community-content/japan-facts.json
@@ -646,5 +646,6 @@
   "'Mame' (豆) can mean both 'bean' and 'diligent'—so bean-related gifts sometimes imply good health and hard work.",
   "Japan has a word 'tsundoku' (積ん読) for buying books and letting them pile up unread.",
   "Japan has a unique 4-4-9 emergency number system: 110 for police, 119 for fire/ambulance, and 118 for coast guard emergencies.",
-  "There's a Japanese practice of 'honne and tatemae' - your true feelings (honne) versus your public facade (tatemae) - both are considered valid."
+  "There's a Japanese practice of 'honne and tatemae' - your true feelings (honne) versus your public facade (tatemae) - both are considered valid.",
+  "Japan's Seikan Tunnel connecting Honshu and Hokkaido is the world's longest undersea tunnel at 53.85 kilometers."
 ]


### PR DESCRIPTION
## Summary
- Added fact about Japan's Seikan Tunnel
- World's longest undersea tunnel at 53.85 kilometers
- Connects Honshu and Hokkaido

Closes #3417