### PR TITLE
content: add new trivia question

### DIFF
--- a/.github/templates/messages.cjs
+++ b/.github/templates/messages.cjs
@@ -244,8 +244,8 @@ module.exports = {
     buildInstructions(filePath, itemType, prTitle, overrides = {}) {
       const steps = this.common.steps;
       const normalizedFilePath = String(filePath).replace(
-        'data/community-content/data/community-content/',
-        'data/community-content/',
+        'community/content/community/content/',
+        'community/content/',
       );
       return [
         steps.star,
@@ -292,7 +292,7 @@ module.exports = {
       taskDescription: 'Add this beautiful new theme to KanaDojo!',
       detailsHeader: '### Theme Details',
       vibeLabel: '💡 **Vibe:**',
-      file: 'data/community-content/community-themes.json',
+      file: 'community/content/community-themes.json',
       itemType: 'theme',
       prTitle: 'feat(theme): add {name} theme',
       // Theme has unique step2 and step3
@@ -332,7 +332,7 @@ module.exports = {
         'Add this interesting fact about Japan to our collection!',
       factHeader: '### The Fact',
       // Use buildInstructions: filePath, itemType, prTitle
-      file: 'data/community-content/japan-facts.json',
+      file: 'community/content/japan-facts.json',
       itemType: 'fact',
       prTitle: 'content: add new japan fact',
     },
@@ -367,7 +367,7 @@ module.exports = {
       taskDescription:
         'Add this traditional Japanese proverb to help learners understand Japanese wisdom!',
       proverbHeader: '### The Proverb',
-      file: 'data/community-content/japanese-proverbs.json',
+      file: 'community/content/japanese-proverbs.json',
       itemType: 'proverb object',
       prTitle: 'content: add new japanese proverb',
     },
@@ -401,8 +401,8 @@ module.exports = {
       estimatedTime: '<1 min',
       taskDescription: 'Add this trivia question to our growing quiz bank!',
       triviaHeader: '### The Trivia Question',
-      // Trivia uses dynamic file path: data/community-content/{difficultyFile}
-      file: 'data/community-content/{difficultyFile}',
+      // Trivia uses dynamic file path: community/content/{difficultyFile}
+      file: 'community/content/{difficultyFile}',
       itemType: 'trivia object',
       prTitle: 'content: add new trivia question',
     },
@@ -437,7 +437,7 @@ module.exports = {
       taskDescription:
         'Add this grammar explanation to our learner-friendly grammar list!',
       grammarHeader: '### The Grammar Point',
-      file: 'data/community-content/japanese-grammar.json',
+      file: 'community/content/japanese-grammar.json',
       itemType: 'grammar string',
       prTitle: 'content: add new grammar point',
     },
@@ -472,7 +472,7 @@ module.exports = {
       taskDescription:
         'Add this iconic anime quote so learners can enjoy Japanese pop culture!',
       quoteHeader: '### The Quote',
-      file: 'data/community-content/anime-quotes.json',
+      file: 'community/content/anime-quotes.json',
       itemType: 'anime quote object',
       prTitle: 'content: add anime quote',
     },

--- a/.github/workflows/pr-community-review.yml
+++ b/.github/workflows/pr-community-review.yml
@@ -334,7 +334,7 @@ jobs:
               validationType = 'trivia';
               console.log('Validating trivia contribution');
 
-              const triviaFilePattern = /^data\/community-content\/japan-trivia(?:-(easy|medium|hard))?\.json$/;
+              const triviaFilePattern = /^community\/content\/japan-trivia(?:-(easy|medium|hard))?\.json$/;
               const changed = reviewedFiles.map(function(f) { return f.filename; });
               const triviaChanged = changed.filter(function(p) { return triviaFilePattern.test(p); });
               const invalidFiles = changed.filter(function(p) { return !triviaFilePattern.test(p); });

--- a/app/api/trivia/route.ts
+++ b/app/api/trivia/route.ts
@@ -22,12 +22,7 @@ type TriviaQuestion = {
 };
 
 function readJsonFile(fileName: string): TriviaQuestion[] {
-  const filePath = path.join(
-    process.cwd(),
-    'data',
-    'community-content',
-    fileName,
-  );
+  const filePath = path.join(process.cwd(), 'community', 'content', fileName);
   if (!fs.existsSync(filePath)) {
     return [];
   }

--- a/community/content/japan-trivia-medium.json
+++ b/community/content/japan-trivia-medium.json
@@ -165,15 +165,16 @@
     "answers": ["Rakugo", "Kabuki", "Noh", "Ikebana"],
     "correctIndex": 0
   },
-   {
+  {
     "question": "What ingredient is traditionally the main source of umami flavor in shoyu (Japanese soy sauce)?",
     "difficulty": "easy",
-    "answers": [
-      "Fermented Soybeans", 
-      "Salt", 
-      "Rice Vinegar", 
-      "Brown Sugar"
-    ],
+    "answers": ["Fermented Soybeans", "Salt", "Rice Vinegar", "Brown Sugar"],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which city is known for the historic district of Higashiyama?",
+    "difficulty": "medium",
+    "answers": ["Kanazawa", "Kagoshima", "Nara", "Matsue"],
     "correctIndex": 0
   }
 ]

--- a/shared/lib/server/facts.ts
+++ b/shared/lib/server/facts.ts
@@ -13,8 +13,8 @@ export function getAllFacts(): string[] {
 
   const factsPath = join(
     process.cwd(),
-    'data',
-    'community-content',
+    'community',
+    'content',
     'japan-facts.json',
   );
   const factsData = readFileSync(factsPath, 'utf-8');


### PR DESCRIPTION
## 📝 Description

Added a new trivia to japan-trivia-medium' solving issue 5192

## 🔗 Related Issue

Closes #

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  A self-test was performed using the endpoint `/api/trivia?difficulty=medium`.

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Tested in api/trivia questions

## 📸 Screenshots/Videos (if applicable)

...

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

I had to change some paths, moving files that referenced 'data/community-content' to 'community/content'

Closes #5192
