### PR TITLE
feat(theme): add Sumo Strength theme

### DIFF
--- a/data/community-content/community-themes.json
+++ b/data/community-content/community-themes.json
@@ -292,5 +292,11 @@
     "backgroundColor": "oklch(90.0% 0.032 340.0 / 1)",
     "mainColor": "oklch(70.0% 0.185 345.0 / 1)",
     "secondaryColor": "oklch(55.0% 0.145 350.0 / 1)"
+  },
+  {
+    "id": "sumo-strength",
+    "backgroundColor": "oklch(20.0% 0.022 35.0 / 1)",
+    "mainColor": "oklch(72.0% 0.065 75.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.185 20.0 / 1)"
   }
 ]


### PR DESCRIPTION
This PR addresses issue #4852 by adding the Sumo Strength theme to KanaDojo.

**Theme Details:**
- **ID**: `sumo-strength`
- **Background**: `oklch(20.0% 0.022 35.0 / 1)`
- **Main Color**: `oklch(72.0% 0.065 75.0 / 1)`
- **Secondary**: `oklch(60.0% 0.185 20.0 / 1)`

**Vibe**: Power and tradition in the ring ⛩️

The theme has been added to the `community-themes.json` file with proper JSON formatting.

Closes #4852