### PR TITLE
content: add new japanese false friend (ハイテンション) - Closes #6559

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -52,5 +52,11 @@
   "termB": "salaryman",
   "explanation": "Refers broadly to office workers. (Set 1)",
   "example": "父は都内でサラリーマンをしている。"
+},
+   {
+  "termA": "ハイテンション (haitenshon)",
+  "termB": "high tension (English)",
+  "explanation": "Means very energetic mood. (Set 6)",
+  "example": "試合前はみんなハイテンションだった。"
 }
 ]


### PR DESCRIPTION
Closes #6559

Added new Japanese false friend pair:

Term A: ハイテンション (haitenshon)  
Term B: high tension (English)  
Explanation: Means very energetic mood. (Set 6)  
Example: 試合前はみんなハイテンションだった。

Ensured JSON formatting remains valid and added comma where required.