### PR TITLE
fix(docs): correct GitHub repository URL

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,7 +29,7 @@ This file provides comprehensive guidance for AI coding assistants (GitHub Copil
 | i18n      | next-intl (namespace-based)              |
 | Testing   | Vitest with jsdom                        |
 
-**URLs**: [kanadojo.com](https://kanadojo.com) · [GitHub](https://github.com/lingdojo/kanadojo)
+**URLs**: [kanadojo.com](https://kanadojo.com) · [GitHub](https://github.com/lingdojo/kana-dojo)
 
 ---
 


### PR DESCRIPTION
## 📝 Description

This PR fixes an incorrect GitHub repository URL in the AI Assistant Guide.

The URL was updated from `kanadojo` to `kana-dojo` to match the correct repository name.

## 🔗 Related Issue

Closes #

## 🎯 Type of Change

* [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
* [ ] `feat`: New feature (non-breaking change which adds functionality)
* [x] `docs`: Documentation update (e.g., this file, README)
* [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
* [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
* [ ] `refactor`: Code refactor (no functional changes)
* [ ] `test`: Test update (adding missing tests or correcting existing tests)
* [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Verified the updated URL opens the correct GitHub repository.
2. Ensured no other content was modified.

## 📸 Screenshots/Videos (if applicable)

Not applicable.

## ✅ Pre-Submission Checklist

* [x] My code follows the project's code style and uses `cn()` utility where needed.
* [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
* [x] My commit messages follow the Conventional Commits format.
* [x] I have updated the documentation (if applicable).
* [x] This PR is against the `main` branch.

## 📦 Additional Context

AI assistance was used to identify the issue, but the fix was manually verified.
