### PR TITLE
content: add new japanese false friend

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -9,6 +9,12 @@
   "termA": "リベンジ (ribenji)",
   "termB": "revenge (English)",
   "explanation": "Often used as 'try again after failing'. (Set 6)",
-  "example": "去年落ちた試験に今年リベンジする。"    
+  "example": "去年落ちた試験に今年リベンジする。"
+},
+{
+  "termA": "イメージ (imeeji)",
+  "termB": "image",
+  "explanation": "Often means impression/public image. (Set 5)",
+  "example": "会社のイメージが良くなった。"
 }
 ]


### PR DESCRIPTION
## Summary

Added new false friend pair for Japanese learners.

## Changes

- Added イメージ (imeeji) / image false friend pair
- Term explanation: Often means impression/public image
- Example sentence: 会社のイメージが良くなった。

Closes #6117