### PR TITLE
content: add new regional dialect entry

### DIFF
--- a/community/content/japanese-regional-dialects.json
+++ b/community/content/japanese-regional-dialects.json
@@ -75,5 +75,12 @@
   "english": "well then/see you",
   "region": "Hokkaido",
   "note": "Transition/goodbye phrase. (Set 6)"
+},
+{
+  "dialect": "ほんま",
+  "standardJapanese": "本当に",
+  "english": "really",
+  "region": "Kansai",
+  "note": "Very common in Osaka/Kyoto speech. (Set 5)"
 }
 ]


### PR DESCRIPTION
This PR adds the regional dialect `ほんま` to help learners understand real-world Japanese variation. Closes #8059.