### PR TITLE
feat(theme): add Akihabara Glow theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -522,51 +522,57 @@
     "secondaryColor": "oklch(55.0% 0.100 120.0 / 1)"
   },
   {
-  "id": "ruby-kabuki",
-  "backgroundColor": "oklch(16.0% 0.040 20.0 / 1)",
-  "mainColor": "oklch(70.0% 0.215 25.0 / 1)",
-  "secondaryColor": "oklch(85.0% 0.055 95.0 / 1)"
+    "id": "ruby-kabuki",
+    "backgroundColor": "oklch(16.0% 0.040 20.0 / 1)",
+    "mainColor": "oklch(70.0% 0.215 25.0 / 1)",
+    "secondaryColor": "oklch(85.0% 0.055 95.0 / 1)"
   },
   {
-  "id": "vending-glow",
-  "backgroundColor": "oklch(16.0% 0.025 280.0 / 1)",
-  "mainColor": "oklch(85.0% 0.125 220.0 / 1)",
-  "secondaryColor": "oklch(78.0% 0.165 45.0 / 1)"
+    "id": "vending-glow",
+    "backgroundColor": "oklch(16.0% 0.025 280.0 / 1)",
+    "mainColor": "oklch(85.0% 0.125 220.0 / 1)",
+    "secondaryColor": "oklch(78.0% 0.165 45.0 / 1)"
   },
   {
-  "id": "school-uniform",
-  "backgroundColor": "oklch(92.0% 0.015 250.0 / 1)",
-  "mainColor": "oklch(40.0% 0.145 255.0 / 1)",
-  "secondaryColor": "oklch(60.0% 0.175 20.0 / 1)"
+    "id": "school-uniform",
+    "backgroundColor": "oklch(92.0% 0.015 250.0 / 1)",
+    "mainColor": "oklch(40.0% 0.145 255.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.175 20.0 / 1)"
   },
   {
-  "id": "plum-ink",
-  "backgroundColor": "oklch(16.0% 0.030 280.0 / 1)",
-  "mainColor": "oklch(72.0% 0.145 330.0 / 1)",
-  "secondaryColor": "oklch(60.0% 0.075 260.0 / 1)"
+    "id": "plum-ink",
+    "backgroundColor": "oklch(16.0% 0.030 280.0 / 1)",
+    "mainColor": "oklch(72.0% 0.145 330.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.075 260.0 / 1)"
   },
   {
-  "id": "mountain-cedar",
-  "backgroundColor": "oklch(20.0% 0.020 150.0 / 1)",
-  "mainColor": "oklch(70.0% 0.105 145.0 / 1)",
-  "secondaryColor": "oklch(60.0% 0.055 110.0 / 1)"
+    "id": "mountain-cedar",
+    "backgroundColor": "oklch(20.0% 0.020 150.0 / 1)",
+    "mainColor": "oklch(70.0% 0.105 145.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.055 110.0 / 1)"
   },
   {
-  "id": "ginkgo-gold",
-  "backgroundColor": "oklch(23.0% 0.045 85.0 / 1)",
-  "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
-  "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
+    "id": "ginkgo-gold",
+    "backgroundColor": "oklch(23.0% 0.045 85.0 / 1)",
+    "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
+    "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
   },
   {
-  "id": "kendo-strike",
-  "backgroundColor": "oklch(16.0% 0.028 265.0 / 1)",
-  "mainColor": "oklch(65.0% 0.025 270.0 / 1)",
-  "secondaryColor": "oklch(72.0% 0.165 25.0 / 1)"
+    "id": "kendo-strike",
+    "backgroundColor": "oklch(16.0% 0.028 265.0 / 1)",
+    "mainColor": "oklch(65.0% 0.025 270.0 / 1)",
+    "secondaryColor": "oklch(72.0% 0.165 25.0 / 1)"
   },
   {
-  "id": "pearl-wave",
-  "backgroundColor": "oklch(21.0% 0.045 235.0 / 1)",
-  "mainColor": "oklch(88.0% 0.055 245.0 / 1)",
-  "secondaryColor": "oklch(68.0% 0.165 215.0 / 1)"
+    "id": "pearl-wave",
+    "backgroundColor": "oklch(21.0% 0.045 235.0 / 1)",
+    "mainColor": "oklch(88.0% 0.055 245.0 / 1)",
+    "secondaryColor": "oklch(68.0% 0.165 215.0 / 1)"
+  },
+  {
+    "id": "akihabara-glow",
+    "backgroundColor": "oklch(15.0% 0.065 300.0 / 1)",
+    "mainColor": "oklch(80.0% 0.210 180.0 / 1)",
+    "secondaryColor": "oklch(85.0% 0.190 320.0 / 1)"
   }
 ]


### PR DESCRIPTION
## 📝 Description
Add new theme "Akihabara Glow" inspired by the vibrant electric town.

Theme colors:
- Background: Deep purple (oklch(15.0% 0.065 300.0))
- Main: Bright cyan (oklch(80.0% 0.210 180.0))
- Secondary: Pink/magenta (oklch(85.0% 0.190 320.0))

## 🔗 Related Issue
Closes #9696

## 🎯 Type of Change
- [x] `content`: Content update

## ✅ Pre-Submission Checklist
- [x] My commit messages follow the Conventional Commits format.
- [x] This PR is against the `main` branch.