### PR TITLE
content: add video game quote

### DIFF
--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -68,5 +68,12 @@
     "english": "We're going to change the future!",
     "game": "Steins;Gate: My Darling's Embrace",
     "character": "Rintaro Okabe"
+  },
+  {
+    "japanese": "希望は前に進むんだ！",
+    "romaji": "Kibou wa mae ni susumun da!",
+    "english": "Hope moves forward!",
+    "game": "Danganronpa series",
+    "character": "Makoto Naegi"
   }
 ]


### PR DESCRIPTION
## 📝 Description

Added a new Japanese video game quote from the Danganronpa series to `community/content/japanese-videogame-quotes.json`.

## 🔗 Related Issue https://github.com/lingdojo/kana-dojo/issues/7775

Closes #7775

## 🎯 Type of Change

* [ ] fix
* [ ] feat
* [ ] docs
* [x] content
* [ ] style
* [ ] refactor
* [ ] test
* [ ] chore

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Added the quote object to the end of `japanese-videogame-quotes.json`
2. Verified the JSON structure is valid and the array format is correct

**Manual Test Checklist:**

* [ ] Tested in Kana dojo
* [ ] Tested in Kanji dojo
* [ ] Tested in Vocabulary dojo
* [ ] Tested all 4 game modes

## 📸 Screenshots/Videos (if applicable)

<img width="674" height="278" alt="image" src="https://github.com/user-attachments/assets/71fffc04-6abd-40d3-8a68-79b5e08aced5" />


## ✅ Pre-Submission Checklist

* [x] My change only updates content
* [x] JSON format is valid
* [x] Commit message follows Conventional Commits format
* [x] This PR is against the `main` branch

## 📦 Additional Context

Added the quote:

"希望は前に進むんだ！"
Romaji: Kibou wa mae ni susumun da!
Character: Makoto Naegi
Game: Danganronpa series
