### PR TITLE
fix: [Good First Issue] 🀄 Add new Japan Fact 290 - Beginner-Friendly

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -76,6 +76,7 @@
   "Japan’s 'shrine stamps' called 'goshuin' (御朱印) are calligraphy seals collected in special books by visitors.",
   "Japan has robots that serve as Buddhist priests conducting funeral ceremonies - complete with chanting and prayer beads.",
   "The Japanese word 'yūgen' (幽玄) describes a profound awareness of the universe that triggers emotional responses too deep for words.",
-  "There's a Japanese word 'dokkiri' (ドッキリ) for the heart-pounding shock of surprise - now the name of prank TV shows."
+  "There's a Japanese word 'dokkiri' (ドッキリ) for the heart-pounding shock of surprise - now the name of prank TV shows.",
+  "The term 'kigatsuku' (気がつく) means to notice or realize, and is often associated with considerate awareness."
 
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -77,6 +77,6 @@
   "Japan has robots that serve as Buddhist priests conducting funeral ceremonies - complete with chanting and prayer beads.",
   "The Japanese word 'yūgen' (幽玄) describes a profound awareness of the universe that triggers emotional responses too deep for words.",
   "There's a Japanese word 'dokkiri' (ドッキリ) for the heart-pounding shock of surprise - now the name of prank TV shows.",
-  "The term 'kigatsuku' (気がつく) means to notice or realize, and is often associated with considerate awareness."
+  "The Japanese word 'kigatsuku' (気がつく) describes the ability to notice what others need before being asked - a quietly admired trait in daily life."
 
 ]


### PR DESCRIPTION
Fixes #8855

Adds Japan fact #290 to `community/content/japan-facts.json`. The initial entry for `kigatsuku` (気がつく) read as a dry dictionary definition, mismatching the vivid, culturally contextual tone of surrounding entries. Rewrote the fact to describe the concept with cultural insight, consistent with the style of other entries in the collection. Verified by review consensus pass.