### PR TITLE
revert: restore zero-diff after PR #9581

### DIFF
--- a/data/etiquetteTips.json
+++ b/data/etiquetteTips.json
@@ -1,8 +1,0 @@
-[
-  {
-    "id": 10,
-    "text": "Avoid talking loudly on public transportation in Japan.",
-    "translation": "Tránh nói chuyện lớn tiếng trên phương tiện công cộng ở Nhật.",
-    "romaji": ""
-  }
-]


### PR DESCRIPTION
Revert the merged changes from PR #9581 so the repository returns to its previous state while preserving contributor credit for the original PR.