### PR TITLE
content: add new grammar point about wake dewa nai

### DIFF
--- a/data/community-content/japanese-grammar.json
+++ b/data/community-content/japanese-grammar.json
@@ -90,6 +90,6 @@
   "〜ために also means \"for the sake of\" and explains purpose or reason.",
   "〜ことができる expresses ability, like \"can do\".",
   "\"〜ながらも\" means \"even while\" or \"though\" (contrast).",
-  "〜はずだ means \"should / is supposed to\" and expresses expectation."
-
+  "〜はずだ means \"should / is supposed to\" and expresses expectation.",
+  "\"〜わけではない\" means \"not necessarily\" or \"it's not that\"."
 ]


### PR DESCRIPTION
This PR addresses issue #4851 by adding a new grammar point to the learner-friendly grammar list.

**New Grammar Point:**
> "〜わけではない" means "not necessarily" or "it's not that".

The grammar point has been added to the `japanese-grammar.json` file with proper JSON formatting.

Closes #4851