### PR TITLE
content: add video game quote

### DIFF
--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -217,24 +217,31 @@
     "character": "Sephiroth"
   },
   {
-  "japanese": "?????????",
-  "romaji": "Koko kara ga honban da.",
-  "english": "The real battle starts now.",
-  "game": "Final Fantasy VII",
-  "character": "Sephiroth"
+    "japanese": "?????????",
+    "romaji": "Koko kara ga honban da.",
+    "english": "The real battle starts now.",
+    "game": "Final Fantasy VII",
+    "character": "Sephiroth"
   },
   {
-  "japanese": "??????????",
-  "romaji": "Mirai wa kono te de tsukamu.",
-  "english": "I will seize the future with my own hands.",
-  "game": "Final Fantasy VII",
-  "character": "Sephiroth"
-} ,
+    "japanese": "??????????",
+    "romaji": "Mirai wa kono te de tsukamu.",
+    "english": "I will seize the future with my own hands.",
+    "game": "Final Fantasy VII",
+    "character": "Sephiroth"
+  },
   {
-  "japanese": "????",
-  "romaji": "Ikuzo!",
-  "english": "Let's go!",
-  "game": "Final Fantasy VII",
-  "character": "Sephiroth"
-}
+    "japanese": "????",
+    "romaji": "Ikuzo!",
+    "english": "Let's go!",
+    "game": "Final Fantasy VII",
+    "character": "Sephiroth"
+  },
+  {
+    "japanese": "????????????",
+    "romaji": "Makeru wake ni wa ikanai.",
+    "english": "I can't afford to lose.",
+    "game": "Final Fantasy X",
+    "character": "Tidus"
+  }
 ]


### PR DESCRIPTION
## 📝 Description
Added the Final Fantasy X quote from Tidus to the Japanese video game quotes dataset.

## 🔗 Related Issue

Closes #5345

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)

...

## ✅ Pre-Submission Checklist

- [ ] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

...
