### PR TITLE
feat(theme): add Shogun Gold theme

### DIFF
--- a/data/community-content/community-themes.json
+++ b/data/community-content/community-themes.json
@@ -113,4 +113,10 @@
     "mainColor": "oklch(20.0% 0.015 270.0 / 1)",
     "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
   },
+  {
+    "id": "shogun-gold",
+    "backgroundColor": "oklch(18.0% 0.035 80.0 / 1)",
+    "mainColor": "oklch(82.0% 0.155 85.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.180 30.0 / 1)"
+  }
 ]


### PR DESCRIPTION
## Summary
- Added new "Shogun Gold" color theme
- Imperial opulence and power aesthetic
- Background: dark warm tone
- Main: golden accents
- Secondary: rich amber

Closes #3438