### PR TITLE
Add arcade classic color theme

### DIFF
--- a/data/community-content/community-themes.json
+++ b/data/community-content/community-themes.json
@@ -136,5 +136,11 @@
     "backgroundColor": "oklch(21.0% 0.045 235.0 / 1)",
     "mainColor": "oklch(88.0% 0.055 245.0 / 1)",
     "secondaryColor": "oklch(68.0% 0.165 215.0 / 1)"
+  },
+  {
+    "id": "arcade-classic",
+    "backgroundColor": "oklch(13.0% 0.035 290.0 / 1)",
+    "mainColor": "oklch(88.0% 0.195 115.0 / 1)",
+    "secondaryColor": "oklch(82.0% 0.175 350.0 / 1)"
   }
 ]


### PR DESCRIPTION
Added a new community color theme "Arcade Classic" with background, main, and secondary colors to the community-themes collection.


---
🤖 **Auto-linked:** Closes #3583