### PR TITLE
feat(theme): add Sushi Counter theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -646,5 +646,11 @@
     "backgroundColor": "oklch(24.0% 0.028 65.0 / 1)",
     "mainColor": "oklch(72.0% 0.085 70.0 / 1)",
     "secondaryColor": "oklch(60.0% 0.065 55.0 / 1)"
-  }
+  },
+  {
+  "id": "sushi-counter",
+  "backgroundColor": "oklch(23.0% 0.028 70.0 / 1)",
+  "mainColor": "oklch(70.0% 0.145 20.0 / 1)",
+  "secondaryColor": "oklch(68.0% 0.095 75.0 / 1)"
+}
 ]


### PR DESCRIPTION
Closes #6550
## ✨ Add Sushi Counter Theme



### 🎨 Theme Details

- **ID:** `sushi-counter`
- **Background:** `oklch(23.0% 0.028 70.0 / 1)`
- **Main Color:** `oklch(70.0% 0.145 20.0 / 1)`
- **Secondary:** `oklch(68.0% 0.095 75.0 / 1)`

### 🌊 Vibe
Fresh fish on cypress wood — warm, earthy, and minimal.

---

### 🛠 Changes Made

- Added the `sushi-counter` theme object to: