### PR TITLE
feat(theme): add Tokyo Metro theme

### DIFF
--- a/data/community-content/community-themes.json
+++ b/data/community-content/community-themes.json
@@ -113,4 +113,10 @@
     "mainColor": "oklch(20.0% 0.015 270.0 / 1)",
     "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
   },
+  {
+    "id": "tokyo-metro",
+    "backgroundColor": "oklch(20.0% 0.025 260.0 / 1)",
+    "mainColor": "oklch(70.0% 0.180 145.0 / 1)",
+    "secondaryColor": "oklch(80.0% 0.120 50.0 / 1)"
+  }
 ]


### PR DESCRIPTION
## Summary
- Added new "Tokyo Metro" color theme
- Underground commute through the city's veins aesthetic
- Vibrant green main color with warm accents

Closes #3383