### PR TITLE
Feat/add kintsugi japan fact

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -646,5 +646,11 @@
     "backgroundColor": "oklch(24.0% 0.028 65.0 / 1)",
     "mainColor": "oklch(72.0% 0.085 70.0 / 1)",
     "secondaryColor": "oklch(60.0% 0.065 55.0 / 1)"
-  }
+  },
+  {
+  "id": "sushi-counter",
+  "backgroundColor": "oklch(23.0% 0.028 70.0 / 1)",
+  "mainColor": "oklch(70.0% 0.145 20.0 / 1)",
+  "secondaryColor": "oklch(68.0% 0.095 75.0 / 1)"
+}
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -726,5 +726,6 @@
   "Japan’s 'michi-no-eki' (道の駅) are highway rest stops that double as local farmers’ markets and souvenir hubs.",
   "There's a Japanese concept 'omoiyari' (思いやり) meaning sensitivity to others' feelings - anticipating needs before they're expressed.",
   "Japan has robots that serve as Buddhist priests conducting funeral ceremonies - complete with chanting and prayer beads.",
-  "Japan has an 'everlasting love' museum in Hokkaido dedicated to sculptor Takeichi Nishimura's 60-year love for his wife."
+  "Japan has an 'everlasting love' museum in Hokkaido dedicated to sculptor Takeichi Nishimura's 60-year love for his wife.",
+  "The term 'kintsugi' (金継ぎ) refers to repairing ceramics with gold, embracing cracks as part of an object’s history."
   ]


### PR DESCRIPTION
## 🎋 Add New Japan Fact

Closes  #6599

### 📚 Added Fact

> "The term 'kintsugi' (金継ぎ) refers to repairing ceramics with gold, embracing cracks as part of an object’s history."

---

### 🛠 Changes Made

- Added new fact to: