### PR TITLE
content: add learner mistake #11

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -48,5 +48,10 @@
     "wrong": "これは私のです本。",
     "correct": "これは私の本です。",
     "explanation": "Place の correctly in noun phrase. (Pattern set 2)"
+  },
+  {
+    "wrong": "毎日日本語を勉強していますから上手になります。",
+    "correct": "毎日日本語を勉強しているので上手になります。",
+    "explanation": "ので is smoother/neutral for reason. (Pattern set 1)"
   }
 ]


### PR DESCRIPTION
Closes #7909. Adds a common Japanese learner mistake entry to the database regarding the use of ので vs から.