### PR TITLE
Add Japanese grammar points: 〜にしたがって, 〜ところ

### DIFF
--- a/data/community-content/japanese-grammar.json
+++ b/data/community-content/japanese-grammar.json
@@ -69,5 +69,6 @@
   "\"〜ことにする\" means \"decide to...\".",
   "\"〜ことになっている\" means \"it is decided/arranged that...\".",
   "\"〜にしたがって\" means \"as / in accordance with...\".",
-  "\"〜ところ\" refers to a point in time, like \"about to\", \"in the middle of\", or \"just finished\"."
+  "\"〜ところ\" refers to a point in time, like \"about to\", \"in the middle of\", or \"just finished\".",
+  "〜ところ" refers to a point in time, like "about to", "in the middle of", or "just finished".
 ]


### PR DESCRIPTION
Added two new Japanese grammar points '〜にしたがって' and '〜ところ' with explanations to the grammar collection.
