### PR TITLE
content: add new trivia question

### DIFF
--- a/data/community-content/japan-trivia-easy.json
+++ b/data/community-content/japan-trivia-easy.json
@@ -2,25 +2,45 @@
   {
     "question": "Which month is traditionally associated with cherry blossom viewing (hanami) in Japan?",
     "difficulty": "easy",
-    "answers": ["January", "April", "July", "October"],
+    "answers": [
+      "January",
+      "April",
+      "July",
+      "October"
+    ],
     "correctIndex": 1
   },
   {
     "question": "Which Japanese city is known for the historic Gion district?",
     "difficulty": "easy",
-    "answers": ["Kyoto", "Osaka", "Sendai", "Saitama"],
+    "answers": [
+      "Kyoto",
+      "Osaka",
+      "Sendai",
+      "Saitama"
+    ],
     "correctIndex": 0
   },
   {
     "question": "What is Japan's high-speed rail network called?",
     "difficulty": "easy",
-    "answers": ["Shinkansen", "Maglev", "JR Loop", "Tsubasa"],
+    "answers": [
+      "Shinkansen",
+      "Maglev",
+      "JR Loop",
+      "Tsubasa"
+    ],
     "correctIndex": 0
   },
   {
     "question": "Which Japanese festival celebrates the return of ancestral spirits in summer?",
     "difficulty": "easy",
-    "answers": ["Obon", "Tanabata", "Setsubun", "Seijin Shiki"],
+    "answers": [
+      "Obon",
+      "Tanabata",
+      "Setsubun",
+      "Seijin Shiki"
+    ],
     "correctIndex": 0
   },
   {
@@ -48,72 +68,133 @@
   {
     "question": "What is the Japanese term for a hot spring?",
     "difficulty": "easy",
-    "answers": ["Onsen", "Sentou", "Ryokan", "Izakaya"],
+    "answers": [
+      "Onsen",
+      "Sentou",
+      "Ryokan",
+      "Izakaya"
+    ],
     "correctIndex": 0
   },
   {
     "question": "Which Japanese dish consists of skewered grilled chicken?",
     "difficulty": "easy",
-    "answers": ["Yakitori", "Sukiyaki", "Tonkatsu", "Oden"],
+    "answers": [
+      "Yakitori",
+      "Sukiyaki",
+      "Tonkatsu",
+      "Oden"
+    ],
     "correctIndex": 0
   },
   {
     "question": "What is the main ingredient in miso?",
     "difficulty": "easy",
-    "answers": ["Fermented soybeans", "Rice flour", "Buckwheat", "Seaweed"],
+    "answers": [
+      "Fermented soybeans",
+      "Rice flour",
+      "Buckwheat",
+      "Seaweed"
+    ],
     "correctIndex": 0
   },
   {
     "question": "Which city is famous for the Peace Memorial Park?",
     "difficulty": "easy",
-    "answers": ["Hiroshima", "Osaka", "Tokyo", "Fukuoka"],
+    "answers": [
+      "Hiroshima",
+      "Osaka",
+      "Tokyo",
+      "Fukuoka"
+    ],
     "correctIndex": 0
   },
   {
     "question": "Which city is known for its snow festival and ice sculptures?",
     "difficulty": "easy",
-    "answers": ["Sapporo", "Aomori", "Toyama", "Nagano"],
+    "answers": [
+      "Sapporo",
+      "Aomori",
+      "Toyama",
+      "Nagano"
+    ],
     "correctIndex": 0
   },
   {
     "question": "What is Japan’s currency called?",
     "difficulty": "easy",
-    "answers": ["Yen", "Won", "Yuan", "Ringgit"],
+    "answers": [
+      "Yen",
+      "Won",
+      "Yuan",
+      "Ringgit"
+    ],
     "correctIndex": 0
   },
   {
     "question": "Which animal is famously associated with Inari shrines in Japan?",
     "difficulty": "easy",
-    "answers": ["Fox", "Crane", "Turtle", "Deer"],
+    "answers": [
+      "Fox",
+      "Crane",
+      "Turtle",
+      "Deer"
+    ],
     "correctIndex": 0
   },
   {
     "question": "Which Japanese dish is made of raw fish over rice?",
     "difficulty": "easy",
-    "answers": ["Sushi", "Tempura", "Tonkatsu", "Okonomiyaki"],
+    "answers": [
+      "Sushi",
+      "Tempura",
+      "Tonkatsu",
+      "Okonomiyaki"
+    ],
     "correctIndex": 0
   },
   {
     "question": "Which mountain is Japan's highest peak?",
     "difficulty": "easy",
-    "answers": ["Mount Fuji", "Mount Kita", "Mount Tate", "Mount Haku"],
+    "answers": [
+      "Mount Fuji",
+      "Mount Kita",
+      "Mount Tate",
+      "Mount Haku"
+    ],
     "correctIndex": 0
   },
   {
     "question": "Which city is known for its snow festival and ice sculptures?",
     "difficulty": "easy",
-    "answers": ["Sapporo", "Aomori", "Toyama", "Nagano"],
+    "answers": [
+      "Sapporo",
+      "Aomori",
+      "Toyama",
+      "Nagano"
+    ],
     "correctIndex": 0
   },
-{
-  "question": "Which Japanese food is a savory pancake cooked on a griddle?",
-  "difficulty": "easy",
-  "answers": [
-    "Okonomiyaki",
-    "Tempura",
-    "Yakitori",
-    "Sashimi"
-  ],
-  "correctIndex": 0
-}
+  {
+    "question": "Which Japanese food is a savory pancake cooked on a griddle?",
+    "difficulty": "easy",
+    "answers": [
+      "Okonomiyaki",
+      "Tempura",
+      "Yakitori",
+      "Sashimi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese city is famous for the floating torii gate at Itsukushima Shrine?",
+    "difficulty": "easy",
+    "answers": [
+      "Kyoto",
+      "Hiroshima",
+      "Nagasaki",
+      "Kanazawa"
+    ],
+    "correctIndex": 1
+  }
 ]


### PR DESCRIPTION
Add trivia question about Itsukushima Shrine's floating torii gate in Hiroshima.

Closes #4613

## 📝 Description

Adds a new trivia question about Itsukushima Shrine's iconic floating torii gate to the easy Japan trivia question bank. The question asks which Japanese city is famous for this landmark, with the correct answer being Hiroshima.

## 🔗 Related Issue

Closes #4613

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Verified JSON syntax is valid using `python3 -m json.tool`
2. Confirmed proper formatting and structure matches existing trivia questions
3. Validated correct answer index (1 = Hiroshima)

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Validated JSON file structure and syntax

## 📸 Screenshots/Videos (if applicable)

N/A - JSON data file update only

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

This is a good first issue contribution that adds cultural knowledge about one of Japan's most iconic landmarks - the floating torii gate at Itsukushima Shrine on Miyajima Island near Hiroshima. The shrine and its torii gate are UNESCO World Heritage Sites and among Japan's most photographed locations.