### PR TITLE
content: add new regional dialect entry (〜じゃけぇ) - Closes #6572

### DIFF
--- a/community/content/japanese-regional-dialects.json
+++ b/community/content/japanese-regional-dialects.json
@@ -40,5 +40,12 @@
   "english": "very",
   "region": "Yamaguchi/Hiroshima",
   "note": "Regional intensifier. (Set 5)"
+  },
+  {
+  "dialect": "〜じゃけぇ",
+  "standardJapanese": "〜だから",
+  "english": "because",
+  "region": "Hiroshima",
+  "note": "Common causal ending. (Set 6)"
   }
 ]


### PR DESCRIPTION
Closes #6572

Added a new regional dialect entry:

Dialect: 〜じゃけぇ  
Standard Japanese: 〜だから  
English: because  
Region: Hiroshima  
Note: Common causal ending. (Set 6)

Ensured JSON formatting remains valid and added comma where required.