### PR TITLE
content: add new trivia question

### DIFF
--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -2,67 +2,37 @@
   {
     "question": "Which Japanese city is known for its historic wooden district, Gion? (Community variation 29)",
     "difficulty": "hard",
-    "answers": [
-      "Kyoto",
-      "Yokohama",
-      "Nagoya",
-      "Sendai"
-    ],
+    "answers": ["Kyoto", "Yokohama", "Nagoya", "Sendai"],
     "correctIndex": 0
   },
   {
     "question": "Which Japanese island chain is known for tropical beaches and coral reefs? (Community variation 27)",
     "difficulty": "hard",
-    "answers": [
-      "Okinawa",
-      "Sado",
-      "Awaji",
-      "Oki"
-    ],
+    "answers": ["Okinawa", "Sado", "Awaji", "Oki"],
     "correctIndex": 0
   },
   {
     "question": "Which Japanese island is known for the UNESCO site Shirakami-Sanchi?",
     "difficulty": "hard",
-    "answers": [
-      "Honshu",
-      "Hokkaido",
-      "Shikoku",
-      "Kyushu"
-    ],
+    "answers": ["Honshu", "Hokkaido", "Shikoku", "Kyushu"],
     "correctIndex": 0
   },
   {
     "question": "Which Japanese city is famous for its street food district, Dotonbori? (Community variation 22)",
     "difficulty": "hard",
-    "answers": [
-      "Osaka",
-      "Niigata",
-      "Kagoshima",
-      "Takayama"
-    ],
+    "answers": ["Osaka", "Niigata", "Kagoshima", "Takayama"],
     "correctIndex": 0
   },
   {
     "question": "What is the name of the traditional Japanese board game similar to chess? (Community variation 25)",
     "difficulty": "hard",
-    "answers": [
-      "Shogi",
-      "Go",
-      "Mahjong",
-      "Reversi"
-    ],
+    "answers": ["Shogi", "Go", "Mahjong", "Reversi"],
     "correctIndex": 0
   },
   {
     "question": "What is the name of the Japanese comic and animation style?",
     "difficulty": "hard",
-    "answers": [
-      "Manga",
-      "Donghua",
-      "Manhwa",
-      "Comique"
-    ],
+    "answers": ["Manga", "Donghua", "Manhwa", "Comique"],
     "correctIndex": 0
   },
   {
@@ -79,45 +49,36 @@
   {
     "question": "Which Japanese city hosted the 1998 Winter Olympics?",
     "difficulty": "hard",
-    "answers": [
-      "Nagano",
-      "Kobe",
-      "Hiroshima",
-      "Naha"
-    ],
+    "answers": ["Nagano", "Kobe", "Hiroshima", "Naha"],
     "correctIndex": 0
   },
   {
-  "question": "What is the name of Japan's national currency?",
-  "difficulty": "hard",
-  "answers": [
-    "Yuan",
-    "Yen",
-    "Won",
-    "Rupee"
-  ],
-  "correctIndex": 1
+    "question": "What is the name of Japan's national currency?",
+    "difficulty": "hard",
+    "answers": ["Yuan", "Yen", "Won", "Rupee"],
+    "correctIndex": 1
   },
   {
-  "question": "Which Japanese island is known for its active volcano, Sakurajima? (Community variation 45)",
-  "difficulty": "hard",
-  "answers": [
-    "Kyushu",
-    "Honshu",
-    "Shikoku",
-    "Hokkaido"
-  ],
-  "correctIndex": 0
-},
+    "question": "Which Japanese island is known for its active volcano, Sakurajima? (Community variation 45)",
+    "difficulty": "hard",
+    "answers": ["Kyushu", "Honshu", "Shikoku", "Hokkaido"],
+    "correctIndex": 0
+  },
   {
-  "question": "What is the Japanese name for the autumn moon-viewing festival? (Community variation 28)",
-  "difficulty": "hard",
-  "answers": [
-    "Tanabata",
-    "Tsukimi",
-    "Shogatsu",
-    "Hina Matsuri"
-  ],
-  "correctIndex": 1
-}
+    "question": "What is the Japanese name for the autumn moon-viewing festival? (Community variation 28)",
+    "difficulty": "hard",
+    "answers": ["Tanabata", "Tsukimi", "Shogatsu", "Hina Matsuri"],
+    "correctIndex": 1
+  },
+  {
+    "question": "Which sea separates Japan from the Korean Peninsula? (Community variation 47)",
+    "difficulty": "hard",
+    "answers": [
+      "Sea of Japan",
+      "East China Sea",
+      "Philippine Sea",
+      "Bering Sea"
+    ],
+    "correctIndex": 0
+  }
 ]


### PR DESCRIPTION
## 📝 Description
Add new trivia question #127 about the sea separating Japan from the Korean Peninsula.

### Question Details
- **Question:** Which sea separates Japan from the Korean Peninsula? (Community variation 47)
- **Difficulty:** hard
- **Answers:** Sea of Japan, East China Sea, Philippine Sea, Bering Sea
- **Correct Answer:** Sea of Japan (index 0)

## 🔗 Related Issue
Closes #9691

## 🎯 Type of Change
- [x] `content`: Content update

## ✅ Pre-Submission Checklist
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] This PR is against the `main` branch.