### PR TITLE
content: add new trivia question

### DIFF
--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -80,6 +80,17 @@
     "Bering Sea"
   ],
   "correctIndex": 0
+},
+{
+  "question": "Which Japanese city is known for its historic wooden district, Gion? (Community variation 29)",
+  "difficulty": "hard",
+  "answers": [
+    "Kyoto",
+    "Yokohama",
+    "Nagoya",
+    "Sendai"
+  ],
+  "correctIndex": 0
 }
 ]
 


### PR DESCRIPTION
Closes #6626.

## Summary
- Added a new hard trivia entry to `community/content/japan-trivia-hard.json`:
  - Question: "Which Japanese city is known for its historic wooden district, Gion? (Community variation 29)"
  - Answers: Kyoto / Yokohama / Nagoya / Sendai
  - Correct index: 0

## Validation
- Confirmed JSON validity with `python -m json.tool community/content/japan-trivia-hard.json`.
