### PR TITLE
feat(theme): add Bento Box theme

### DIFF
--- a/data/community-content/community-themes.json
+++ b/data/community-content/community-themes.json
@@ -113,4 +113,10 @@
     "mainColor": "oklch(20.0% 0.015 270.0 / 1)",
     "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
   },
+  {
+    "id": "bento-box",
+    "backgroundColor": "oklch(22.0% 0.025 45.0 / 1)",
+    "mainColor": "oklch(70.0% 0.175 20.0 / 1)",
+    "secondaryColor": "oklch(75.0% 0.165 145.0 / 1)"
+  },
 ]

--- a/data/community-content/community-themes.json
+++ b/data/community-content/community-themes.json
@@ -118,5 +118,5 @@
     "backgroundColor": "oklch(22.0% 0.025 45.0 / 1)",
     "mainColor": "oklch(70.0% 0.175 20.0 / 1)",
     "secondaryColor": "oklch(75.0% 0.165 145.0 / 1)"
-  },
+  }
 ]


### PR DESCRIPTION
## Summary
- Add the Bento Box color theme to community themes
- Colors: warm background with complementary red/green main and secondary colors

## Theme Details
| Property | Value |
|----------|-------|
| **ID** | `bento-box` |
| **Background** | `oklch(22.0% 0.025 45.0 / 1)` |
| **Main Color** | `oklch(70.0% 0.175 20.0 / 1)` |
| **Secondary** | `oklch(75.0% 0.165 145.0 / 1)` |

## Test Plan
- [ ] JSON file remains valid
- [ ] Theme appears in theme selector
- [ ] Colors render correctly

Closes #3479