### PR TITLE
feat(theme): add Tsukimi Moon theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -466,5 +466,11 @@
     "backgroundColor": "oklch(96.0% 0.018 340.0 / 1)",
     "mainColor": "oklch(62.0% 0.195 10.0 / 1)",
     "secondaryColor": "oklch(78.0% 0.095 350.0 / 1)"
+  },
+  {
+    "id": "komorebi-green",
+    "backgroundColor": "oklch(22.0% 0.030 150.0 / 1)",
+    "mainColor": "oklch(78.0% 0.135 145.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.090 110.0 / 1)"
   }
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -472,5 +472,11 @@
     "backgroundColor": "oklch(22.0% 0.030 150.0 / 1)",
     "mainColor": "oklch(78.0% 0.135 145.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.090 110.0 / 1)"
+  },
+  {
+    "id": "tsukimi-moon",
+    "backgroundColor": "oklch(18.0% 0.028 255.0 / 1)",
+    "mainColor": "oklch(92.0% 0.020 95.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.105 270.0 / 1)"
   }
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -698,5 +698,6 @@
   "The word 'otsukaresama' (ã�Šç–²ã‚Œæ§˜) literally means 'you're tired' but is used to acknowledge someone's hard work.",
   "Japan has 'salary men insurance' that pays out if you're transferred to a remote location away from your family.",
   "Japan's Shinkansen (bullet train) has a cleaning crew that fully cleans each car in exactly 7 minutes between arrivals and departures.",
-  "Japan has a festival where parents throw their babies to sumo wrestlers, who bounce them for good luck and health."
+  "Japan has a festival where parents throw their babies to sumo wrestlers, who bounce them for good luck and health.",
+  "The Japanese concept 'meibutsu' (銘物) refers to famous local products - every region has foods and crafts found nowhere else."
 ]


### PR DESCRIPTION
This PR adds the Tsukimi Moon color theme to KanaDojo.

Theme Details:
- ID: tsukimi-moon
- Background: oklch(18.0% 0.028 255.0 / 1)
- Main Color: oklch(92.0% 0.020 95.0 / 1)
- Secondary: oklch(65.0% 0.105 270.0 / 1)

Vibe: Harvest moon viewing with silver and indigo

Closes #5429