### PR TITLE
Add Japan Fact 217 - Deserted Train Stations

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -59,5 +59,6 @@
   "Japan has a highway that passes directly through a building in Osaka - the Gate Tower Building has floors 5-7 as a tunnel.",
   "Japan has 'kominka' farmhouses that are renovated into cafes, inns, and galleries while keeping original beams and hearths.",
   "The Japanese term 'shuudan ishiki' (集団意識) refers to strong group consciousness — prioritizing harmony within the group.",
-  "The word 'yuigahama' appears in coastal place names, referencing a long, gently sloping beach."
+  "The word 'yuigahama' appears in coastal place names, referencing a long, gently sloping beach.",
+  "Japan has 'deserted train stations' (eeritsu teisha) across rural areas - once vital community hubs now preserved as time capsules of Showa-era Japan."
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -58,6 +58,6 @@
   "The word 'shiawase' (幸せ) for happiness originally meant 'what happens' - suggesting happiness is accepting what comes.",
   "Japan has a highway that passes directly through a building in Osaka - the Gate Tower Building has floors 5-7 as a tunnel.",
   "Japan has 'kominka' farmhouses that are renovated into cafes, inns, and galleries while keeping original beams and hearths.",
-  "The Japanese term 'shuudan ishiki' (集団意識) refers to strong group consciousness — prioritizing harmony within the group."
+  "The Japanese term 'shuudan ishiki' (集団意識) refers to strong group consciousness — prioritizing harmony within the group.",
   "The word 'yuigahama' appears in coastal place names, referencing a long, gently sloping beach."
 ]


### PR DESCRIPTION
hey, i noticed there was a json syntax error (missing comma on line 62) and also added the new japan fact #217 about deserted train stations. the fact talks about eeritsu teisha - these abandoned rural stations that are basically time capsules of showa-era japan. let me know if you need any changes!