### PR TITLE
content: add new common mistake (で location usage) - Closes #6535

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -38,5 +38,10 @@
   "wrong": "これは私のです本。",
   "correct": "これは私の本です。",
   "explanation": "Place の correctly in noun phrase. (Pattern set 1)"
+},
+  {
+  "wrong": "図書館に本を借りました。",
+  "correct": "図書館で本を借りました。",
+  "explanation": "で marks location of action. (Pattern set 4)"
 }
 ]


### PR DESCRIPTION
Closes #6535

Added new common learner mistake entry:

Wrong: 図書館に本を借りました。  
Correct: 図書館で本を借りました。  
Explanation: で marks location of action. (Pattern set 4)

Ensured JSON formatting remains valid and added comma where required.