### PR TITLE
Add trivia question about autumn and maple leaves

### DIFF
--- a/community/content/japan-trivia-medium.json
+++ b/community/content/japan-trivia-medium.json
@@ -1,5 +1,11 @@
 [
   {
+  "question": "Which season is associated with red maple leaves (momiji) in Japan? (Community variation 16)",
+  "difficulty": "medium",
+  "answers": ["Spring", "Summer", "Autumn", "Winter"],
+  "correctIndex": 2
+  },
+  {
     "question": "Which Japanese festival features people throwing beans to drive away evil spirits?",
     "difficulty": "medium",
     "answers": ["Setsubun", "Obon", "Tanabata", "Shichi-Go-San"],


### PR DESCRIPTION
### What does this PR do?
Adds a new easy-difficulty trivia question about the season associated with red maple leaves (momiji) in Japan.

### Changes made
Added one trivia object to `japan-trivia-medium.json`

### Notes
Please let me know if any changes or formatting adjustments are needed.