### PR TITLE
fix: correct json key names and formatting in japanese common mistakes

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -43,5 +43,10 @@
     "mistake": "Using \"hai\" instead of \"ee\"",
     "correction": "ee (ええ)",
     "explanation": "In casual Japanese, ee is more common than hai."
+  },
+  {
+    "wrong": "これは私のです本。",
+    "correct": "これは私の本です。",
+    "explanation": "Place の correctly in noun phrase. (Pattern set 2)"
   }
 ]

--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -48,5 +48,5 @@
     "wrong": "これは私のです本。",
     "correct": "これは私の本です。",
     "explanation": "Place の correctly in noun phrase. (Pattern set 2)"
-}
+  }
 ]

--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -40,13 +40,13 @@
     "explanation": "Nominalize with の before を. (Pattern set 4)"
   },
   {
-    "mistake": "Using \"hai\" instead of \"ee\"",
-    "correction": "ee (ええ)",
+    "wrong": "Using \"hai\" instead of \"ee\"",
+    "correct": "ee (ええ)",
     "explanation": "In casual Japanese, ee is more common than hai."
   },
   {
-  "wrong": "これは私のです本。",
-  "correct": "これは私の本です。",
-  "explanation": "Place の correctly in noun phrase. (Pattern set 2)"
+    "wrong": "これは私のです本。",
+    "correct": "これは私の本です。",
+    "explanation": "Place の correctly in noun phrase. (Pattern set 2)"
 }
 ]


### PR DESCRIPTION
## 📝 Description

This PR fixes incorrect JSON key names and formatting issues in the Japanese common mistakes file.

## 🔗 Related Issue

Closes #7833

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)
