### PR TITLE
content: add new japanese idiom

### DIFF
--- a/community/content/japanese-idioms.json
+++ b/community/content/japanese-idioms.json
@@ -40,5 +40,11 @@
   "romaji": "Tatsu tori ato o nigosazu",
   "english": "A bird leaves no mess",
   "meaning": "Leave cleanly without trouble. (Set 6)"
+},
+{
+  "japanese": "耳が早い",
+  "romaji": "Mimi ga hayai",
+  "english": "Fast ears",
+  "meaning": "Quick to hear news/gossip. (Set 6)"
 }
 ]


### PR DESCRIPTION
## 📝 Description

Add "耳が早い" to community/content/japanese-idioms.json 

## 🔗 Related Issue

Closes #6557

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [v] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  npm run check
2.  npm run test

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)

<img width="1344" height="564" alt="image" src="https://github.com/user-attachments/assets/519ed9b8-d93b-4b18-b408-43893eb80deb" />
<img width="1349" height="589" alt="image" src="https://github.com/user-attachments/assets/62be4387-e82c-45e6-8d5c-2f5bf9dc7ca7" />


## ✅ Pre-Submission Checklist

- [ ] My code follows the project's code style and uses `cn()` utility where needed.
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [ ] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

I have run both "npm run check" and "npm run test". There are some unrelated errors and test failures as attached screenshots which require more information to resolve. 
