### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -764,5 +764,6 @@
     "category": "transportation"
   },
   "Japan’s 'wagashi' sweets are often designed to match the season, with colors and shapes inspired by flowers or snow.",
-  "Japan has 'lucky bags' (fukubukuro) sold on New Year's - sealed bags of discount mystery items worth more than price."
+  "Japan has 'lucky bags' (fukubukuro) sold on New Year's - sealed bags of discount mystery items worth more than price.",
+  "The term 'shinnen' (信念) means conviction or strongly held belief, often tied to personal principles."
 ]


### PR DESCRIPTION
Closes #7357

Added the fact about the term 'shinnen' (信念) meaning conviction or strongly held belief.