### PR TITLE
feat(theme): add Hanami Picnic theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -501,8 +501,7 @@
   "id": "harajuku-pop",
   "backgroundColor": "oklch(96.0% 0.025 85.0 / 1)",
   "mainColor": "oklch(72.0% 0.225 320.0 / 1)",
-  "secondaryColor": "oklch(80.0% 0.195 200.0 / 1)",
-},
+  "secondaryColor": "oklch(80.0% 0.195 200.0 / 1)"},
 {
   "id": "lucky-bamboo",
   "backgroundColor": "oklch(92.0% 0.025 145.0 / 1)",
@@ -551,4 +550,10 @@
   "mainColor": "oklch(85.0% 0.155 85.0 / 1)",
   "secondaryColor": "oklch(60.0% 0.085 25.0 / 1)"
 },
+  {
+    "id": "hanami-picnic",
+    "backgroundColor": "oklch(96.0% 0.018 20.0 / 1)",
+    "mainColor": "oklch(70.0% 0.165 350.0 / 1)",
+    "secondaryColor": "oklch(78.0% 0.120 135.0 / 1)"
+  }
 ]


### PR DESCRIPTION
Hey! I noticed the previous PR (#9054) had a JSON formatting issue - should be all fixed now.

### Theme Details
- **ID:** hanami-picnic
- **Background:** oklch(96.0% 0.018 20.0 / 1)
- **Main Color:** oklch(70.0% 0.165 350.0 / 1)
- **Secondary:** oklch(78.0% 0.120 135.0 / 1)

Closes #9039