### PR TITLE
feat(theme): add Bamboo Mist theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -582,9 +582,15 @@
     "secondaryColor": "oklch(40.0% 0.110 250.0 / 1)"
   },
   {
-  "id": "konbini-light",
-  "backgroundColor": "oklch(96.0% 0.015 210.0 / 1)",
-  "mainColor": "oklch(55.0% 0.185 200.0 / 1)",
-  "secondaryColor": "oklch(60.0% 0.155 25.0 / 1)"
-}
+    "id": "konbini-light",
+    "backgroundColor": "oklch(96.0% 0.015 210.0 / 1)",
+    "mainColor": "oklch(55.0% 0.185 200.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.155 25.0 / 1)"
+  },
+  {
+    "id": "bamboo-mist",
+    "backgroundColor": "oklch(24.0% 0.032 150.0 / 1)",
+    "mainColor": "oklch(78.0% 0.145 145.0 / 1)",
+    "secondaryColor": "oklch(68.0% 0.085 130.0 / 1)"
+  }
 ]


### PR DESCRIPTION
## 📝 Description
Add new theme "Bamboo Mist" inspired by morning fog drifting through a bamboo forest.

### Theme Details
- **ID:** bamboo-mist
- **Background:** oklch(24.0% 0.032 150.0 / 1) - Deep bamboo green
- **Main Color:** oklch(78.0% 0.145 145.0 / 1) - Fresh bamboo shoot green
- **Secondary Color:** oklch(68.0% 0.085 130.0 / 1) - Misty forest green

## 🔗 Related Issue
Closes #9740

## 🎯 Type of Change
- [x] `content`: Content update

## ✅ Pre-Submission Checklist
- [x] My commit messages follow the Conventional Commits format
- [x] This PR is against the `main` branch