### PR TITLE
Add new false friend pair #67: カンニング (kanningu) / cunning

### DIFF
--- a/community/backlog/anime-quotes-backlog.json
+++ b/community/backlog/anime-quotes-backlog.json
@@ -1226,7 +1226,7 @@
     "english": "What?! (alt wording 19) (alt wording 71)",
     "anime": "Fist of the North Star",
     "character": "Shin",
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "grammar",
-  "lastRun": "2026-03-11T01:15:26.516Z",
-  "totalIssuesCreated": 3649,
+  "lastType": "animeQuote",
+  "lastRun": "2026-03-11T01:30:30.762Z",
+  "totalIssuesCreated": 3650,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T01:15:26.516Z"
+  "lastIssueCreatedAt": "2026-03-11T01:30:30.762Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "exampleSentence",
-  "lastRun": "2026-03-11T00:00:42.439Z",
-  "totalIssuesCreated": 3644,
+  "lastType": "commonMistake",
+  "lastRun": "2026-03-11T00:15:25.822Z",
+  "totalIssuesCreated": 3645,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T00:00:42.439Z"
+  "lastIssueCreatedAt": "2026-03-11T00:15:25.822Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "commonMistake",
-  "lastRun": "2026-03-11T00:15:25.822Z",
-  "totalIssuesCreated": 3645,
+  "lastType": "theme",
+  "lastRun": "2026-03-11T00:30:32.806Z",
+  "totalIssuesCreated": 3646,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T00:15:25.822Z"
+  "lastIssueCreatedAt": "2026-03-11T00:30:32.806Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "theme",
-  "lastRun": "2026-03-11T00:30:32.806Z",
-  "totalIssuesCreated": 3646,
+  "lastType": "proverb",
+  "lastRun": "2026-03-11T00:45:24.621Z",
+  "totalIssuesCreated": 3647,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T00:30:32.806Z"
+  "lastIssueCreatedAt": "2026-03-11T00:45:24.621Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "videoGameQuote",
-  "lastRun": "2026-03-11T01:45:23.992Z",
-  "totalIssuesCreated": 3651,
+  "lastType": "idiom",
+  "lastRun": "2026-03-11T02:00:36.848Z",
+  "totalIssuesCreated": 3652,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T01:45:23.992Z"
+  "lastIssueCreatedAt": "2026-03-11T02:00:36.848Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "animeQuote",
-  "lastRun": "2026-03-11T01:30:30.762Z",
-  "totalIssuesCreated": 3650,
+  "lastType": "videoGameQuote",
+  "lastRun": "2026-03-11T01:45:23.992Z",
+  "totalIssuesCreated": 3651,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T01:30:30.762Z"
+  "lastIssueCreatedAt": "2026-03-11T01:45:23.992Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "idiom",
-  "lastRun": "2026-03-11T02:00:36.848Z",
-  "totalIssuesCreated": 3652,
+  "lastType": "falseFriend",
+  "lastRun": "2026-03-11T02:15:26.794Z",
+  "totalIssuesCreated": 3653,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T02:00:36.848Z"
+  "lastIssueCreatedAt": "2026-03-11T02:15:26.795Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "trivia",
-  "lastRun": "2026-03-11T01:00:38.952Z",
-  "totalIssuesCreated": 3648,
+  "lastType": "grammar",
+  "lastRun": "2026-03-11T01:15:26.516Z",
+  "totalIssuesCreated": 3649,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T01:00:38.952Z"
+  "lastIssueCreatedAt": "2026-03-11T01:15:26.516Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "proverb",
-  "lastRun": "2026-03-11T00:45:24.621Z",
-  "totalIssuesCreated": 3647,
+  "lastType": "trivia",
+  "lastRun": "2026-03-11T01:00:38.952Z",
+  "totalIssuesCreated": 3648,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-11T00:45:24.621Z"
+  "lastIssueCreatedAt": "2026-03-11T01:00:38.952Z"
 }

--- a/community/backlog/automation-state.json
+++ b/community/backlog/automation-state.json
@@ -1,7 +1,7 @@
 {
-  "lastType": "falseFriend",
-  "lastRun": "2026-03-10T23:45:28.907Z",
-  "totalIssuesCreated": 3643,
+  "lastType": "exampleSentence",
+  "lastRun": "2026-03-11T00:00:42.439Z",
+  "totalIssuesCreated": 3644,
   "consecutiveNoIssueRuns": 0,
-  "lastIssueCreatedAt": "2026-03-10T23:45:28.908Z"
+  "lastIssueCreatedAt": "2026-03-11T00:00:42.439Z"
 }

--- a/community/backlog/common-mistakes-backlog.json
+++ b/community/backlog/common-mistakes-backlog.json
@@ -436,7 +436,7 @@
     "correct": "日本へ旅行に行きたい。",
     "explanation": "Use に行く for purpose. (Pattern set 3)",
     "id": 55,
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/cultural-etiquette-backlog.json
+++ b/community/backlog/cultural-etiquette-backlog.json
@@ -77,7 +77,7 @@
     "dont": "話を遮る",
     "note": "合意形成を重視する文化。",
     "id": 9,
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/example-sentences-backlog.json
+++ b/community/backlog/example-sentences-backlog.json
@@ -510,7 +510,7 @@
     "jlpt": "N4",
     "id": 57,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "japanese": "この問題は思ったより難しくなかった。",
@@ -518,7 +518,7 @@
     "english": "This problem wasn't as hard as I expected.",
     "jlpt": "N3",
     "id": 58,
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/facts-backlog.json
+++ b/community/backlog/facts-backlog.json
@@ -416,7 +416,7 @@
   {
     "id": 70,
     "fact": "Japan has a shrine where you can pray for better Wi-Fi signal - the Kanda Myojin Shrine in Tokyo blesses electronics.",
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/false-friends-backlog.json
+++ b/community/backlog/false-friends-backlog.json
@@ -528,7 +528,7 @@
     "example": "ペットボトルは分別して捨てる。",
     "id": 59,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "termA": "アニメ (anime)",
@@ -537,7 +537,7 @@
     "example": "子どものころからアニメが好きだ。",
     "id": 60,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "termA": "手紙 (tegami)",
@@ -546,7 +546,7 @@
     "example": "祖母に手紙を書きました。",
     "id": 61,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "termA": "マンション (manshon)",
@@ -564,7 +564,7 @@
     "example": "コンセントが足りないので延長コードを使います。",
     "id": 63,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "termA": "スマート (sumaato)",
@@ -573,7 +573,7 @@
     "example": "彼はスマートな着こなしをしている。",
     "id": 64,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "termA": "テンション (tenshon)",
@@ -582,7 +582,7 @@
     "example": "ライブでテンションが上がった。",
     "id": 65,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "termA": "バイキング (baikingu)",
@@ -599,7 +599,7 @@
     "explanation": "カンニング means cheating on tests. (Set 4)",
     "example": "試験でカンニングしてはいけません。",
     "id": 67,
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/grammar-backlog.json
+++ b/community/backlog/grammar-backlog.json
@@ -296,7 +296,7 @@
   {
     "id": 50,
     "text": "\"〜わけではない\" means \"not necessarily\" or \"it's not that\".",
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/idioms-backlog.json
+++ b/community/backlog/idioms-backlog.json
@@ -347,7 +347,7 @@
     "english": "A bird leaves no mess",
     "meaning": "Leave cleanly without trouble. (Set 2)",
     "id": 39,
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/pr-authors.json
+++ b/community/backlog/pr-authors.json
@@ -358,6 +358,7 @@
     "krishna-singha",
     "Krishna-Sivakumar",
     "krishnapschauhan",
+    "Kubudak90",
     "Kushalchavan",
     "L-rrrr",
     "LaiTszKin",

--- a/community/backlog/proverbs-backlog.json
+++ b/community/backlog/proverbs-backlog.json
@@ -123,7 +123,7 @@
     "english": "Hearing a hundred times is not as good as seeing once",
     "meaning": "Seeing is believing",
     "completed": false,
-    "issued": false
+    "issued": true
   },
   {
     "id": 15,

--- a/community/backlog/proverbs-backlog.json
+++ b/community/backlog/proverbs-backlog.json
@@ -122,8 +122,10 @@
     "romaji": "Hyakubun wa ikken ni shikazu",
     "english": "Hearing a hundred times is not as good as seeing once",
     "meaning": "Seeing is believing",
-    "completed": false,
-    "issued": true
+    "completed": true,
+    "issued": false,
+    "completedBy": "Kubudak90",
+    "completedPR": 8020
   },
   {
     "id": 15,

--- a/community/backlog/regional-dialects-backlog.json
+++ b/community/backlog/regional-dialects-backlog.json
@@ -57,7 +57,7 @@
     "note": "Used for severe winter cold. (Set 1)",
     "id": 6,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "dialect": "なまら",
@@ -67,7 +67,7 @@
     "note": "Hokkaido intensifier. (Set 1)",
     "id": 7,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "dialect": "したっけ",
@@ -77,7 +77,7 @@
     "note": "Transition/goodbye phrase. (Set 1)",
     "id": 8,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "dialect": "〜ばい",
@@ -86,7 +86,7 @@
     "region": "Fukuoka",
     "note": "Assertive friendly ending. (Set 1)",
     "id": 9,
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/theme-backlog.json
+++ b/community/backlog/theme-backlog.json
@@ -1740,8 +1740,10 @@
     "backgroundColor": "oklch(20.0% 0.030 70.0 / 1)",
     "mainColor": "oklch(86.0% 0.155 85.0 / 1)",
     "secondaryColor": "oklch(75.0% 0.095 60.0 / 1)",
-    "issued": true,
-    "completed": false
+    "issued": false,
+    "completed": true,
+    "completedBy": "Kubudak90",
+    "completedPR": 8017
   },
   {
     "id": "lantern-blue",

--- a/community/backlog/theme-backlog.json
+++ b/community/backlog/theme-backlog.json
@@ -1740,7 +1740,7 @@
     "backgroundColor": "oklch(20.0% 0.030 70.0 / 1)",
     "mainColor": "oklch(86.0% 0.155 85.0 / 1)",
     "secondaryColor": "oklch(75.0% 0.095 60.0 / 1)",
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/backlog/trivia-backlog.json
+++ b/community/backlog/trivia-backlog.json
@@ -487,7 +487,7 @@
     ],
     "correctIndex": 0,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "id": 36,
@@ -501,7 +501,7 @@
     ],
     "correctIndex": 0,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "id": 37,
@@ -515,7 +515,7 @@
     ],
     "correctIndex": 0,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "id": 38,
@@ -529,7 +529,7 @@
     ],
     "correctIndex": 0,
     "completed": false,
-    "issued": false
+    "issued": true
   },
   {
     "id": 39,

--- a/community/backlog/video-game-quotes-backlog.json
+++ b/community/backlog/video-game-quotes-backlog.json
@@ -247,7 +247,7 @@
     "character": "Makoto Naegi",
     "id": 25,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "japanese": "覚悟はいいか？ 俺はできてる。",
@@ -257,7 +257,7 @@
     "character": "Giorno Giovanna",
     "id": 26,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "japanese": "仲間を信じろ",
@@ -267,7 +267,7 @@
     "character": "Recurring command voice",
     "id": 27,
     "issued": false,
-    "completed": false
+    "completed": true
   },
   {
     "japanese": "行くぞ、みんな！",
@@ -276,7 +276,7 @@
     "game": "Kingdom Hearts series (JP dub)",
     "character": "Sora",
     "id": 28,
-    "issued": false,
+    "issued": true,
     "completed": false
   },
   {

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -293,9 +293,15 @@
     "secondaryColor": "oklch(65.0% 0.125 145.0 / 1)"
   },
   {
-  "id": "morning-fog",
-  "backgroundColor": "oklch(22.0% 0.010 240.0 / 1)",
-  "mainColor": "oklch(78.0% 0.030 220.0 / 1)",
-  "secondaryColor": "oklch(65.0% 0.040 260.0 / 1)"
-}
+    "id": "morning-fog",
+    "backgroundColor": "oklch(22.0% 0.010 240.0 / 1)",
+    "mainColor": "oklch(78.0% 0.030 220.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.040 260.0 / 1)"
+  },
+  {
+    "id": "citrus-shrine",
+    "backgroundColor": "oklch(20.0% 0.030 70.0 / 1)",
+    "mainColor": "oklch(86.0% 0.155 85.0 / 1)",
+    "secondaryColor": "oklch(75.0% 0.095 60.0 / 1)"
+  }
 ]

--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -68,5 +68,10 @@
   "wrong": "私は兄さんが二人います。",
   "correct": "私は兄が二人います。",
   "explanation": "Use 兄 for your own older brother. (Pattern set 3)"
-}
+},
+  {
+    "wrong": "日本へ旅行を行きたい。",
+    "correct": "日本へ旅行に行きたい。",
+    "explanation": "Use に行く for purpose. (Pattern set 3)"
+  }
 ]

--- a/community/content/japanese-example-sentences.json
+++ b/community/content/japanese-example-sentences.json
@@ -76,5 +76,11 @@
   "romaji": "Teishutsu kigen made ni repooto o shiagenakereba naranai.",
   "english": "I must finish the report by the deadline.",
   "jlpt": "N3"
-}
+  },
+  {
+    "japanese": "雨が降ってきたので、傘を持って出かけた。",
+    "romaji": "Ame ga futte kita node, kasa o motte dekaketa.",
+    "english": "Since it started raining, I went out with an umbrella.",
+    "jlpt": "N4"
+  }
 ]

--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -82,5 +82,11 @@
     "termB": "naive (English)",
     "explanation": "Often means sensitive/delicate in Japanese. (Set 5)",
     "example": "彼は意外とナイーブな性格だ。"
+  },
+  {
+    "termA": "カンニング (kanningu)",
+    "termB": "cunning (English)",
+    "explanation": "カンニング means cheating on tests. (Set 4)",
+    "example": "試験でカンニングしてはいけません。"
   }
 ]

--- a/community/content/japanese-idioms.json
+++ b/community/content/japanese-idioms.json
@@ -76,5 +76,11 @@
   "romaji": "Kao ga hiroi",
   "english": "Wide face",
   "meaning": "Have many connections. (Set 4)"
+},
+{
+  "japanese": "立つ鳥跡を濁さず",
+  "romaji": "Tatsu tori ato o nigosazu",
+  "english": "A bird leaves no mess",
+  "meaning": "Leave cleanly without trouble. (Set 2)"
 }
 ]

--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -231,5 +231,11 @@
     "romaji": "Hari no ana kara ten wo nozoku",
     "english": "Peek at the sky through a needle's eye",
     "meaning": "A narrow viewpoint leads to poor judgment"
-}
+  },
+  {
+    "japanese": "百聞は一見に如かず",
+    "romaji": "Hyakubun wa ikken ni shikazu",
+    "english": "Hearing a hundred times is not as good as seeing once",
+    "meaning": "Seeing is believing"
+  }
 ]

--- a/data/github-metrics.json
+++ b/data/github-metrics.json
@@ -427,5 +427,16 @@
       "forks": 7,
       "contributors": 7
     }
+  },
+  {
+    "collectedAt": "2026-03-11T00:00:39.904Z",
+    "stars": 1819,
+    "forks": 1046,
+    "contributors": 768,
+    "diff": {
+      "stars": 5,
+      "forks": 8,
+      "contributors": 6
+    }
   }
 ]


### PR DESCRIPTION
This PR adds a new false friend pair as requested in issue #8027.

**Changes:**
- Added false friend pair #67: カンニング (kanningu) / cunning
- カンニング means cheating on tests (not cunning)
- Example sentence: 試験でカンニングしてはいけません。

Closes #8027