### PR TITLE
content: add new japan fact (everlasting love museum) - Closes #6537

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -725,5 +725,6 @@
   "Japan's oldest company, Kongō Gumi, was a construction company that operated continuously for 1,428 years (578-2006 CE) before being absorbed.",
   "Japan’s 'michi-no-eki' (道の駅) are highway rest stops that double as local farmers’ markets and souvenir hubs.",
   "There's a Japanese concept 'omoiyari' (思いやり) meaning sensitivity to others' feelings - anticipating needs before they're expressed.",
-  "Japan has robots that serve as Buddhist priests conducting funeral ceremonies - complete with chanting and prayer beads."
+  "Japan has robots that serve as Buddhist priests conducting funeral ceremonies - complete with chanting and prayer beads.",
+  "Japan has an 'everlasting love' museum in Hokkaido dedicated to sculptor Takeichi Nishimura's 60-year love for his wife."
   ]


### PR DESCRIPTION
Closes #6537

Added new Japan fact:

"Japan has an 'everlasting love' museum in Hokkaido dedicated to sculptor Takeichi Nishimura's 60-year love for his wife."

Ensured JSON formatting remains valid and added comma where required.