### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -9,6 +9,12 @@
     "japanese": "見るは法楽",
     "romaji": "Miru wa houraku",
     "english": "Just watching is a pleasure",
+  },
+  {
+    "japanese": "月とすっぽん",
+    "romaji": "Tsuki to suppon",
+    "english": "The moon and a turtle",
+    "meaning": "Vastly different; not comparable"
     "meaning": "Enjoy observing; you don't always need to participate"
   },
   {

--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -9,13 +9,13 @@
     "japanese": "見るは法楽",
     "romaji": "Miru wa houraku",
     "english": "Just watching is a pleasure",
+    "meaning": "Enjoy observing; you don't always need to participate"
   },
   {
     "japanese": "月とすっぽん",
     "romaji": "Tsuki to suppon",
     "english": "The moon and a turtle",
     "meaning": "Vastly different; not comparable"
-    "meaning": "Enjoy observing; you don't always need to participate"
   },
   {
     "japanese": "猫に鰹節",


### PR DESCRIPTION
## Problem
Issue #9601 requests adding a new Japanese proverb entry in the community content dataset.

## Root Cause
The requested proverb object was missing from the JSON array used by the community contribution content.

## Solution
Added the proverb object in community/content/japanese-proverbs.json with japanese, romaji, english, and meaning fields.

## Validation
- Verified JSON parses successfully.
- Confirmed net diff adds only the requested proverb entry.

## Related Issues
Closes #9601