### PR TITLE
content: add new japan fact (robot priests) - Closes #6564

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -724,5 +724,6 @@
   "Japan has 'butler cafes' where women are served by men in formal butler attire who address them as 'Princess' or 'Mistress'.",
   "Japan's oldest company, Kongō Gumi, was a construction company that operated continuously for 1,428 years (578-2006 CE) before being absorbed.",
   "Japan’s 'michi-no-eki' (道の駅) are highway rest stops that double as local farmers’ markets and souvenir hubs.",
-  "There's a Japanese concept 'omoiyari' (思いやり) meaning sensitivity to others' feelings - anticipating needs before they're expressed."
+  "There's a Japanese concept 'omoiyari' (思いやり) meaning sensitivity to others' feelings - anticipating needs before they're expressed.",
+  "Japan has robots that serve as Buddhist priests conducting funeral ceremonies - complete with chanting and prayer beads."
   ]


### PR DESCRIPTION
Closes #6564

Added new Japan fact:

"Japan has robots that serve as Buddhist priests conducting funeral ceremonies - complete with chanting and prayer beads."

Ensured JSON formatting remains valid and added comma where required.