### PR TITLE
content: add new grammar point

### DIFF
--- a/data/community-content/japanese-grammar.json
+++ b/data/community-content/japanese-grammar.json
@@ -85,5 +85,6 @@
   "\"〜やすい\" attaches to verb stems to mean \"easy to do\".",
   "\"〜に限って\" means \"only / exclusively\".",
   "\"〜てしまう\" can show completion or regret about an action.",
-  "\"〜ようと思う\" expresses a decision made at the moment of speaking."
+  "\"〜ようと思う\" expresses a decision made at the moment of speaking.",
+  "\"〜すぎる\" attaches to verbs or adjectives to mean \"too much\"."
 ]


### PR DESCRIPTION
Closes #4769
Added grammar point:
"〜すぎる" attaches to verbs or adjectives to mean "too much".