### PR TITLE
Add Japanese False Friend Pair: リベンジ (ribenji) vs revenge

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -88,5 +88,11 @@
     "termB": "cunning (English)",
     "explanation": "カンニング means cheating on tests. (Set 4)",
     "example": "試験でカンニングしてはいけません。"
+  },
+  {
+    "termA": "リベンジ (ribenji)",
+    "termB": "revenge (English)",
+    "explanation": "Often used as 'try again after failing'. (Set 4)",
+    "example": "去年落ちた試験に今年リベンジする。"
   }
 ]


### PR DESCRIPTION
This PR adds False Friend Pair #68 as requested in issue #8086.

## Changes
- Added new false friend entry to `community/content/japanese-false-friends.json`

## New Entry Details
- **Term A**: リベンジ (ribenji)
- **Term B**: revenge (English)  
- **Explanation**: Often used as 'try again after failing'. (Set 4)
- **Example**: 去年落ちた試験に今年リベンジする。

## Checklist
- [x] JSON format is valid
- [x] Follows existing entry structure
- [x] Example sentence uses natural Japanese
- [x] Explanation clarifies the false friend relationship

Closes #8086