### PR TITLE
feat(theme): add Papercraft White theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -270,7 +270,7 @@
     "secondaryColor": "oklch(58.0% 0.060 260.0 / 1)"
   },
   {
-    "id": "ocean-blue",
+  "id": "ocean-blue",
   "backgroundColor": "oklch(0.0% 0.0 0 / 1)", 
   "mainColor": "oklch(40.0% 0.050 210.0 / 1)",
   "secondaryColor": "oklch(30.0% 0.030 190.0 / 1)"
@@ -334,5 +334,11 @@
   "backgroundColor": "oklch(19.0% 0.055 165.0 / 1)",
   "mainColor": "oklch(68.0% 0.175 160.0 / 1)",
   "secondaryColor": "oklch(78.0% 0.145 140.0 / 1)"
+  },
+  {
+  "id": "papercraft-white",
+  "backgroundColor": "oklch(98.0% 0.005 90.0 / 1)",
+  "mainColor": "oklch(35.0% 0.165 255.0 / 1)",
+  "secondaryColor": "oklch(55.0% 0.145 200.0 / 1)"
   }
 ]


### PR DESCRIPTION
Closes #8153

## 📝 Description

Added a new color theme "Papercraft White" to KanaDojo.  
This theme provides a clean, bright aesthetic with soft main and secondary colors for improved readability and user experience.

## 🔗 Related Issue

Closes #8153

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Opened the KanaDojo web app in the browser.
2. Applied the "Papercraft White" theme via the theme selector.
3. Verified background, main, and secondary colors render correctly across all interface components.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Verified theme displays correctly in light and dark interface elements (where applicable)

## 📸 Screenshots/Videos (if applicable)

_N/A – purely color/theme update_

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

This theme complements the existing "Papercraft" aesthetic set and is designed to provide a bright, minimal, and clean interface for learners.
