### PR TITLE
content: add new japanese false friend

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -17,10 +17,10 @@
   "explanation": "Often means impression/public image. (Set 5)",
   "example": "会社のイメージが良くなった。"
 },
-  {
+{
     "termA": "クレーム (kureemu)",
     "termB": "claim (English)",
     "explanation": "In Japanese it usually means complaint. (Set 4)",
     "example": "お客様からクレームが届いた。"
-  }
+}
 ]

--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -16,5 +16,11 @@
   "termB": "image",
   "explanation": "Often means impression/public image. (Set 5)",
   "example": "会社のイメージが良くなった。"
-}
+},
+  {
+    "termA": "クレーム (kureemu)",
+    "termB": "claim (English)",
+    "explanation": "In Japanese it usually means complaint. (Set 4)",
+    "example": "お客様からクレームが届いた。"
+  }
 ]


### PR DESCRIPTION
## 📝 Description

Adds the Japanese false friend pair クレーム (kureemu) / claim (English) to the community content file. In Japanese, クレーム means "complaint", not "claim" as one might assume from the English word.

## 🔗 Related Issue

Closes #6133

## 🔄 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

Manual review of the JSON file to ensure valid JSON structure and correct data.

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have performed a self-review of my own code.
- [x] The JSON is valid and properly formatted.