### PR TITLE
Add Citrus Shrine theme 🍊⛩️

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -293,9 +293,15 @@
     "secondaryColor": "oklch(65.0% 0.125 145.0 / 1)"
   },
   {
-  "id": "morning-fog",
-  "backgroundColor": "oklch(22.0% 0.010 240.0 / 1)",
-  "mainColor": "oklch(78.0% 0.030 220.0 / 1)",
-  "secondaryColor": "oklch(65.0% 0.040 260.0 / 1)"
-}
+    "id": "morning-fog",
+    "backgroundColor": "oklch(22.0% 0.010 240.0 / 1)",
+    "mainColor": "oklch(78.0% 0.030 220.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.040 260.0 / 1)"
+  },
+  {
+    "id": "citrus-shrine",
+    "backgroundColor": "oklch(20.0% 0.030 70.0 / 1)",
+    "mainColor": "oklch(86.0% 0.155 85.0 / 1)",
+    "secondaryColor": "oklch(75.0% 0.095 60.0 / 1)"
+  }
 ]


### PR DESCRIPTION
Adds a new community theme 'Citrus Shrine' with warm yuzu peel and wooden beams vibes.

Theme colors:
- Background: oklch(20.0% 0.030 70.0 / 1)
- Main: oklch(86.0% 0.155 85.0 / 1)  
- Secondary: oklch(75.0% 0.095 60.0 / 1)

Closes #8016