### PR TITLE
fix: [Good First Issue] 🍥 Add new Japan Fact 87 - Beginner-Friendly

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -73,6 +73,6 @@
   "Japan’s 'omotenashi' culture emphasizes thoughtful hospitality and anticipating guests’ needs.",
   "Japan’s 'shrine stamps' called 'goshuin' (御朱印) are calligraphy seals collected in special books by visitors.",
   "Japan has robots that serve as Buddhist priests conducting funeral ceremonies - complete with chanting and prayer beads.",
-  "The Japanese word 'yūgen' (幽玄) describes a profound awareness of the universe that triggers emotional responses too deep for words."
-  
+  "The Japanese word 'yūgen' (幽玄) describes a profound awareness of the universe that triggers emotional responses too deep for words.",
+  "There's a Japanese word 'dokkiri' (ドッキリ) for the heart-pounding shock of surprise - now the name of prank TV shows."
 ]


### PR DESCRIPTION
Fixes #8807

Adds fact entry 87 to `community/content/japan-facts.json`. The array was missing a trailing comma after the final element, which prevented appending new entries cleanly. Corrects the comma on the `yūgen` entry and appends the new `dokkiri` (ドッキリ) fact in the same change. Verified by inspecting the JSON array structure in `japan-facts.json` for valid syntax and consistent style with surrounding entries.