### PR TITLE
content: add learner mistake #8298

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -80,14 +80,14 @@
     "explanation": "Use ように for purpose/prevention. (Pattern set 1)"
   },
   {
-  "wrong": "図書館に本を借りました。",
-  "correct": "図書館で本を借りました。",
-  "explanation": "で marks location of action. (Pattern set 2)"
+    "wrong": "図書館に本を借りました。",
+    "correct": "図書館で本を借りました。",
+    "explanation": "で marks location of action. (Pattern set 2)"
   },
   {
-  "wrong": "この漢字は読み方が難しいです。",
-  "correct": "この漢字の読み方は難しいです。",
-  "explanation": "Prefer noun linkage with の. (Pattern set 5)"
+    "wrong": "この漢字は読み方が難しいです。",
+    "correct": "この漢字の読み方は難しいです。",
+    "explanation": "Prefer noun linkage with の. (Pattern set 5)"
   },
   {
     "wrong": "静かい部屋",
@@ -95,13 +95,18 @@
     "explanation": "な-adjectives require な before nouns. (Pattern set 4)"
   },
   {
-  "wrong": "駅まで十分歩きますかかる。",
-  "correct": "駅まで歩いて十分かかる。",
-  "explanation": "Use natural collocation and order. (Pattern set 3)"
+    "wrong": "駅まで十分歩きますかかる。",
+    "correct": "駅まで歩いて十分かかる。",
+    "explanation": "Use natural collocation and order. (Pattern set 3)"
   },
   {
-  "wrong": "東京は人が多いです、きれいです。",
-  "correct": "東京は人が多くて、きれいです。",
-  "explanation": "Use て-form to connect clauses. (Pattern set 2)"
+    "wrong": "東京は人が多いです、きれいです。",
+    "correct": "東京は人が多くて、きれいです。",
+    "explanation": "Use て-form to connect clauses. (Pattern set 2)"
+  },
+  {
+    "wrong": "先生は私を日本語を教えました。",
+    "correct": "先生は私に日本語を教えました。",
+    "explanation": "Recipient takes に with 教える. (Pattern set 3)"
   }
 ]


### PR DESCRIPTION
Closes #8298. Adds a common Japanese learner mistake entry to the database regarding the use of に vs を with 教える.