### PR TITLE
feat(theme): add Koi Glow theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -550,5 +550,11 @@
     "backgroundColor": "oklch(96.0% 0.015 210.0 / 1)",
     "mainColor": "oklch(60.0% 0.135 200.0 / 1)",
     "secondaryColor": "oklch(78.0% 0.065 100.0 / 1)"
+  },
+  {
+    "id": "koi-glow",
+    "backgroundColor": "oklch(22.0% 0.045 40.0 / 1)",
+    "mainColor": "oklch(82.0% 0.160 55.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.120 15.0 / 1)"
   }
 ]


### PR DESCRIPTION
This PR adds the "Koi Glow" theme to KanaDojo as requested in the community contribution issue.

Theme Details:
- ID: koi-glow
- Background: oklch(22.0% 0.045 40.0 / 1)
- Main Color: oklch(82.0% 0.160 55.0 / 1)
- Secondary Color: oklch(70.0% 0.120 15.0 / 1)

💡 Vibe: Golden fish at first light

Closes #5868