### PR TITLE
content: add new regional dialect entry

### DIFF
--- a/community/content/japanese-regional-dialects.json
+++ b/community/content/japanese-regional-dialects.json
@@ -26,5 +26,12 @@
     "english": "no/cannot",
     "region": "Chugoku",
     "note": "Prohibitive nuance. (Set 1)"
+  },
+  {
+    "dialect": "なんくるないさ",
+    "standardJapanese": "なんとかなる",
+    "english": "it'll work out",
+    "region": "Okinawa",
+    "note": "Famous Okinawan resilience phrase. (Set 5)"
   }
 ]


### PR DESCRIPTION
## 📝 Description

- add the requested Okinawan dialect phrase (`なんくるないさ`) to `community/content/japanese-regional-dialects.json`
- keep the diff scoped to a single content entry, matching issue instructions exactly

## 🔗 Related Issue

Closes #7559

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Parsed `community/content/japanese-regional-dialects.json` with Python's `json` module to validate syntax.
2. Verified exactly one matching entry exists for dialect `なんくるないさ` in region `Okinawa`.

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] JSON file validates and includes the requested entry

## 📸 Screenshots/Videos (if applicable)

- N/A (content-only JSON update)

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

- This follows the beginner contribution issue instructions and keeps a minimal, reviewable diff.
