### PR TITLE
content: add new common mistake

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -78,5 +78,10 @@
     "wrong": "宿題を忘れないよう、メモします。",
     "correct": "宿題を忘れないように、メモします。",
     "explanation": "Use ように for purpose/prevention. (Pattern set 1)"
+  },
+  {
+  "wrong": "図書館に本を借りました。",
+  "correct": "図書館で本を借りました。",
+  "explanation": "で marks location of action. (Pattern set 2)"
   }
 ]


### PR DESCRIPTION
## 📝 Description

Adds a new Japanese learner mistake entry to `community/content/japanese-common-mistakes.json`.

## 🔗 Related Issue

Closes #8110

## 🎯 Type of Change

* [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Added the new common mistake entry to `japanese-common-mistakes.json`.
2. Verified the JSON structure remains valid and correctly formatted.

## 📸 Screenshots/Videos (if applicable)

N/A

## ✅ Pre-Submission Checklist

* [x] My commit messages follow the Conventional Commits format.
* [x] This PR is against the `main` branch.

## 📦 Additional Context

This change adds a common learner mistake involving the incorrect use of the particle **に** instead of **で** when describing the location of an action.
