### PR TITLE
feat: add question 53 on `japan-trivia-easy.json` 

### DIFF
--- a/data/community-content/japan-trivia-easy.json
+++ b/data/community-content/japan-trivia-easy.json
@@ -64,59 +64,39 @@
     "correctIndex": 0
   },
   {
-  "question": "Which city is famous for the Peace Memorial Park?",
-  "difficulty": "easy",
-  "answers": [
-    "Hiroshima",
-    "Osaka",
-    "Tokyo",
-    "Fukuoka"
-  ],
-  "correctIndex": 0
+    "question": "Which city is famous for the Peace Memorial Park?",
+    "difficulty": "easy",
+    "answers": ["Hiroshima", "Osaka", "Tokyo", "Fukuoka"],
+    "correctIndex": 0
   },
   {
-  "question": "Which city is known for its snow festival and ice sculptures?",
-  "difficulty": "easy",
-  "answers": [
-    "Sapporo",
-    "Aomori",
-    "Toyama",
-    "Nagano"
-  ],
-  "correctIndex": 0
+    "question": "Which city is known for its snow festival and ice sculptures?",
+    "difficulty": "easy",
+    "answers": ["Sapporo", "Aomori", "Toyama", "Nagano"],
+    "correctIndex": 0
   },
   {
-  "question": "What is Japan’s currency called?",
-  "difficulty": "easy",
-  "answers": [
-    "Yen",
-    "Won",
-    "Yuan",
-    "Ringgit"
-  ],
-  "correctIndex": 0
+    "question": "What is Japan’s currency called?",
+    "difficulty": "easy",
+    "answers": ["Yen", "Won", "Yuan", "Ringgit"],
+    "correctIndex": 0
   },
   {
-  "question": "Which animal is famously associated with Inari shrines in Japan?",
-  "difficulty": "easy",
-  "answers": [
-    "Fox",
-    "Crane",
-    "Turtle",
-    "Deer"
-  ],
-  "correctIndex": 0
+    "question": "Which animal is famously associated with Inari shrines in Japan?",
+    "difficulty": "easy",
+    "answers": ["Fox", "Crane", "Turtle", "Deer"],
+    "correctIndex": 0
   },
   {
-  "question": "Which Japanese dish is made of raw fish over rice?",
-  "difficulty": "easy",
-  "answers": [
-    "Sushi",
-    "Tempura",
-    "Tonkatsu",
-    "Okonomiyaki"
-  ],
-  "correctIndex": 0
-}
+    "question": "Which Japanese dish is made of raw fish over rice?",
+    "difficulty": "easy",
+    "answers": ["Sushi", "Tempura", "Tonkatsu", "Okonomiyaki"],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which mountain is Japan’s highest peak?",
+    "difficulty": "easy",
+    "answers": ["Mount Fuji", "Mount Kita", "Mount Tate", "Mount Haku"],
+    "correctIndex": 0
+  }
 ]
-


### PR DESCRIPTION
## 📝 Description
This PR add one more trivia question about mountains in japan (question 53)

## 🔗 Related Issue

Closes #4546 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  npm run check
2.  npm run test

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)

...

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context


