### PR TITLE
content: add new Japan fact

### DIFF
--- a/data/community-content/japan-facts.json
+++ b/data/community-content/japan-facts.json
@@ -683,5 +683,6 @@
   "Japan has a zero-tolerance policy for drunk driving - any detectable alcohol means immediate arrest and potential prison time.",
   "The Japanese word 'kuyashii' (悔しい) describes frustration mixed with determination to do better next time - no English equivalent.",
   "There's a Japanese practice 'meshi' (召し) where a boss inviting you for a meal is essentially a command, not a request.",
-  "Japan has more Michelin-starred restaurants than any other country - Tokyo alone has more stars than Paris."
+  "Japan has more Michelin-starred restaurants than any other country - Tokyo alone has more stars than Paris.",
+  "Japan has 'Peko-chan' - a cartoon mascot for Fujiya confectionery since 1950, whose tongue-sticking pose has become an iconic symbol recognized by nearly all Japanese people."
 ]

--- a/data/community-content/japan-trivia-easy.json
+++ b/data/community-content/japan-trivia-easy.json
@@ -218,5 +218,16 @@
     "Yakitori"
   ],
   "correctIndex": 0
+},
+{
+  "question": "What is the Japanese term for a summer fireworks festival?",
+  "difficulty": "easy",
+  "answers": [
+    "Hanabi Taikai",
+    "Bon Odori",
+    "Kagura",
+    "Kanda Matsuri"
+  ],
+  "correctIndex": 0
 }
 ]


### PR DESCRIPTION
Closes #4839

Added a new interesting fact about Japan's Peko-chan mascot for Fujiya confectionery since 1950.

Fact: Japan has 'Peko-chan' - a cartoon mascot for Fujiya confectionery since 1950, whose tongue-sticking pose has become an iconic symbol recognized by nearly all Japanese people.