### PR TITLE
chore: skip Japan fact #69, already exists

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -50,4 +50,5 @@
   "Japan has 'chiiki matsuri' — neighborhood festivals run by local committees where residents carry portable shrines together.",
   "The phrase 'ichigo ichie' (一期一会) means 'one time, one meeting' - reminding people to treasure each encounter.",
   "The Japanese word 'koi no yokan' (恋の予感) describes knowing you'll inevitably fall in love with someone you just met."
+  
 ]


### PR DESCRIPTION
Japan Fact #69 is already present in `japan-facts.json`. No changes required.

Closes #8070