### PR TITLE
content: add new grammar point

### DIFF
--- a/data/community-content/japanese-grammar.json
+++ b/data/community-content/japanese-grammar.json
@@ -88,5 +88,6 @@
   "\"〜ようと思う\" expresses a decision made at the moment of speaking.",
   "\"〜すぎる\" attaches to verbs or adjectives to mean \"too much\".",
   "〜ために also means \"for the sake of\" and explains purpose or reason.",
-  "〜ことができる expresses ability, like \"can do\"."
+  "〜ことができる expresses ability, like \"can do\".",
+  "\"〜ながらも\" means \"even while\" or \"though\" (contrast)."
 ]


### PR DESCRIPTION
## 📝 Description

Added the new grammar point "〜ながらも" to the community-driven Japanese grammar list. This addition provides a learner-friendly explanation of the contrastive "even while" / "though" structure.

## 🔗 Related Issue

Closes #4844

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  Modified [data/community-content/japanese-grammar.json](cci:7://file:///c:/Users/DX/Downloads/PRs/kana-dojo/data/community-content/japanese-grammar.json:0:0-0:0) to include the new entry.
2.  Verified JSON syntax is valid.
3.  Ensured the string exactly matches the task description: `"〜ながらも" means "even while" or "though" (contrast).`

**Manual Test Checklist:**

- [x] Verified JSON format locally.

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.
