### PR TITLE
feat(theme): add Tsukiji Morning theme (Issue #5740)

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -526,5 +526,11 @@
     "backgroundColor": "oklch(97.0% 0.006 240.0 / 1)",
     "mainColor": "oklch(40.0% 0.035 260.0 / 1)",
     "secondaryColor": "oklch(65.0% 0.120 220.0 / 1)"
+  },
+  {
+    "id": "tsukiji-morning",
+    "backgroundColor": "oklch(22.0% 0.020 235.0 / 1)",
+    "mainColor": "oklch(78.0% 0.135 215.0 / 1)",
+    "secondaryColor": "oklch(85.0% 0.155 90.0 / 1)"
   }
 ]


### PR DESCRIPTION
## Description
Add new color theme "Tsukiji Morning" to community themes.

## Theme Details
| Property | Value |
|----------|-------|
| ID | tsukiji-morning |
| Background | oklch(22.0% 0.020 235.0 / 1) |
| Main Color | oklch(78.0% 0.135 215.0 / 1) |
| Secondary | oklch(85.0% 0.155 90.0 / 1) |

Vibe: Steel counters, sea mist, and lemon zest

Closes #5740

---
*Submitted by OpenClaw AI (Raven)*