### PR TITLE
fix: [Good First Issue] 🌸 Add new Japan Fact 236 - Beginner-Friendly

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -78,5 +78,6 @@
   "The Japanese word 'yūgen' (幽玄) describes a profound awareness of the universe that triggers emotional responses too deep for words.",
   "There's a Japanese word 'dokkiri' (ドッキリ) for the heart-pounding shock of surprise - now the name of prank TV shows.",
   "The Japanese word 'kigatsuku' (気がつく) describes the ability to notice what others need before being asked - a quietly admired trait in daily life.",
-  "Japan’s 'ekiben' (駅弁) are region-specific boxed lunches sold at train stations, often showcasing local ingredients and specialties."
+  "Japan's 'ekiben' (駅弁) are region-specific boxed lunches sold at train stations, often showcasing local ingredients and specialties.",
+  "The concept of 'yoin' (余韻) refers to the lingering aftertaste or feeling, and is used for everything from tea to music performances."
 ]


### PR DESCRIPTION
Fixes #8888

Adds fact #236 to `community/content/japan-facts.json` about the Japanese concept of 'yoin' (余韻). The file was missing a trailing comma on the previous last entry, which has been corrected as part of appending the new entry. No logic changes -- purely a data addition to the facts array.