### PR TITLE
content: add new japanese false friend

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -70,5 +70,11 @@
   "termB": "viking (English)",
   "explanation": "Usually means buffet/all-you-can-eat in Japan. (Set 4)",
   "example": "ホテルの朝食はバイキングです。"
+},
+{
+  "termA": "マンション (manshon)",
+  "termB": "mansion (English)",
+  "explanation": "マンション means apartment building in Japanese. (Set 3)",
+  "example": "駅前のマンションに住んでいます。"
 }
 ]


### PR DESCRIPTION
Adds Japanese false friend pair #42.

Term A: マンション (manshon)  
Term B: mansion (English)

Explanation: マンション means apartment building in Japanese.

Example: 駅前のマンションに住んでいます。

Closes #7952