### PR TITLE
feat(theme): add Plum Blossom theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -346,5 +346,11 @@
     "backgroundColor": "oklch(22.0% 0.035 240.0 / 1)",
     "mainColor": "oklch(90.0% 0.085 220.0 / 1)",
     "secondaryColor": "oklch(65.0% 0.185 25.0 / 1)"
-  }
+  }, 
+  {
+  id: 'plum-blossom',
+  backgroundColor: 'oklch(23.0% 0.042 340.0 / 1)',
+  mainColor: 'oklch(78.0% 0.165 350.0 / 1)',
+  secondaryColor: 'oklch(88.0% 0.095 85.0 / 1)'
+  },
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -348,9 +348,9 @@
     "secondaryColor": "oklch(65.0% 0.185 25.0 / 1)"
   }, 
   {
-  id: 'plum-blossom',
-  backgroundColor: 'oklch(23.0% 0.042 340.0 / 1)',
-  mainColor: 'oklch(78.0% 0.165 350.0 / 1)',
-  secondaryColor: 'oklch(88.0% 0.095 85.0 / 1)'
-  },
+  "id": "plum-blossom",
+  "backgroundColor": "oklch(23.0% 0.042 340.0 / 1)",
+  "mainColor": "oklch(78.0% 0.165 350.0 / 1)",
+  "secondaryColor": "oklch(88.0% 0.095 85.0 / 1)"
+  }
 ]


### PR DESCRIPTION
Closes #8252

## 📝 Description

Added a new color theme **Plum Blossom** to KanaDojo. This theme reflects early spring ume flowers in soft pink and enhances the community themes available for users.  

## 🔗 Related Issue

Closes #8252

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Verified that `community-themes.json` parses correctly in a JSON linter.
2. Applied the theme in the local development build to confirm colors render as expected.

**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)

## 📸 Screenshots/Videos (if applicable)

N/A — Theme added via JSON, no visual screenshots required.

## ✅ Pre-Submission Checklist

- [x] My code follows the project's code style and uses `cn()` utility where needed.
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] I have updated the documentation (if applicable).
- [x] This PR is against the `main` branch.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

This theme addition completes the Plum Blossom community contribution and is ready for review.
