### PR TITLE
content: add new japanese false friend

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -64,5 +64,11 @@
     "termB": "Hotchkiss (name)",
     "explanation": "ホッチキス means stapler. (Set 3)",
     "example": "資料をホッチキスで留めてください。"
+  },
+  {
+    "termA": "イメージ (imeeji)",
+    "termB": "image",
+    "explanation": "Often means impression/public image. (Set 4)",
+    "example": "会社のイメージが良くなった。"
   }
 ]


### PR DESCRIPTION
## Summary

Add new Japanese false friend pair to help learners avoid common mixups.

## Changes

Added new false friend entry:
- Term A: イメージ (imeeji)
- Term B: image
- Explanation: Often means impression/public image. (Set 4)
- Example: 会社のイメージが良くなった。

Closes #7006