### PR TITLE
content: add new regional dialect entry (〜けん from Kyushu)

### DIFF
--- a/community/content/japanese-regional-dialects.json
+++ b/community/content/japanese-regional-dialects.json
@@ -33,5 +33,12 @@
     "english": "it'll work out",
     "region": "Okinawa",
     "note": "Famous Okinawan resilience phrase. (Set 5)"
+  },
+  {
+    "dialect": "〜けん",
+    "standardJapanese": "〜から",
+    "english": "because",
+    "region": "Kyushu",
+    "note": "Reason marker in Kyushu. (Set 3)"
   }
 ]


### PR DESCRIPTION
## Summary
Add new regional dialect entry for Kyushu dialect (〜けん) to the japanese-regional-dialects.json file.

## Changes
- Added new dialect entry:
  - Dialect: 〜けん
  - Standard Japanese: 〜から
  - English: because
  - Region: Kyushu
  - Note: Reason marker in Kyushu. (Set 3)

## Related Issue
Closes #7578