### PR TITLE
content: add new trivia question about Japan's currency (variation 21)

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -466,5 +466,11 @@
     "backgroundColor": "oklch(96.0% 0.018 340.0 / 1)",
     "mainColor": "oklch(62.0% 0.195 10.0 / 1)",
     "secondaryColor": "oklch(78.0% 0.095 350.0 / 1)"
+  },
+  {
+    "id": "komorebi-green",
+    "backgroundColor": "oklch(22.0% 0.030 150.0 / 1)",
+    "mainColor": "oklch(78.0% 0.135 145.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.090 110.0 / 1)"
   }
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -698,5 +698,6 @@
   "The word 'otsukaresama' (ã�Šç–²ã‚Œæ§˜) literally means 'you're tired' but is used to acknowledge someone's hard work.",
   "Japan has 'salary men insurance' that pays out if you're transferred to a remote location away from your family.",
   "Japan's Shinkansen (bullet train) has a cleaning crew that fully cleans each car in exactly 7 minutes between arrivals and departures.",
-  "Japan has a festival where parents throw their babies to sumo wrestlers, who bounce them for good luck and health."
+  "Japan has a festival where parents throw their babies to sumo wrestlers, who bounce them for good luck and health.",
+  "The Japanese concept 'meibutsu' (銘物) refers to famous local products - every region has foods and crafts found nowhere else."
 ]

--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -44,12 +44,14 @@
   {
   "question": "Which Japanese city hosted the 1998 Winter Olympics?",
   "difficulty": "hard",
-  "answers": [
-    "Nagano",
-    "Kobe",
-    "Hiroshima",
-    "Naha"
-  ],
+  "answers": ["Nagano", "Kobe", "Hiroshima", "Naha"],
   "correctIndex": 0
-}
+  },
+  {
+    "question": "What is the name of Japan's national currency? (Community variation 21)",
+    "difficulty": "hard",
+    "answers": ["Yuan", "Yen", "Won", "Rupee"],
+    "correctIndex": 1
+  }
+]
 ]

--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -243,5 +243,12 @@
     "english": "I can't afford to lose.",
     "game": "Final Fantasy X",
     "character": "Tidus"
+  },
+  {
+    "japanese": "仲間を守る",
+    "romaji": "Nakama o mamoru.",
+    "english": "I protect my friends.",
+    "game": "Final Fantasy X",
+    "character": "Tidus"
   }
 ]


### PR DESCRIPTION
Added trivia question "What is the name of Japan's national currency? (Community variation 21)" to japan-trivia-hard.json as per issue #5423

Fixes #5423