### PR TITLE
Add Grammar Point #50: 〜わけではない (not necessarily)

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -41,5 +41,6 @@
   "〜ばかり means \"just\" (in terms of time) or \"only\" depending on context. (practice variation 27)",
   "\"〜てあげる\" shows the speaker does a favor for someone else. (practice variation 17)",
   "\"〜ながらも\" means \"even while\" or \"though\" (contrast).",
-  "\"〜に加えて\" means \"in addition to...\"."
+  "\"〜に加えて\" means \"in addition to...\".",
+  "\"〜わけではない\" means \"not necessarily\" or \"it's not that\"."
 ]


### PR DESCRIPTION
This PR adds a new grammar point as requested in issue #8022.

**Changes:**
- Added Grammar Point #50: 〜わけではない
- Meaning: not necessarily / it's not that
- JLPT Level: N3

This grammar point is commonly used to soften statements or clarify that something isn't always the case.

Closes #8022