### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -46,5 +46,6 @@
   "Japan's elementary school students often clean their classrooms themselves in a routine called 'souji'.",
   "Japan's rail system is so punctual that train companies issue delay certificates for commuters.",
   "Japan has more than 6,800 islands, though only about 430 are inhabited.",
-  "Japan has over 1,500 earthquakes every year because it sits on the Pacific Ring of Fire."
+  "Japan has over 1,500 earthquakes every year because it sits on the Pacific Ring of Fire.",
+  "Japan has 'chiiki matsuri' — neighborhood festivals run by local committees where residents carry portable shrines together."
 ]


### PR DESCRIPTION
Adds Japan fact #263.

Japan has 'chiiki matsuri' — neighborhood festivals run by local committees where residents carry portable shrines together.

Closes #7958