### PR TITLE
feat(audio): add auto-play pronunciation setting for vocab/kanji prompts

### DIFF
--- a/features/Kanji/components/Game/Input.tsx
+++ b/features/Kanji/components/Game/Input.tsx
@@ -111,6 +111,7 @@ const KanjiInputGame = ({
       ];
 
   const [displayAnswerSummary, setDisplayAnswerSummary] = useState(false);
+  const [promptSequence, setPromptSequence] = useState(0);
   const [feedback, setFeedback] = useState<React.ReactElement>(
     <>{'feedback ~'}</>,
   );
@@ -266,6 +267,7 @@ const KanjiInputGame = ({
     setInputValue('');
     setDisplayAnswerSummary(false);
     generateNewCharacter();
+    setPromptSequence(prev => prev + 1);
     setBottomBarState('check');
     speedStopwatch.reset();
     speedStopwatch.start();
@@ -336,6 +338,8 @@ const KanjiInputGame = ({
                   variant='icon-only'
                   size='sm'
                   className='bg-(--card-color) text-(--secondary-color)'
+                  autoPlay
+                  autoPlayTrigger={promptSequence}
                 />
               )}
             </motion.div>

--- a/features/Kanji/components/Game/Pick.tsx
+++ b/features/Kanji/components/Game/Pick.tsx
@@ -224,6 +224,7 @@ const KanjiPickGame = ({ selectedKanjiObjs, isHidden }: KanjiPickGameProps) => {
   );
 
   const [displayAnswerSummary, setDisplayAnswerSummary] = useState(false);
+  const [promptSequence, setPromptSequence] = useState(0);
   const [feedback, setFeedback] = useState(<>{'feedback ~'}</>);
   const [wrongSelectedAnswers, setWrongSelectedAnswers] = useState<string[]>(
     [],
@@ -368,6 +369,7 @@ const KanjiPickGame = ({ selectedKanjiObjs, isHidden }: KanjiPickGameProps) => {
     );
     adaptiveSelector.markCharacterSeen(newChar);
     setCorrectChar(newChar);
+    setPromptSequence(prev => prev + 1);
   };
 
   const gameMode = 'pick';
@@ -409,6 +411,8 @@ const KanjiPickGame = ({ selectedKanjiObjs, isHidden }: KanjiPickGameProps) => {
                 variant='icon-only'
                 size='sm'
                 className='bg-(--card-color) text-(--secondary-color)'
+                autoPlay
+                autoPlayTrigger={promptSequence}
               />
             )}
           </div>

--- a/features/Preferences/components/Behavior.tsx
+++ b/features/Preferences/components/Behavior.tsx
@@ -36,6 +36,12 @@ const Behavior = () => {
   const setPronunciationPitch = usePreferencesStore(
     state => state.setPronunciationPitch,
   );
+  const pronunciationAutoPlay = usePreferencesStore(
+    state => state.pronunciationAutoPlay,
+  );
+  const setPronunciationAutoPlay = usePreferencesStore(
+    state => state.setPronunciationAutoPlay,
+  );
   const furiganaEnabled = usePreferencesStore(state => state.furiganaEnabled);
   const setFuriganaEnabled = usePreferencesStore(
     state => state.setFuriganaEnabled,
@@ -283,6 +289,64 @@ const Behavior = () => {
           <span>
             <span className='text-(--main-color)'>
               {!pronunciationEnabled && '\u2B24 '}
+            </span>
+            off
+          </span>
+          <VolumeX size={20} className='mb-0.5' />
+        </button>
+      </div>
+
+      <h4 className='text-lg'>Auto-play pronunciation for new prompts:</h4>
+      <div className='flex flex-row gap-4 p-1'>
+        <button
+          className={clsx(
+            buttonBorderStyles,
+            'text-center text-lg',
+            'w-1/2 p-4 md:w-1/4',
+            'flex flex-row items-end justify-center gap-1.5',
+            'text-(--secondary-color)',
+            'flex-1 overflow-hidden',
+          )}
+          style={{
+            outline: pronunciationAutoPlay
+              ? '3px solid var(--secondary-color)'
+              : 'none',
+          }}
+          onClick={() => {
+            playClick();
+            setPronunciationAutoPlay(true);
+          }}
+        >
+          <span>
+            <span className='text-(--main-color)'>
+              {pronunciationAutoPlay && '\u2B24 '}
+            </span>
+            on
+          </span>
+          <Volume2 size={20} className='mb-0.5' />
+        </button>
+        <button
+          className={clsx(
+            buttonBorderStyles,
+            'text-center text-lg',
+            'w-1/2 p-4 md:w-1/4',
+            'flex flex-row items-end justify-center gap-1.5',
+            'text-(--secondary-color)',
+            'flex-1 overflow-hidden',
+          )}
+          style={{
+            outline: !pronunciationAutoPlay
+              ? '3px solid var(--secondary-color)'
+              : 'none',
+          }}
+          onClick={() => {
+            playClick();
+            setPronunciationAutoPlay(false);
+          }}
+        >
+          <span>
+            <span className='text-(--main-color)'>
+              {!pronunciationAutoPlay && '\u2B24 '}
             </span>
             off
           </span>

--- a/features/Preferences/facade/useAudioPreferences.ts
+++ b/features/Preferences/facade/useAudioPreferences.ts
@@ -14,6 +14,8 @@ export interface AudioPreferences {
   setPronunciationPitch: (pitch: number) => void;
   pronunciationVoiceName: string | null;
   setPronunciationVoiceName: (name: string | null) => void;
+  pronunciationAutoPlay: boolean;
+  setPronunciationAutoPlay: (enabled: boolean) => void;
 }
 
 /**
@@ -48,6 +50,12 @@ export function useAudioPreferences(): AudioPreferences {
   const setPronunciationVoiceName = usePreferencesStore(
     state => state.setPronunciationVoiceName,
   );
+  const pronunciationAutoPlay = usePreferencesStore(
+    state => state.pronunciationAutoPlay,
+  );
+  const setPronunciationAutoPlay = usePreferencesStore(
+    state => state.setPronunciationAutoPlay,
+  );
 
   return useMemo<AudioPreferences>(
     () => ({
@@ -61,6 +69,8 @@ export function useAudioPreferences(): AudioPreferences {
       setPronunciationPitch,
       pronunciationVoiceName,
       setPronunciationVoiceName,
+      pronunciationAutoPlay,
+      setPronunciationAutoPlay,
     }),
     [
       silentMode,
@@ -73,6 +83,8 @@ export function useAudioPreferences(): AudioPreferences {
       setPronunciationPitch,
       pronunciationVoiceName,
       setPronunciationVoiceName,
+      pronunciationAutoPlay,
+      setPronunciationAutoPlay,
     ],
   );
 }

--- a/features/Preferences/store/usePreferencesStore.ts
+++ b/features/Preferences/store/usePreferencesStore.ts
@@ -34,6 +34,9 @@ interface PreferencesState {
   pronunciationVoiceName: string | null;
   setPronunciationVoiceName: (name: string | null) => void;
 
+  pronunciationAutoPlay: boolean;
+  setPronunciationAutoPlay: (enabled: boolean) => void;
+
   furiganaEnabled: boolean;
   setFuriganaEnabled: (enabled: boolean) => void;
 
@@ -79,6 +82,9 @@ const usePreferencesStore = create<PreferencesState>()(
       setPronunciationPitch: pitch => set({ pronunciationPitch: pitch }),
       pronunciationVoiceName: null,
       setPronunciationVoiceName: name => set({ pronunciationVoiceName: name }),
+      pronunciationAutoPlay: false,
+      setPronunciationAutoPlay: enabled =>
+        set({ pronunciationAutoPlay: enabled }),
       furiganaEnabled: false,
       setFuriganaEnabled: enabled => set({ furiganaEnabled: enabled }),
 

--- a/features/Vocabulary/components/Game/Input.tsx
+++ b/features/Vocabulary/components/Game/Input.tsx
@@ -80,6 +80,7 @@ const VocabInputGame = ({
       : correctWordObj?.reading;
 
   const [displayAnswerSummary, setDisplayAnswerSummary] = useState(false);
+  const [promptSequence, setPromptSequence] = useState(0);
 
   // Generate new character - defined before useCallback that uses it
   const generateNewCharacter = useCallback(() => {
@@ -103,6 +104,7 @@ const VocabInputGame = ({
     setInputValue('');
     setDisplayAnswerSummary(false);
     generateNewCharacter();
+    setPromptSequence(prev => prev + 1);
     setBottomBarState('check');
     speedStopwatch.reset();
     speedStopwatch.start();
@@ -296,6 +298,8 @@ const VocabInputGame = ({
                     variant='icon-only'
                     size='sm'
                     className='bg-(--card-color) text-(--secondary-color)'
+                    autoPlay
+                    autoPlayTrigger={promptSequence}
                   />
                 )}
               </motion.div>

--- a/features/Vocabulary/components/Game/Pick.tsx
+++ b/features/Vocabulary/components/Game/Pick.tsx
@@ -68,8 +68,7 @@ const OptionButton = memo(
           'text-(--border-color)',
           'border-b-4',
           isReverse ? 'text-4xl' : 'text-3xl',
-          isWrong &&
-            'border-(--border-color) hover:bg-(--card-color)',
+          isWrong && 'border-(--border-color) hover:bg-(--card-color)',
           !isWrong &&
             'border-(--secondary-color)/50 text-(--secondary-color) hover:border-(--secondary-color)',
         )}
@@ -89,9 +88,7 @@ const OptionButton = memo(
         <span
           className={clsx(
             'mr-4 hidden rounded-full bg-(--border-color) px-1 text-xs lg:inline',
-            isWrong
-              ? 'text-(--border-color)'
-              : 'text-(--secondary-color)',
+            isWrong ? 'text-(--border-color)' : 'text-(--secondary-color)',
           )}
         >
           {index + 1}
@@ -213,6 +210,7 @@ const VocabPickGame = ({ selectedWordObjs, isHidden }: VocabPickGameProps) => {
   );
 
   const [displayAnswerSummary, setDisplayAnswerSummary] = useState(false);
+  const [promptSequence, setPromptSequence] = useState(0);
   const [feedback, setFeedback] = useState(<>{'feedback ~'}</>);
   const [wrongSelectedAnswers, setWrongSelectedAnswers] = useState<string[]>(
     [],
@@ -329,6 +327,7 @@ const VocabPickGame = ({ selectedWordObjs, isHidden }: VocabPickGameProps) => {
     );
     adaptiveSelector.markCharacterSeen(newChar);
     setCorrectChar(newChar);
+    setPromptSequence(prev => prev + 1);
 
     // Get the actual word for the new character to check if it contains kanji
     const newWordObj = wordObjMap.get(newChar);
@@ -399,6 +398,8 @@ const VocabPickGame = ({ selectedWordObjs, isHidden }: VocabPickGameProps) => {
                   variant='icon-only'
                   size='sm'
                   className='bg-(--card-color) text-(--secondary-color)'
+                  autoPlay
+                  autoPlayTrigger={promptSequence}
                 />
               )}
             </div>

--- a/features/Vocabulary/components/Game/WordBuildingGame.tsx
+++ b/features/Vocabulary/components/Game/WordBuildingGame.tsx
@@ -37,7 +37,6 @@ const containsKanji = (text: string): boolean => {
   return /[\u4E00-\u9FAF]/.test(text);
 };
 
-
 interface VocabWordBuildingGameProps {
   selectedWordObjs: IVocabObj[];
   isHidden: boolean;
@@ -217,6 +216,7 @@ const VocabWordBuildingGame = ({
   const [questionData, setQuestionData] = useState(() =>
     generateQuestion(quizType),
   );
+  const [promptSequence, setPromptSequence] = useState(0);
   const [placedTiles, setPlacedTiles] = useState<string[]>([]);
   const [isChecking, setIsChecking] = useState(false);
   const [isCelebrating, setIsCelebrating] = useState(false);
@@ -249,6 +249,7 @@ const VocabWordBuildingGame = ({
       const typeToUse = nextQuizType ?? quizType;
       const newQuestion = generateQuestion(typeToUse);
       setQuestionData(newQuestion);
+      setPromptSequence(prev => prev + 1);
       setPlacedTiles([]);
       setIsChecking(false);
       setIsCelebrating(false);
@@ -560,6 +561,8 @@ const VocabWordBuildingGame = ({
                       variant='icon-only'
                       size='sm'
                       className='bg-(--card-color) text-(--secondary-color)'
+                      autoPlay
+                      autoPlayTrigger={promptSequence}
                     />
                   )}
                 </motion.div>
@@ -590,7 +593,9 @@ const VocabWordBuildingGame = ({
                   : 'min-h-[5rem]',
               )}
               tilesContainerClassName={
-                isGlassMode ? 'rounded-xl bg-(--card-color) px-4 py-2' : undefined
+                isGlassMode
+                  ? 'rounded-xl bg-(--card-color) px-4 py-2'
+                  : undefined
               }
               tilesWrapperKey={questionData.word}
             />

--- a/shared/components/audio/SSRAudioButton.tsx
+++ b/shared/components/audio/SSRAudioButton.tsx
@@ -11,6 +11,8 @@ interface SSRAudioButtonProps {
   disabled?: boolean;
   onPlay?: () => void;
   onStop?: () => void;
+  autoPlay?: boolean;
+  autoPlayTrigger?: string | number;
 }
 
 const SSRAudioButton: React.FC<SSRAudioButtonProps> = props => {


### PR DESCRIPTION
* feat(audio): add autoplay pronunciation setting for vocab and kanji prompts

## 📝 Description

- Persisted a new preference `pronunciationAutoPlay` with setter in the preferences store and exposed it via the audio facade `useAudioPreferences`.  
- Added an "Auto-play pronunciation for new prompts" toggle to the Preferences → Behavior UI wired to the new store state.  
- Extended `AudioButton` and `SSRAudioButton` with `autoPlay` and `autoPlayTrigger` props and implemented guarded auto-play logic that runs once per trigger and respects both `pronunciationEnabled` and `pronunciationAutoPlay`.  
- Wired `autoPlay` into the existing vocab/kanji prompt screens (`Input`, `Pick`, and `WordBuildingGame`) so prompt audio can auto-play on new questions.  

### Motivation

- Add a user-facing setting so vocabulary/kanji prompts can optionally speak automatically when a new question appears.

## 🔗 Related Issue

Closes  N/A

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Go to settings and enable the new setting
2. Play any mode for Vocabulary and audio should auto play

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)

N/A

## ✅ Pre-Submission Checklist

- [X] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

N/A
