### PR TITLE
fix(api): harden progress sync against race conditions and abuse

### DIFF
--- a/app/api/progress-sync/lib.test.ts
+++ b/app/api/progress-sync/lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildProgressSyncStorageKey,
+  getProgressUpdatedAtMs,
   MAX_SYNC_PAYLOAD_BYTES,
   normalizeSyncKey,
   shouldAcceptIncomingUpdate,
@@ -49,6 +50,9 @@ describe('progress-sync/lib', () => {
       const result = validateProgressSyncRequestBody(validSyncBody);
 
       expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.updatedAt).toBe('2026-02-20T12:00:00.000Z');
+      }
     });
 
     it('rejects non-object payloads', () => {
@@ -126,6 +130,25 @@ describe('progress-sync/lib', () => {
           '2026-02-20T12:00:00.000Z',
         ),
       ).toBe(false);
+    });
+  });
+
+  describe('getProgressUpdatedAtMs', () => {
+    it('prefers updatedAtMs when provided and valid', () => {
+      expect(
+        getProgressUpdatedAtMs({
+          updatedAt: '2026-02-20T12:00:00.000Z',
+          updatedAtMs: 1000,
+        }),
+      ).toBe(1000);
+    });
+
+    it('falls back to parsing updatedAt when updatedAtMs is missing', () => {
+      expect(
+        getProgressUpdatedAtMs({
+          updatedAt: '2026-02-20T12:00:00.000Z',
+        }),
+      ).toBe(Date.parse('2026-02-20T12:00:00.000Z'));
     });
   });
 });

--- a/app/api/progress-sync/route.test.ts
+++ b/app/api/progress-sync/route.test.ts
@@ -1,16 +1,40 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GET, POST } from './route';
-import { buildProgressSyncStorageKey, PROGRESS_SYNC_TTL_SECONDS } from './lib';
+import {
+  buildProgressSyncStorageKey,
+  MAX_SYNC_PAYLOAD_BYTES,
+  PROGRESS_SYNC_TTL_SECONDS,
+} from './lib';
 
 const mockHasRedisConfig = vi.fn();
 const mockRedisGetJson = vi.fn();
-const mockRedisSetJson = vi.fn();
+const mockRedisPipeline = vi.fn();
+const mockCheckProgressSyncRateLimit = vi.fn();
 
 vi.mock('@/shared/lib/redis', () => ({
   hasRedisConfig: () => mockHasRedisConfig(),
   redisGetJson: (...args: unknown[]) => mockRedisGetJson(...args),
-  redisSetJson: (...args: unknown[]) => mockRedisSetJson(...args),
+  redisPipeline: (...args: unknown[]) => mockRedisPipeline(...args),
+}));
+
+vi.mock('@/shared/lib/rateLimit', () => ({
+  checkProgressSyncRateLimit: (...args: unknown[]) =>
+    mockCheckProgressSyncRateLimit(...args),
+  createRateLimitHeaders: (result: {
+    remaining: number;
+    resetAt: number;
+    retryAfter?: number;
+  }) => {
+    const headers = new Headers();
+    headers.set('X-RateLimit-Remaining', String(result.remaining));
+    headers.set('X-RateLimit-Reset', String(Math.floor(result.resetAt / 1000)));
+    if (typeof result.retryAfter === 'number') {
+      headers.set('Retry-After', String(result.retryAfter));
+    }
+    return headers;
+  },
+  getClientIP: () => '127.0.0.1',
 }));
 
 const validSyncKey = 'sync-key-1234567890';
@@ -23,6 +47,14 @@ const validBody = {
   },
 };
 
+function allowedRateLimitResult() {
+  return {
+    allowed: true,
+    remaining: 19,
+    resetAt: Date.now() + 60_000,
+  };
+}
+
 function makeRequest(
   url: string,
   init?: RequestInit & { headers?: Record<string, string> },
@@ -34,8 +66,10 @@ describe('GET /api/progress-sync', () => {
   beforeEach(() => {
     mockHasRedisConfig.mockReset();
     mockRedisGetJson.mockReset();
-    mockRedisSetJson.mockReset();
+    mockRedisPipeline.mockReset();
+    mockCheckProgressSyncRateLimit.mockReset();
     mockHasRedisConfig.mockReturnValue(true);
+    mockCheckProgressSyncRateLimit.mockResolvedValue(allowedRateLimitResult());
   });
 
   it('returns 503 when Redis is unavailable', async () => {
@@ -62,6 +96,25 @@ describe('GET /api/progress-sync', () => {
     expect(data.code).toBe('INVALID_SYNC_KEY');
   });
 
+  it('returns 429 when request exceeds rate limit', async () => {
+    mockCheckProgressSyncRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 30_000,
+      retryAfter: 30,
+      reason: 'rate_limit',
+    });
+
+    const response = await GET(
+      makeRequest('http://localhost/api/progress-sync', {
+        headers: { 'x-sync-key': validSyncKey },
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('30');
+  });
+
   it('returns 404 when no synced progress exists', async () => {
     mockRedisGetJson.mockResolvedValue(null);
 
@@ -83,6 +136,7 @@ describe('GET /api/progress-sync', () => {
     const storedRecord = {
       schemaVersion: 1 as const,
       updatedAt: '2026-02-20T12:00:00.000Z',
+      updatedAtMs: Date.parse('2026-02-20T12:00:00.000Z'),
       serverUpdatedAt: '2026-02-20T12:00:01.000Z',
       snapshot: validBody.snapshot,
     };
@@ -101,6 +155,8 @@ describe('GET /api/progress-sync', () => {
     };
     expect(data.updatedAt).toBe(storedRecord.updatedAt);
     expect(data.snapshot).toEqual(storedRecord.snapshot);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Vary')).toBe('x-sync-key');
   });
 });
 
@@ -108,8 +164,34 @@ describe('POST /api/progress-sync', () => {
   beforeEach(() => {
     mockHasRedisConfig.mockReset();
     mockRedisGetJson.mockReset();
-    mockRedisSetJson.mockReset();
+    mockRedisPipeline.mockReset();
+    mockCheckProgressSyncRateLimit.mockReset();
     mockHasRedisConfig.mockReturnValue(true);
+    mockCheckProgressSyncRateLimit.mockResolvedValue(allowedRateLimitResult());
+  });
+
+  it('returns 429 when request exceeds rate limit', async () => {
+    mockCheckProgressSyncRateLimit.mockResolvedValue({
+      allowed: false,
+      remaining: 0,
+      resetAt: Date.now() + 30_000,
+      retryAfter: 30,
+      reason: 'rate_limit',
+    });
+
+    const response = await POST(
+      makeRequest('http://localhost/api/progress-sync', {
+        method: 'POST',
+        headers: {
+          'x-sync-key': validSyncKey,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(validBody),
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('30');
   });
 
   it('returns 400 for invalid JSON body', async () => {
@@ -129,13 +211,35 @@ describe('POST /api/progress-sync', () => {
     expect(data.code).toBe('INVALID_PAYLOAD');
   });
 
+  it('returns 413 when Content-Length exceeds max payload', async () => {
+    const jsonSpy = vi.fn();
+    const oversizedRequest = {
+      headers: new Headers({
+        'x-sync-key': validSyncKey,
+        'content-length': String(MAX_SYNC_PAYLOAD_BYTES + 1),
+      }),
+      json: jsonSpy,
+    } as unknown as NextRequest;
+
+    const response = await POST(oversizedRequest);
+
+    expect(response.status).toBe(413);
+    expect(jsonSpy).not.toHaveBeenCalled();
+  });
+
   it('returns 409 when incoming payload is older than remote state', async () => {
-    mockRedisGetJson.mockResolvedValue({
+    const latestRecord = {
       schemaVersion: 1,
       updatedAt: '2026-02-20T12:30:00.000Z',
+      updatedAtMs: Date.parse('2026-02-20T12:30:00.000Z'),
       serverUpdatedAt: '2026-02-20T12:30:01.000Z',
       snapshot: validBody.snapshot,
-    });
+    };
+    mockRedisPipeline.mockResolvedValue([
+      {
+        result: [0, JSON.stringify(latestRecord)],
+      },
+    ]);
 
     const response = await POST(
       makeRequest('http://localhost/api/progress-sync', {
@@ -152,17 +256,12 @@ describe('POST /api/progress-sync', () => {
     const data = (await response.json()) as { code: string; latest?: unknown };
     expect(data.code).toBe('CONFLICT');
     expect(data.latest).toBeTruthy();
-    expect(mockRedisSetJson).not.toHaveBeenCalled();
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('Vary')).toBe('x-sync-key');
   });
 
   it('stores payload when incoming data is newer', async () => {
-    mockRedisGetJson.mockResolvedValue({
-      schemaVersion: 1,
-      updatedAt: '2026-02-20T11:59:59.000Z',
-      serverUpdatedAt: '2026-02-20T11:59:59.500Z',
-      snapshot: validBody.snapshot,
-    });
-    mockRedisSetJson.mockResolvedValue(undefined);
+    mockRedisPipeline.mockResolvedValue([{ result: [1] }]);
 
     const response = await POST(
       makeRequest('http://localhost/api/progress-sync', {
@@ -176,16 +275,23 @@ describe('POST /api/progress-sync', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockRedisSetJson).toHaveBeenCalledTimes(1);
-    const [key, payload, ttl] = mockRedisSetJson.mock.calls[0] as [
-      string,
-      { updatedAt: string; schemaVersion: number; snapshot: unknown },
-      number,
-    ];
-    expect(key).toBe(buildProgressSyncStorageKey(validSyncKey));
+    expect(mockRedisPipeline).toHaveBeenCalledTimes(1);
+
+    const [commands] = mockRedisPipeline.mock.calls[0] as [unknown[][]];
+    const command = commands[0];
+    expect(command[0]).toBe('EVAL');
+    expect(command[3]).toBe(buildProgressSyncStorageKey(validSyncKey));
+
+    const payload = JSON.parse(String(command[4])) as {
+      updatedAt: string;
+      updatedAtMs: number;
+      schemaVersion: number;
+      snapshot: unknown;
+    };
     expect(payload.updatedAt).toBe(validBody.updatedAt);
+    expect(payload.updatedAtMs).toBe(Date.parse(validBody.updatedAt));
     expect(payload.schemaVersion).toBe(1);
     expect(payload.snapshot).toEqual(validBody.snapshot);
-    expect(ttl).toBe(PROGRESS_SYNC_TTL_SECONDS);
+    expect(Number(command[6])).toBe(PROGRESS_SYNC_TTL_SECONDS);
   });
 });

--- a/app/api/progress-sync/route.ts
+++ b/app/api/progress-sync/route.ts
@@ -1,12 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { hasRedisConfig, redisGetJson, redisSetJson } from '@/shared/lib/redis';
+import {
+  hasRedisConfig,
+  redisGetJson,
+  redisPipeline,
+} from '@/shared/lib/redis';
+import {
+  checkProgressSyncRateLimit,
+  createRateLimitHeaders,
+  getClientIP,
+} from '@/shared/lib/rateLimit';
 import type { ApiErrorResponse } from '@/shared/types/api';
 import {
   buildProgressSyncStorageKey,
+  getProgressUpdatedAtMs,
   isProgressSyncRecord,
   normalizeSyncKey,
+  MAX_SYNC_PAYLOAD_BYTES,
   PROGRESS_SYNC_TTL_SECONDS,
-  shouldAcceptIncomingUpdate,
   validateProgressSyncRequestBody,
   type ProgressSyncRecord,
 } from './lib';
@@ -15,11 +25,41 @@ const ERROR_CODES = {
   INVALID_SYNC_KEY: 'INVALID_SYNC_KEY',
   INVALID_PAYLOAD: 'INVALID_PAYLOAD',
   PAYLOAD_TOO_LARGE: 'PAYLOAD_TOO_LARGE',
+  RATE_LIMIT: 'RATE_LIMIT',
   CONFLICT: 'CONFLICT',
   NOT_FOUND: 'NOT_FOUND',
   SYNC_UNAVAILABLE: 'SYNC_UNAVAILABLE',
   SERVER_ERROR: 'SERVER_ERROR',
 } as const;
+
+type ProgressSyncRateLimitResult = Awaited<
+  ReturnType<typeof checkProgressSyncRateLimit>
+>;
+
+const UPSERT_PROGRESS_SYNC_RECORD_LUA = `
+local key = KEYS[1]
+local incoming_payload = ARGV[1]
+local incoming_ts = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+
+if incoming_ts == nil then
+  return {err = 'invalid incoming timestamp'}
+end
+
+local current_raw = redis.call('GET', key)
+if current_raw then
+  local ok, current = pcall(cjson.decode, current_raw)
+  if ok and current and current.updatedAtMs ~= nil then
+    local current_ts = tonumber(current.updatedAtMs)
+    if current_ts ~= nil and incoming_ts < current_ts then
+      return {0, current_raw}
+    end
+  end
+end
+
+redis.call('SET', key, incoming_payload, 'EX', ttl)
+return {1}
+`;
 
 function createErrorResponse(
   status: number,
@@ -39,31 +79,135 @@ function createErrorResponse(
   );
 }
 
+function applyPrivateSyncHeaders(
+  response: NextResponse,
+  varyBySyncKey: boolean = false,
+): NextResponse {
+  response.headers.set('Cache-Control', 'no-store');
+  if (varyBySyncKey) {
+    response.headers.set('Vary', 'x-sync-key');
+  }
+  return response;
+}
+
 function resolveSyncKey(request: Request): string | null {
   return normalizeSyncKey(request.headers.get('x-sync-key'));
 }
 
-function ensureSyncAvailable() {
+function ensureSyncAvailable(): NextResponse | null {
   if (!hasRedisConfig()) {
-    return createErrorResponse(
-      503,
-      ERROR_CODES.SYNC_UNAVAILABLE,
-      'Progress sync backend is not configured.',
+    return applyPrivateSyncHeaders(
+      createErrorResponse(
+        503,
+        ERROR_CODES.SYNC_UNAVAILABLE,
+        'Progress sync backend is not configured.',
+      ),
+      true,
     );
   }
   return null;
+}
+
+function createRateLimitErrorResponse(
+  rateLimitResult: ProgressSyncRateLimitResult,
+): NextResponse {
+  const headers = createRateLimitHeaders(rateLimitResult);
+
+  let message: string;
+  if (rateLimitResult.reason === 'daily_quota') {
+    message = 'Daily progress sync limit reached. Please try again tomorrow.';
+  } else if (rateLimitResult.reason === 'global_limit') {
+    message =
+      'Service is experiencing high demand. Please try again in a moment.';
+  } else {
+    message = `Too many requests. Please wait ${rateLimitResult.retryAfter} seconds.`;
+  }
+
+  const response = createErrorResponse(429, ERROR_CODES.RATE_LIMIT, message, {
+    retryAfter: rateLimitResult.retryAfter,
+  });
+
+  headers.forEach((value, key) => {
+    response.headers.set(key, value);
+  });
+
+  return applyPrivateSyncHeaders(response, true);
+}
+
+async function enforceRateLimit(
+  request: NextRequest,
+): Promise<NextResponse | null> {
+  const clientIP = getClientIP(request);
+  const rateLimitResult = await checkProgressSyncRateLimit(clientIP);
+  if (rateLimitResult.allowed) {
+    return null;
+  }
+  return createRateLimitErrorResponse(rateLimitResult);
+}
+
+async function upsertProgressSyncRecordAtomically(
+  storageKey: string,
+  record: ProgressSyncRecord,
+): Promise<
+  { stored: true } | { stored: false; latest: ProgressSyncRecord | null }
+> {
+  const pipelineResults = await redisPipeline([
+    [
+      'EVAL',
+      UPSERT_PROGRESS_SYNC_RECORD_LUA,
+      1,
+      storageKey,
+      JSON.stringify(record),
+      record.updatedAtMs ?? 0,
+      PROGRESS_SYNC_TTL_SECONDS,
+    ],
+  ]);
+
+  const evalResult = pipelineResults[0];
+  if (evalResult?.error) {
+    throw new Error(`Redis EVAL failed: ${evalResult.error}`);
+  }
+
+  const result = evalResult?.result;
+  if (Array.isArray(result) && Number(result[0]) === 1) {
+    return { stored: true };
+  }
+
+  if (Array.isArray(result) && Number(result[0]) === 0) {
+    const latestRaw = result[1];
+    if (typeof latestRaw === 'string') {
+      try {
+        const parsed = JSON.parse(latestRaw) as unknown;
+        if (isProgressSyncRecord(parsed)) {
+          return { stored: false, latest: parsed };
+        }
+      } catch {
+        // Ignore parse failures and return generic conflict response.
+      }
+    }
+
+    return { stored: false, latest: null };
+  }
+
+  throw new Error('Unexpected Redis EVAL result.');
 }
 
 export async function GET(request: NextRequest) {
   const unavailableResponse = ensureSyncAvailable();
   if (unavailableResponse) return unavailableResponse;
 
+  const rateLimitResponse = await enforceRateLimit(request);
+  if (rateLimitResponse) return rateLimitResponse;
+
   const syncKey = resolveSyncKey(request);
   if (!syncKey) {
-    return createErrorResponse(
-      400,
-      ERROR_CODES.INVALID_SYNC_KEY,
-      'x-sync-key is missing or invalid.',
+    return applyPrivateSyncHeaders(
+      createErrorResponse(
+        400,
+        ERROR_CODES.INVALID_SYNC_KEY,
+        'x-sync-key is missing or invalid.',
+      ),
+      true,
     );
   }
 
@@ -72,27 +216,36 @@ export async function GET(request: NextRequest) {
   try {
     const stored = await redisGetJson<unknown>(storageKey);
     if (!isProgressSyncRecord(stored)) {
-      return createErrorResponse(
-        404,
-        ERROR_CODES.NOT_FOUND,
-        'No synced progress found for this key.',
+      return applyPrivateSyncHeaders(
+        createErrorResponse(
+          404,
+          ERROR_CODES.NOT_FOUND,
+          'No synced progress found for this key.',
+        ),
+        true,
       );
     }
 
-    return NextResponse.json(
-      {
-        updatedAt: stored.updatedAt,
-        serverUpdatedAt: stored.serverUpdatedAt,
-        snapshot: stored.snapshot,
-      },
-      { status: 200 },
+    return applyPrivateSyncHeaders(
+      NextResponse.json(
+        {
+          updatedAt: stored.updatedAt,
+          serverUpdatedAt: stored.serverUpdatedAt,
+          snapshot: stored.snapshot,
+        },
+        { status: 200 },
+      ),
+      true,
     );
   } catch (error) {
     console.error('[progress-sync] GET failed:', error);
-    return createErrorResponse(
-      500,
-      ERROR_CODES.SERVER_ERROR,
-      'Failed to fetch synced progress.',
+    return applyPrivateSyncHeaders(
+      createErrorResponse(
+        500,
+        ERROR_CODES.SERVER_ERROR,
+        'Failed to fetch synced progress.',
+      ),
+      true,
     );
   }
 }
@@ -101,6 +254,9 @@ export async function POST(request: NextRequest) {
   const unavailableResponse = ensureSyncAvailable();
   if (unavailableResponse) return unavailableResponse;
 
+  const rateLimitResponse = await enforceRateLimit(request);
+  if (rateLimitResponse) return rateLimitResponse;
+
   const syncKey = resolveSyncKey(request);
   if (!syncKey) {
     return createErrorResponse(
@@ -108,6 +264,21 @@ export async function POST(request: NextRequest) {
       ERROR_CODES.INVALID_SYNC_KEY,
       'x-sync-key is missing or invalid.',
     );
+  }
+
+  const contentLength = request.headers.get('content-length');
+  if (contentLength) {
+    const contentLengthBytes = Number(contentLength);
+    if (
+      Number.isFinite(contentLengthBytes) &&
+      contentLengthBytes > MAX_SYNC_PAYLOAD_BYTES
+    ) {
+      return createErrorResponse(
+        413,
+        ERROR_CODES.PAYLOAD_TOO_LARGE,
+        `Payload exceeds ${MAX_SYNC_PAYLOAD_BYTES} bytes.`,
+      );
+    }
   }
 
   let requestBody: unknown;
@@ -131,35 +302,46 @@ export async function POST(request: NextRequest) {
   }
 
   const storageKey = buildProgressSyncStorageKey(syncKey);
+  const incomingUpdatedAtMs = getProgressUpdatedAtMs({
+    updatedAt: validation.value.updatedAt,
+  });
+  if (incomingUpdatedAtMs === null) {
+    return createErrorResponse(
+      400,
+      ERROR_CODES.INVALID_PAYLOAD,
+      'updatedAt must be a valid ISO-8601 date string.',
+    );
+  }
 
   try {
-    const existing = await redisGetJson<unknown>(storageKey);
-    const existingRecord = isProgressSyncRecord(existing) ? existing : null;
-
-    if (
-      existingRecord &&
-      !shouldAcceptIncomingUpdate(
-        existingRecord.updatedAt,
-        validation.value.updatedAt,
-      )
-    ) {
-      return createErrorResponse(409, ERROR_CODES.CONFLICT, 'Sync conflict.', {
-        latest: {
-          updatedAt: existingRecord.updatedAt,
-          serverUpdatedAt: existingRecord.serverUpdatedAt,
-          snapshot: existingRecord.snapshot,
-        },
-      });
-    }
-
     const nextRecord: ProgressSyncRecord = {
       schemaVersion: 1,
       updatedAt: validation.value.updatedAt,
+      updatedAtMs: incomingUpdatedAtMs,
       snapshot: validation.value.snapshot,
       serverUpdatedAt: new Date().toISOString(),
     };
 
-    await redisSetJson(storageKey, nextRecord, PROGRESS_SYNC_TTL_SECONDS);
+    const upsertResult = await upsertProgressSyncRecordAtomically(
+      storageKey,
+      nextRecord,
+    );
+
+    if (!upsertResult.stored) {
+      const latest = upsertResult.latest;
+      return applyPrivateSyncHeaders(
+        createErrorResponse(409, ERROR_CODES.CONFLICT, 'Sync conflict.', {
+          latest: latest
+            ? {
+                updatedAt: latest.updatedAt,
+                serverUpdatedAt: latest.serverUpdatedAt,
+                snapshot: latest.snapshot,
+              }
+            : undefined,
+        }),
+        true,
+      );
+    }
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## Related
- Follow-up to #5498
- Related to #236 (Progress synchronization between devices)

## Why this follow-up
This PR addresses review concerns from the initial MVP merge and hardens the progress-sync API for production safety.

## What changed

### 1) Atomic conflict handling in Redis
- Replaced non-atomic read/compare/write with an atomic Redis Lua upsert.
- The script compares `incoming.updatedAtMs` against stored `updatedAtMs` and rejects stale writes with `409 CONFLICT`.
- This prevents concurrent stale overwrite races.

### 2) Added rate limiting for progress sync
- Added a dedicated progress-sync limiter in `shared/lib/rateLimit.ts`.
- The route now enforces per-IP limits and returns standard 429 responses with rate-limit headers.

### 3) Early payload rejection
- Added early `Content-Length` guard before `request.json()` parsing.
- Requests exceeding the sync payload cap are rejected with `413` without parsing the body.

### 4) Cache safety headers for sync responses
- Added `Cache-Control: no-store` and `Vary: x-sync-key` on sync read/conflict paths.
- Prevents accidental intermediary caching across different sync keys.

## Notes on compatibility
- Existing records without `updatedAtMs` are still readable.
- New writes persist `updatedAtMs` to support strict atomic ordering moving forward.

## Tests
Updated and expanded tests:
- `app/api/progress-sync/route.test.ts`
  - rate-limit 429 behavior
  - early 413 via oversized `Content-Length`
  - atomic conflict path (`409`) with returned `latest`
  - cache safety headers on GET/conflict
- `app/api/progress-sync/lib.test.ts`
  - normalized timestamp behavior
  - `updatedAtMs` parsing helpers

Ran locally:
```bash
npm run test -- app/api/progress-sync/lib.test.ts app/api/progress-sync/route.test.ts
```

Result:
- 2 test files passed
- 21 tests passed
