### PR TITLE
Fix formatting of Japanese proverb entry

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -198,15 +198,14 @@
     "meaning": "Mistakes lead to growth"
   },
   {
-    "japanese": "良薬は口に苦し",
-    "romaji": "Ryouyaku wa kuchi ni nigashi",
-    "english": "Good medicine tastes bitter",
-    "meaning": "Helpful advice can be hard to hear"
-  },
-  {
+  "japanese": "良薬は口に苦し",
+  "romaji": "Ryouyaku wa kuchi ni nigashi",
+  "english": "Good medicine tastes bitter",
+  "meaning": "Helpful advice can be hard to hear"
+},
+{
   "japanese": "善因善果",
   "romaji": "Zenin zenka",
   "english": "Good causes bring good results",
   "meaning": "Good deeds lead to good outcomes"
 }
-]

--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -209,3 +209,4 @@
   "english": "Good causes bring good results",
   "meaning": "Good deeds lead to good outcomes"
 }
+]


### PR DESCRIPTION
Added the Japanese proverb 善因善果 with romaji, english translation, and meaning.

## 📝 Description

...

## 🔗 Related Issue

Closes #

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)

## 📸 Screenshots/Videos (if applicable)

...

## ✅ Pre-Submission Checklist

- [ ] My code follows the project's code style and uses `cn()` utility where needed.
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [ ] I have updated the documentation (if applicable).
- [ ] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

...
