### PR TITLE
Add new false friend: ナイーブ (naive)

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -30,51 +30,57 @@
     "example": "ペットボトルは分別して捨てる。"
   },
   {
-  "termA": "ナンバー (nanbaa)",
-  "termB": "number (English)",
-  "explanation": "Can mean ranking position in Japanese usage. (Set 2)",
-  "example": "彼はチームのナンバー1だ。"
-},
-{
-  "termA": "スマート (sumaato)",
-  "termB": "smart (English)",
-  "explanation": "Often means slim/stylish, not necessarily intelligent. (Set 5)",
-  "example": "彼はスマートな着こなしをしている。"
-},
-{
-  "termA": "シール (shiiru)",
-  "termB": "seal (animal)",
-  "explanation": "シール usually means sticker/label. (Set 3)",
-  "example": "ノートにシールを貼った。"
-},
-{
-  "termA": "サラリーマン (sarariman)",
-  "termB": "salaryman",
-  "explanation": "Refers broadly to office workers. (Set 5)",
-  "example": "父は都内でサラリーマンをしている。"
-},
-{
-  "termA": "ハイテンション (haitenshon)",
-  "termB": "high tension (English)",
-  "explanation": "Means very energetic mood. (Set 1)",
-  "example": "試合前はみんなハイテンションだった。"
-},
-{
-  "termA": "アニメ (anime)",
-  "termB": "anime (English usage)",
-  "explanation": "In Japanese it can refer to animation in general. (Set 4)",
-  "example": "子どものころからアニメが好きだ。"
-},
-{
-  "termA": "バイキング (baikingu)",
-  "termB": "viking (English)",
-  "explanation": "Usually means buffet/all-you-can-eat in Japan. (Set 4)",
-  "example": "ホテルの朝食はバイキングです。"
-},
-{
-  "termA": "マンション (manshon)",
-  "termB": "mansion (English)",
-  "explanation": "マンション means apartment building in Japanese. (Set 3)",
-  "example": "駅前のマンションに住んでいます。"
-}
+    "termA": "ナンバー (nanbaa)",
+    "termB": "number (English)",
+    "explanation": "Can mean ranking position in Japanese usage. (Set 2)",
+    "example": "彼はチームのナンバー1だ。"
+  },
+  {
+    "termA": "スマート (sumaato)",
+    "termB": "smart (English)",
+    "explanation": "Often means slim/stylish, not necessarily intelligent. (Set 5)",
+    "example": "彼はスマートな着こなしをしている。"
+  },
+  {
+    "termA": "シール (shiiru)",
+    "termB": "seal (animal)",
+    "explanation": "シール usually means sticker/label. (Set 3)",
+    "example": "ノートにシールを貼った。"
+  },
+  {
+    "termA": "サラリーマン (sarariman)",
+    "termB": "salaryman",
+    "explanation": "Refers broadly to office workers. (Set 5)",
+    "example": "父は都内でサラリーマンをしている。"
+  },
+  {
+    "termA": "ハイテンション (haitenshon)",
+    "termB": "high tension (English)",
+    "explanation": "Means very energetic mood. (Set 1)",
+    "example": "試合前はみんなハイテンションだった。"
+  },
+  {
+    "termA": "アニメ (anime)",
+    "termB": "anime (English usage)",
+    "explanation": "In Japanese it can refer to animation in general. (Set 4)",
+    "example": "子どものころからアニメが好きだ。"
+  },
+  {
+    "termA": "バイキング (baikingu)",
+    "termB": "viking (English)",
+    "explanation": "Usually means buffet/all-you-can-eat in Japan. (Set 4)",
+    "example": "ホテルの朝食はバイキングです。"
+  },
+  {
+    "termA": "マンション (manshon)",
+    "termB": "mansion (English)",
+    "explanation": "マンション means apartment building in Japanese. (Set 3)",
+    "example": "駅前のマンションに住んでいます。"
+  },
+  {
+    "termA": "ナイーブ (naibu)",
+    "termB": "naive (English)",
+    "explanation": "Often means sensitive/delicate in Japanese. (Set 5)",
+    "example": "彼は意外とナイーブな性格だ。"
+  }
 ]


### PR DESCRIPTION
Added a new false friend pair to the Japanese false friends collection:

- **Japanese**: ナイーブ (naibu)
- **English**: naive
- **Explanation**: Often means sensitive/delicate in Japanese, not necessarily lacking wisdom as in English
- **Example**: 彼は意外とナイーブな性格だ。(He has a surprisingly sensitive personality.)

This contribution follows the existing format and adds to Set 5.