### PR TITLE
content: add new common mistake

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -23,5 +23,10 @@
   "wrong": "私はお金がありませんです。",
   "correct": "私はお金がありません。",
   "explanation": "Negative polite form already complete. (Pattern set 4)"
+},
+  {
+  "wrong": "私は日本語を話しますです。",
+  "correct": "私は日本語を話します。",
+  "explanation": "Do not stack ます and です in one predicate. (Pattern set 3)"
 }
 ]


### PR DESCRIPTION
## 📝 Description
content: add a new Common Japanese Learner Mistake.

...

## 🔗 Related Issue

Closes #7564 

## 🎯 Type of Change

- **content:** Content update
- I have added the following Common Japanese learner mistake to  `community/content/japanese-common-mistakes.json`
```json
{
  "wrong": "私は日本語話しますです。",
  "correct": "私は日本語話します。",
  "explanation": "Do not stack ます and です in one predicate."
}
```


## ✅ Pre-Submission Checklist

- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] This PR is against the `main` branch.
