### PR TITLE
content: add new trivia question

### DIFF
--- a/community/content/japan-trivia-medium.json
+++ b/community/content/japan-trivia-medium.json
@@ -276,6 +276,17 @@
     "Sendai"
     ],
   "correctIndex": 0
-  }
+  },
+  {
+  "question": "Which Japanese castle was the seat of the Tokugawa shogunate? (Community variation 40)",
+  "difficulty": "medium",
+  "answers": [
+    "Edo Castle",
+    "Himeji Castle",
+    "Matsumoto Castle",
+    "Osaka Castle"
+  ],
+  "correctIndex": 0
+}
 
 ]


### PR DESCRIPTION
## 📌 Description
Added a new medium difficulty trivia question to japan-trivia-medium.json.

## ✨ Changes Made
- Added new trivia question (Community variation 40)
- Ensured JSON format remains valid
- Added comma after previous last entry

## 🧠 Trivia Added
Question: Which Japanese castle was the seat of the Tokugawa shogunate?  
Correct Answer: Edo Castle

Closes #7193
