### PR TITLE
Update japanese-grammar.json

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -78,5 +78,6 @@
   "\"〜ことになる\" indicates something was decided (by others or circumstances).",
   "\"〜おう/〜よう\" is the volitional form, used to say \"let's\" or \"I will\".",
   "\"〜ても\" means \"even if\" or \"even though\". (practice variation 22)",
-  "\"〜ものの\" means \"although...\" with contrast."
+  "\"〜ものの\" means \"although...\" with contrast.",
+  "\"〜ばかり\" means \"just\" (in terms of time) or \"only\" depending on context. (practice variation 27)"
 ]


### PR DESCRIPTION
content: add new grammar point

## 📝 Description

Adds a new grammar point to `japanese-grammar.json`.

This entry explains the usage of 「〜ばかり」, which can mean "just" (in terms of time) or "only" depending on context.

## 🔗 Related Issue

Closes #9994 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Opened `community/content/japanese-grammar.json`
2. Added the new grammar string at the end of the array
3. Escaped inner quotation marks properly
4. Verified JSON structure is valid

**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] JSON structure validated and loads correctly

## 📸 Screenshots/Videos (if applicable)

N/A — content-only update

## ✅ Pre-Submission Checklist

- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
- [x] This PR is against the `main` branch.

## 📦 Additional Context

Added:

```json
"〜ばかり means \"just\" (in terms of time) or \"only\" depending on context. (practice variation 27)"