### PR TITLE
fix(achievements): prevent premature JLPT Graduate unlocks

### DIFF
--- a/features/Achievements/store/useAchievementStore.ts
+++ b/features/Achievements/store/useAchievementStore.ts
@@ -1484,6 +1484,13 @@ function checkContentMastery(
     relevantEntries = entries.filter(([key]) => BASIC_KATAKANA.has(key));
     if (relevantEntries.length < BASIC_KATAKANA.size) return false;
   } else if (contentType === 'kanji') {
+    const jlptLevel = additional?.jlptLevel;
+
+    if (jlptLevel) {
+      const levelCorrect = allTimeStats.kanjiCorrectByLevel?.[jlptLevel] ?? 0;
+      if (levelCorrect === 0) return false;
+    }
+
     relevantEntries = entries.filter(([key]) => isSingleKanji(key));
   } else {
     relevantEntries = entries;


### PR DESCRIPTION
## 📝 Description

- add a JLPT-level guard in `checkContentMastery` for kanji achievements
- require at least one correct answer recorded for the target `jlptLevel` before evaluating kanji mastery unlock
- keeps scope minimal while directly blocking N4–N1 Graduate unlocks when users have only practiced N5

## 🔗 Related Issue

Closes #6961

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Attempted to run targeted tests: `npm run test -- features/Achievements/__tests__/mastery.property.test.ts`
2. Attempted lint for touched file: `npm run lint -- --file features/Achievements/store/useAchievementStore.ts`

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo (logic path inspected against issue repro conditions)
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Validation commands documented when local environment could not execute them (`vitest` module missing; `eslint` not executable in this runner)

## 📸 Screenshots/Videos (if applicable)

N/A (logic-only change)

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

## 📦 Additional Context

This fix is intentionally conservative and scoped to the bug report. It prevents untouched JLPT levels from being marked as mastered, without changing unrelated achievement logic.
