### PR TITLE
Update community-themes.json

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -641,22 +641,29 @@
     "mainColor": "oklch(80.0% 0.085 200.0 / 1)",
     "secondaryColor": "oklch(68.0% 0.105 160.0 / 1)"
   },
-  {
-  id: 'sumi-coal',
-  backgroundColor: 'oklch(13.0% 0.015 260.0 / 1)',
-  mainColor: 'oklch(68.0% 0.035 220.0 / 1)',
-  secondaryColor: 'oklch(45.0% 0.025 260.0 / 1)'
+   {
+    "id": "sumi-coal",
+    "backgroundColor": "oklch(13.0% 0.015 260.0 / 1)",
+    "mainColor": "oklch(68.0% 0.035 220.0 / 1)",
+    "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
   },
   {
-  id: 'riverstone-gray',
-  backgroundColor: 'oklch(20.0% 0.010 260.0 / 1)',
-  mainColor: 'oklch(78.0% 0.020 90.0 / 1)',
-  secondaryColor: 'oklch(55.0% 0.035 240.0 / 1)'
- },
+    "id": "riverstone-gray",
+    "backgroundColor": "oklch(20.0% 0.010 260.0 / 1)",
+    "mainColor": "oklch(78.0% 0.020 90.0 / 1)",
+    "secondaryColor": "oklch(55.0% 0.035 240.0 / 1)"
+  },
   {
-  id: 'neon-arcade',
-  backgroundColor: 'oklch(13.0% 0.055 300.0 / 1)',
-  mainColor: 'oklch(78.0% 0.220 330.0 / 1)',
-  secondaryColor: 'oklch(82.0% 0.185 190.0 / 1)'
-}
+    "id": "neon-arcade",
+    "backgroundColor": "oklch(13.0% 0.055 300.0 / 1)",
+    "mainColor": "oklch(78.0% 0.220 330.0 / 1)",
+    "secondaryColor": "oklch(82.0% 0.185 190.0 / 1)"
+  },
+  {
+    "id": "yuzu-mist",
+    "backgroundColor": "oklch(92.0% 0.025 95.0 / 1)",
+    "mainColor": "oklch(70.0% 0.145 85.0 / 1)",
+    "secondaryColor": "oklch(62.0% 0.090 70.0 / 1)"
+  }
+]
 ]


### PR DESCRIPTION
add Yuzu Mist theme, closes #9769

## 📝 Description

Adds a new color theme, `Yuzu Mist`, to `community-themes.json` and fixes invalid JSON formatting in the affected theme entries at the bottom of the file.

## 🔗 Related Issue

Closes #9769

## 🎯 Type of Change

- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `docs`: Documentation update
- [x] `content`: Content update
- [ ] `style`: UI/Theme changes
- [ ] `refactor`: Code refactor
- [ ] `test`: Test update
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Opened `community/content/community-themes.json`
2. Fixed invalid JSON syntax in the trailing theme entries
3. Added the `yuzu-mist` theme object
4. Verified the JSON structure is valid

## 📸 Screenshots/Videos (if applicable)

N/A — JSON/theme data update

## ✅ Pre-Submission Checklist

- [x] My commit messages follow the Conventional Commits format.
- [x] This PR is against the `main` branch.

## 📦 Additional Context

Added:

```json
{
  "id": "yuzu-mist",
  "backgroundColor": "oklch(92.0% 0.025 95.0 / 1)",
  "mainColor": "oklch(70.0% 0.145 85.0 / 1)",
  "secondaryColor": "oklch(62.0% 0.090 70.0 / 1)"
}