### PR TITLE
fix: prevent next-answer flash in result bar

### DIFF
--- a/shared/components/Game/GameBottomBar.tsx
+++ b/shared/components/Game/GameBottomBar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import {
   CircleCheck,
   CircleX,
@@ -54,6 +54,19 @@ export const GameBottomBar = ({
       : '';
   const displayTitle = feedbackTitle || defaultTitle;
 
+  // Keep feedback tied to the most recently checked question.
+  // This prevents the next question's answer from flashing during transition.
+  const [frozenTitle, setFrozenTitle] = useState(displayTitle);
+  const [frozenFeedbackContent, setFrozenFeedbackContent] =
+    useState<ReactNode>(feedbackContent);
+
+  useEffect(() => {
+    if (state !== 'check') {
+      setFrozenTitle(displayTitle);
+      setFrozenFeedbackContent(feedbackContent);
+    }
+  }, [state, displayTitle, feedbackContent]);
+
   return (
     <div
       className={clsx(
@@ -87,10 +100,10 @@ export const GameBottomBar = ({
           )}
           <div className='flex flex-col'>
             <span className='text-lg text-(--secondary-color) sm:text-xl'>
-              {displayTitle}
+              {frozenTitle}
             </span>
             <span className='text-sm text-(--main-color) sm:text-lg'>
-              {feedbackContent}
+              {frozenFeedbackContent}
             </span>
           </div>
         </div>


### PR DESCRIPTION
## Problem
On correct answers, the bottom result bar can briefly show feedback from the next question during transition after clicking Next.

## Root Cause
GameBottomBar reads eedbackTitle and eedbackContent directly from live parent props. During state transition, parent question state may advance before the feedback animation fully settles, causing a transient mismatch and answer flash.

## Fix
- Added local frozen feedback state in GameBottomBar.
- Feedback title/content are now snapshotted when state is correct or wrong.
- Snapshot is only refreshed on result states, not while in check state.

## Validation
### Manual
- Reproduced baseline behavior before patch.
- Verified no next-answer flash after patch in localhost with repeated rapid Next transitions.
- Captured before/after recordings for evidence.

### Automated
- Targeted lint passed for changed file:
  - 
px eslint shared/components/Game/GameBottomBar.tsx
- Full repository check/test contains pre-existing unrelated failures in current upstream baseline.

## Risk
Low. Change is isolated to feedback rendering behavior in shared bottom bar, and preserves existing action logic.

Closes #9169