### PR TITLE
test(game): add regression for bottom-bar transition flash

### DIFF
--- a/shared/components/Game/GameBottomBar.test.tsx
+++ b/shared/components/Game/GameBottomBar.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { GameBottomBar } from '@/shared/components/Game/GameBottomBar';
+
+describe('GameBottomBar feedback freezing', () => {
+  it('keeps last checked feedback while transitioning through check state', () => {
+    const onAction = vi.fn();
+    const { rerender } = render(
+      <GameBottomBar
+        state='correct'
+        onAction={onAction}
+        canCheck
+        feedbackContent='answer-a'
+      />,
+    );
+
+    expect(screen.getByText('answer-a')).toBeTruthy();
+
+    rerender(
+      <GameBottomBar
+        state='check'
+        onAction={onAction}
+        canCheck
+        feedbackContent='answer-b'
+      />,
+    );
+
+    expect(screen.getByText('answer-a')).toBeTruthy();
+    expect(screen.queryByText('answer-b')).toBeNull();
+
+    rerender(
+      <GameBottomBar
+        state='correct'
+        onAction={onAction}
+        canCheck
+        feedbackContent='answer-b'
+      />,
+    );
+
+    expect(screen.getByText('answer-b')).toBeTruthy();
+  });
+});

--- a/shared/components/Game/GameBottomBar.tsx
+++ b/shared/components/Game/GameBottomBar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import {
   CircleCheck,
   CircleX,


### PR DESCRIPTION
## Summary\n- add focused regression test for GameBottomBar transition behavior\n- verifies feedback content stays tied to last checked question while state passes through check\n\n## Why\nPR #9308 fixed issue #9169, but lacked automated coverage for the race/flash scenario. This PR prevents regressions without changing product behavior.\n\n## Validation\n- 
px vitest run shared/components/Game/GameBottomBar.test.tsx\n\nRelated: #9169