### PR TITLE
Add explanation for 〜ために (Grammar Point 35) (#4793)

### DIFF
--- a/data/community-content/japanese-grammar.json
+++ b/data/community-content/japanese-grammar.json
@@ -86,5 +86,6 @@
   "\"〜に限って\" means \"only / exclusively\".",
   "\"〜てしまう\" can show completion or regret about an action.",
   "\"〜ようと思う\" expresses a decision made at the moment of speaking.",
-  "\"〜すぎる\" attaches to verbs or adjectives to mean \"too much\"."
+  "\"〜すぎる\" attaches to verbs or adjectives to mean \"too much\".",
+  "〜ために also means \"for the sake of\" and explains purpose or reason."
 ]


### PR DESCRIPTION
## Summary
Adds explanation for ～ために (Grammar Point 35) to improve clarity for learners.

## Changes
- Added missing explanation
- Ensured formatting consistency

## Related
Fixes #4793