### PR TITLE
feat(api): add MVP progress sync endpoint with conflict handling

### DIFF
--- a/app/api/progress-sync/lib.test.ts
+++ b/app/api/progress-sync/lib.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProgressSyncStorageKey,
+  MAX_SYNC_PAYLOAD_BYTES,
+  normalizeSyncKey,
+  shouldAcceptIncomingUpdate,
+  validateProgressSyncRequestBody,
+} from './lib';
+
+const validSyncBody = {
+  updatedAt: '2026-02-20T12:00:00.000Z',
+  snapshot: {
+    version: '0.1.14',
+    createdAt: '2026-02-20T12:00:00.000Z',
+    stats: { totalCorrect: 123 },
+  },
+};
+
+describe('progress-sync/lib', () => {
+  describe('normalizeSyncKey', () => {
+    it('trims and accepts valid sync keys', () => {
+      expect(normalizeSyncKey('  sync-key-1234567890  ')).toBe(
+        'sync-key-1234567890',
+      );
+    });
+
+    it('rejects invalid sync keys', () => {
+      expect(normalizeSyncKey(null)).toBeNull();
+      expect(normalizeSyncKey('short')).toBeNull();
+      expect(normalizeSyncKey('invalid key with spaces')).toBeNull();
+      expect(normalizeSyncKey('!invalid_chars_123456')).toBeNull();
+    });
+  });
+
+  describe('buildProgressSyncStorageKey', () => {
+    it('creates deterministic hashed keys', () => {
+      const keyA = buildProgressSyncStorageKey('sync-key-1234567890');
+      const keyB = buildProgressSyncStorageKey('sync-key-1234567890');
+      const keyC = buildProgressSyncStorageKey('sync-key-abcdefg12345');
+
+      expect(keyA).toBe(keyB);
+      expect(keyA).not.toBe(keyC);
+      expect(keyA.startsWith('progress-sync:')).toBe(true);
+    });
+  });
+
+  describe('validateProgressSyncRequestBody', () => {
+    it('accepts valid request bodies', () => {
+      const result = validateProgressSyncRequestBody(validSyncBody);
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects non-object payloads', () => {
+      const result = validateProgressSyncRequestBody('not-an-object');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+      }
+    });
+
+    it('rejects invalid date values', () => {
+      const result = validateProgressSyncRequestBody({
+        ...validSyncBody,
+        updatedAt: 'invalid-date',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+      }
+    });
+
+    it('rejects snapshots without syncable segments', () => {
+      const result = validateProgressSyncRequestBody({
+        ...validSyncBody,
+        snapshot: {
+          version: '0.1.14',
+          createdAt: '2026-02-20T12:00:00.000Z',
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('INVALID_PAYLOAD');
+      }
+    });
+
+    it('rejects oversized payloads', () => {
+      const bigString = 'x'.repeat(MAX_SYNC_PAYLOAD_BYTES + 128);
+      const result = validateProgressSyncRequestBody({
+        ...validSyncBody,
+        snapshot: {
+          ...validSyncBody.snapshot,
+          stats: {
+            blob: bigString,
+          },
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe('PAYLOAD_TOO_LARGE');
+      }
+    });
+  });
+
+  describe('shouldAcceptIncomingUpdate', () => {
+    it('accepts newer or equal updates and rejects older updates', () => {
+      expect(
+        shouldAcceptIncomingUpdate(
+          '2026-02-20T12:00:00.000Z',
+          '2026-02-20T12:00:01.000Z',
+        ),
+      ).toBe(true);
+      expect(
+        shouldAcceptIncomingUpdate(
+          '2026-02-20T12:00:00.000Z',
+          '2026-02-20T12:00:00.000Z',
+        ),
+      ).toBe(true);
+      expect(
+        shouldAcceptIncomingUpdate(
+          '2026-02-20T12:00:01.000Z',
+          '2026-02-20T12:00:00.000Z',
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/app/api/progress-sync/lib.ts
+++ b/app/api/progress-sync/lib.ts
@@ -1,0 +1,193 @@
+import { createHash } from 'crypto';
+
+export const PROGRESS_SYNC_TTL_SECONDS = 60 * 60 * 24 * 365; // 365 days
+export const MAX_SYNC_PAYLOAD_BYTES = 512 * 1024; // 512 KB
+
+const MIN_SYNC_KEY_LENGTH = 16;
+const MAX_SYNC_KEY_LENGTH = 128;
+const SYNC_KEY_PATTERN = /^[A-Za-z0-9_:.=-]+$/;
+const ISO_8601_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+export interface ProgressSnapshot {
+  version: string;
+  createdAt: string;
+  theme?: Record<string, unknown>;
+  customTheme?: Record<string, unknown>;
+  stats?: Record<string, unknown>;
+}
+
+export interface ProgressSyncRequestBody {
+  updatedAt: string;
+  snapshot: ProgressSnapshot;
+}
+
+export interface ProgressSyncRecord extends ProgressSyncRequestBody {
+  schemaVersion: 1;
+  serverUpdatedAt: string;
+}
+
+type ValidationErrorCode = 'INVALID_PAYLOAD' | 'PAYLOAD_TOO_LARGE';
+
+interface ValidationError {
+  code: ValidationErrorCode;
+  message: string;
+}
+
+interface ValidationSuccess {
+  ok: true;
+  value: ProgressSyncRequestBody;
+}
+
+interface ValidationFailure {
+  ok: false;
+  error: ValidationError;
+}
+
+export type ValidationResult = ValidationSuccess | ValidationFailure;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isValidIsoDate(value: unknown): value is string {
+  if (typeof value !== 'string' || !ISO_8601_PATTERN.test(value)) {
+    return false;
+  }
+  return Number.isFinite(Date.parse(value));
+}
+
+function isValidProgressSnapshot(value: unknown): value is ProgressSnapshot {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  if (typeof value.version !== 'string' || value.version.trim().length === 0) {
+    return false;
+  }
+
+  if (!isValidIsoDate(value.createdAt)) {
+    return false;
+  }
+
+  const optionalSegments = ['theme', 'customTheme', 'stats'] as const;
+  let hasSyncableSegment = false;
+
+  for (const key of optionalSegments) {
+    const segment = value[key];
+    if (segment === undefined) continue;
+    if (!isPlainObject(segment)) {
+      return false;
+    }
+    hasSyncableSegment = true;
+  }
+
+  return hasSyncableSegment;
+}
+
+function getPayloadByteLength(value: unknown): number {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf-8');
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+export function normalizeSyncKey(rawKey: string | null): string | null {
+  if (!rawKey) return null;
+
+  const trimmed = rawKey.trim();
+  if (
+    trimmed.length < MIN_SYNC_KEY_LENGTH ||
+    trimmed.length > MAX_SYNC_KEY_LENGTH
+  ) {
+    return null;
+  }
+
+  if (!SYNC_KEY_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  return trimmed;
+}
+
+export function buildProgressSyncStorageKey(syncKey: string): string {
+  const hash = createHash('sha256').update(syncKey).digest('hex');
+  return `progress-sync:${hash}`;
+}
+
+export function validateProgressSyncRequestBody(
+  body: unknown,
+): ValidationResult {
+  if (!isPlainObject(body)) {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_PAYLOAD',
+        message: 'Request body must be a JSON object.',
+      },
+    };
+  }
+
+  if (getPayloadByteLength(body) > MAX_SYNC_PAYLOAD_BYTES) {
+    return {
+      ok: false,
+      error: {
+        code: 'PAYLOAD_TOO_LARGE',
+        message: `Payload exceeds ${MAX_SYNC_PAYLOAD_BYTES} bytes.`,
+      },
+    };
+  }
+
+  if (!isValidIsoDate(body.updatedAt)) {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_PAYLOAD',
+        message: 'updatedAt must be a valid ISO-8601 date string.',
+      },
+    };
+  }
+
+  if (!isValidProgressSnapshot(body.snapshot)) {
+    return {
+      ok: false,
+      error: {
+        code: 'INVALID_PAYLOAD',
+        message:
+          'snapshot must include version, createdAt, and at least one syncable segment.',
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      updatedAt: body.updatedAt,
+      snapshot: body.snapshot,
+    },
+  };
+}
+
+export function isProgressSyncRecord(
+  value: unknown,
+): value is ProgressSyncRecord {
+  if (!isPlainObject(value)) return false;
+  if (value.schemaVersion !== 1) return false;
+  if (!isValidIsoDate(value.serverUpdatedAt)) return false;
+  if (!isValidIsoDate(value.updatedAt)) return false;
+  if (!isValidProgressSnapshot(value.snapshot)) return false;
+  return true;
+}
+
+export function shouldAcceptIncomingUpdate(
+  existingUpdatedAt: string,
+  incomingUpdatedAt: string,
+): boolean {
+  const existingTs = Date.parse(existingUpdatedAt);
+  const incomingTs = Date.parse(incomingUpdatedAt);
+  if (!Number.isFinite(existingTs) || !Number.isFinite(incomingTs)) {
+    return false;
+  }
+  return incomingTs >= existingTs;
+}

--- a/app/api/progress-sync/route.test.ts
+++ b/app/api/progress-sync/route.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET, POST } from './route';
+import { buildProgressSyncStorageKey, PROGRESS_SYNC_TTL_SECONDS } from './lib';
+
+const mockHasRedisConfig = vi.fn();
+const mockRedisGetJson = vi.fn();
+const mockRedisSetJson = vi.fn();
+
+vi.mock('@/shared/lib/redis', () => ({
+  hasRedisConfig: () => mockHasRedisConfig(),
+  redisGetJson: (...args: unknown[]) => mockRedisGetJson(...args),
+  redisSetJson: (...args: unknown[]) => mockRedisSetJson(...args),
+}));
+
+const validSyncKey = 'sync-key-1234567890';
+const validBody = {
+  updatedAt: '2026-02-20T12:00:00.000Z',
+  snapshot: {
+    version: '0.1.14',
+    createdAt: '2026-02-20T12:00:00.000Z',
+    stats: { totalCorrect: 42 },
+  },
+};
+
+function makeRequest(
+  url: string,
+  init?: RequestInit & { headers?: Record<string, string> },
+) {
+  return new Request(url, init) as NextRequest;
+}
+
+describe('GET /api/progress-sync', () => {
+  beforeEach(() => {
+    mockHasRedisConfig.mockReset();
+    mockRedisGetJson.mockReset();
+    mockRedisSetJson.mockReset();
+    mockHasRedisConfig.mockReturnValue(true);
+  });
+
+  it('returns 503 when Redis is unavailable', async () => {
+    mockHasRedisConfig.mockReturnValue(false);
+
+    const response = await GET(
+      makeRequest('http://localhost/api/progress-sync', {
+        headers: { 'x-sync-key': validSyncKey },
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    const data = (await response.json()) as { code: string };
+    expect(data.code).toBe('SYNC_UNAVAILABLE');
+  });
+
+  it('returns 400 for missing sync key', async () => {
+    const response = await GET(
+      makeRequest('http://localhost/api/progress-sync'),
+    );
+
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { code: string };
+    expect(data.code).toBe('INVALID_SYNC_KEY');
+  });
+
+  it('returns 404 when no synced progress exists', async () => {
+    mockRedisGetJson.mockResolvedValue(null);
+
+    const response = await GET(
+      makeRequest('http://localhost/api/progress-sync', {
+        headers: { 'x-sync-key': validSyncKey },
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    const data = (await response.json()) as { code: string };
+    expect(data.code).toBe('NOT_FOUND');
+    expect(mockRedisGetJson).toHaveBeenCalledWith(
+      buildProgressSyncStorageKey(validSyncKey),
+    );
+  });
+
+  it('returns stored snapshot when found', async () => {
+    const storedRecord = {
+      schemaVersion: 1 as const,
+      updatedAt: '2026-02-20T12:00:00.000Z',
+      serverUpdatedAt: '2026-02-20T12:00:01.000Z',
+      snapshot: validBody.snapshot,
+    };
+    mockRedisGetJson.mockResolvedValue(storedRecord);
+
+    const response = await GET(
+      makeRequest('http://localhost/api/progress-sync', {
+        headers: { 'x-sync-key': validSyncKey },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      updatedAt: string;
+      snapshot: unknown;
+    };
+    expect(data.updatedAt).toBe(storedRecord.updatedAt);
+    expect(data.snapshot).toEqual(storedRecord.snapshot);
+  });
+});
+
+describe('POST /api/progress-sync', () => {
+  beforeEach(() => {
+    mockHasRedisConfig.mockReset();
+    mockRedisGetJson.mockReset();
+    mockRedisSetJson.mockReset();
+    mockHasRedisConfig.mockReturnValue(true);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const response = await POST(
+      makeRequest('http://localhost/api/progress-sync', {
+        method: 'POST',
+        headers: {
+          'x-sync-key': validSyncKey,
+          'content-type': 'application/json',
+        },
+        body: '{"invalid"',
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    const data = (await response.json()) as { code: string };
+    expect(data.code).toBe('INVALID_PAYLOAD');
+  });
+
+  it('returns 409 when incoming payload is older than remote state', async () => {
+    mockRedisGetJson.mockResolvedValue({
+      schemaVersion: 1,
+      updatedAt: '2026-02-20T12:30:00.000Z',
+      serverUpdatedAt: '2026-02-20T12:30:01.000Z',
+      snapshot: validBody.snapshot,
+    });
+
+    const response = await POST(
+      makeRequest('http://localhost/api/progress-sync', {
+        method: 'POST',
+        headers: {
+          'x-sync-key': validSyncKey,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(validBody),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    const data = (await response.json()) as { code: string; latest?: unknown };
+    expect(data.code).toBe('CONFLICT');
+    expect(data.latest).toBeTruthy();
+    expect(mockRedisSetJson).not.toHaveBeenCalled();
+  });
+
+  it('stores payload when incoming data is newer', async () => {
+    mockRedisGetJson.mockResolvedValue({
+      schemaVersion: 1,
+      updatedAt: '2026-02-20T11:59:59.000Z',
+      serverUpdatedAt: '2026-02-20T11:59:59.500Z',
+      snapshot: validBody.snapshot,
+    });
+    mockRedisSetJson.mockResolvedValue(undefined);
+
+    const response = await POST(
+      makeRequest('http://localhost/api/progress-sync', {
+        method: 'POST',
+        headers: {
+          'x-sync-key': validSyncKey,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(validBody),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockRedisSetJson).toHaveBeenCalledTimes(1);
+    const [key, payload, ttl] = mockRedisSetJson.mock.calls[0] as [
+      string,
+      { updatedAt: string; schemaVersion: number; snapshot: unknown },
+      number,
+    ];
+    expect(key).toBe(buildProgressSyncStorageKey(validSyncKey));
+    expect(payload.updatedAt).toBe(validBody.updatedAt);
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.snapshot).toEqual(validBody.snapshot);
+    expect(ttl).toBe(PROGRESS_SYNC_TTL_SECONDS);
+  });
+});

--- a/app/api/progress-sync/route.ts
+++ b/app/api/progress-sync/route.ts
@@ -1,0 +1,180 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { hasRedisConfig, redisGetJson, redisSetJson } from '@/shared/lib/redis';
+import type { ApiErrorResponse } from '@/shared/types/api';
+import {
+  buildProgressSyncStorageKey,
+  isProgressSyncRecord,
+  normalizeSyncKey,
+  PROGRESS_SYNC_TTL_SECONDS,
+  shouldAcceptIncomingUpdate,
+  validateProgressSyncRequestBody,
+  type ProgressSyncRecord,
+} from './lib';
+
+const ERROR_CODES = {
+  INVALID_SYNC_KEY: 'INVALID_SYNC_KEY',
+  INVALID_PAYLOAD: 'INVALID_PAYLOAD',
+  PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
+  CONFLICT: 'CONFLICT',
+  NOT_FOUND: 'NOT_FOUND',
+  SYNC_UNAVAILABLE: 'SYNC_UNAVAILABLE',
+  SERVER_ERROR: 'SERVER_ERROR',
+} as const;
+
+function createErrorResponse(
+  status: number,
+  code: string,
+  message: string,
+  extra?: Record<string, unknown>,
+) {
+  return NextResponse.json(
+    {
+      status,
+      code,
+      message,
+      error: message,
+      ...extra,
+    } satisfies ApiErrorResponse & Record<string, unknown>,
+    { status },
+  );
+}
+
+function resolveSyncKey(request: Request): string | null {
+  return normalizeSyncKey(request.headers.get('x-sync-key'));
+}
+
+function ensureSyncAvailable() {
+  if (!hasRedisConfig()) {
+    return createErrorResponse(
+      503,
+      ERROR_CODES.SYNC_UNAVAILABLE,
+      'Progress sync backend is not configured.',
+    );
+  }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  const unavailableResponse = ensureSyncAvailable();
+  if (unavailableResponse) return unavailableResponse;
+
+  const syncKey = resolveSyncKey(request);
+  if (!syncKey) {
+    return createErrorResponse(
+      400,
+      ERROR_CODES.INVALID_SYNC_KEY,
+      'x-sync-key is missing or invalid.',
+    );
+  }
+
+  const storageKey = buildProgressSyncStorageKey(syncKey);
+
+  try {
+    const stored = await redisGetJson<unknown>(storageKey);
+    if (!isProgressSyncRecord(stored)) {
+      return createErrorResponse(
+        404,
+        ERROR_CODES.NOT_FOUND,
+        'No synced progress found for this key.',
+      );
+    }
+
+    return NextResponse.json(
+      {
+        updatedAt: stored.updatedAt,
+        serverUpdatedAt: stored.serverUpdatedAt,
+        snapshot: stored.snapshot,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error('[progress-sync] GET failed:', error);
+    return createErrorResponse(
+      500,
+      ERROR_CODES.SERVER_ERROR,
+      'Failed to fetch synced progress.',
+    );
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const unavailableResponse = ensureSyncAvailable();
+  if (unavailableResponse) return unavailableResponse;
+
+  const syncKey = resolveSyncKey(request);
+  if (!syncKey) {
+    return createErrorResponse(
+      400,
+      ERROR_CODES.INVALID_SYNC_KEY,
+      'x-sync-key is missing or invalid.',
+    );
+  }
+
+  let requestBody: unknown;
+  try {
+    requestBody = await request.json();
+  } catch {
+    return createErrorResponse(
+      400,
+      ERROR_CODES.INVALID_PAYLOAD,
+      'Request body must be valid JSON.',
+    );
+  }
+
+  const validation = validateProgressSyncRequestBody(requestBody);
+  if (!validation.ok) {
+    return createErrorResponse(
+      validation.error.code === 'PAYLOAD_TOO_LARGE' ? 413 : 400,
+      ERROR_CODES[validation.error.code],
+      validation.error.message,
+    );
+  }
+
+  const storageKey = buildProgressSyncStorageKey(syncKey);
+
+  try {
+    const existing = await redisGetJson<unknown>(storageKey);
+    const existingRecord = isProgressSyncRecord(existing) ? existing : null;
+
+    if (
+      existingRecord &&
+      !shouldAcceptIncomingUpdate(
+        existingRecord.updatedAt,
+        validation.value.updatedAt,
+      )
+    ) {
+      return createErrorResponse(409, ERROR_CODES.CONFLICT, 'Sync conflict.', {
+        latest: {
+          updatedAt: existingRecord.updatedAt,
+          serverUpdatedAt: existingRecord.serverUpdatedAt,
+          snapshot: existingRecord.snapshot,
+        },
+      });
+    }
+
+    const nextRecord: ProgressSyncRecord = {
+      schemaVersion: 1,
+      updatedAt: validation.value.updatedAt,
+      snapshot: validation.value.snapshot,
+      serverUpdatedAt: new Date().toISOString(),
+    };
+
+    await redisSetJson(storageKey, nextRecord, PROGRESS_SYNC_TTL_SECONDS);
+
+    return NextResponse.json(
+      {
+        synced: true,
+        updatedAt: nextRecord.updatedAt,
+        serverUpdatedAt: nextRecord.serverUpdatedAt,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error('[progress-sync] POST failed:', error);
+    return createErrorResponse(
+      500,
+      ERROR_CODES.SERVER_ERROR,
+      'Failed to sync progress.',
+    );
+  }
+}


### PR DESCRIPTION
## Related Issue
- Related to #236 (Progress synchronization between devices)

## What this PR adds
This PR introduces a backend MVP for progress sync using Redis:

- Adds a new API route: `GET/POST /api/progress-sync`
- Uses `x-sync-key` as a client-provided sync identifier
- Validates request payload shape and ISO timestamps
- Stores progress snapshots in Redis with TTL
- Returns `409 CONFLICT` when incoming data is older than server state
- Returns `503` when sync backend (Redis) is not configured
- Uses hashed storage keys (`sha256`) to avoid storing raw sync keys

## Engineering choices
- **Snapshot-first approach**: the payload reuses the existing backup-like snapshot shape (`theme`, `customTheme`, `stats`) to minimize integration complexity.
- **Redis-backed sync**: this matches the project’s existing server-side cache/rate-limit infrastructure and enables cross-device shared state.
- **Conflict policy**: incoming updates are accepted only when `incoming.updatedAt >= existing.updatedAt` (prevents stale overwrites and keeps behavior deterministic).
- **Input hardening**: strict sync-key validation, payload size limit (512 KB), and schema validation to reduce malformed traffic risk.

## Tests
Added unit tests for both validation logic and route behavior:

- `app/api/progress-sync/lib.test.ts`
- `app/api/progress-sync/route.test.ts`

Test command run locally:
```bash
npm run test -- app/api/progress-sync/lib.test.ts app/api/progress-sync/route.test.ts
```

Result:
- `2` test files passed
- `16` tests passed
