### PR TITLE
feat(theme): add Sakurajima Ash and Wind God themes

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -22,5 +22,17 @@
     "backgroundColor": "oklch(94.0% 0.025 345.0 / 1)",
     "mainColor": "oklch(68.0% 0.160 350.0 / 1)",
     "secondaryColor": "oklch(72.0% 0.110 210.0 / 1)"
+  },
+  {
+    "id": "sakurajima-ash",
+    "backgroundColor": "oklch(22.0% 0.025 270.0 / 1)",
+    "mainColor": "oklch(65.0% 0.170 25.0 / 1)",
+    "secondaryColor": "oklch(58.0% 0.055 260.0 / 1)"
+  },
+  {
+    "id": "wind-god",
+    "backgroundColor": "oklch(19.0% 0.045 175.0 / 1)",
+    "mainColor": "oklch(82.0% 0.155 180.0 / 1)",
+    "secondaryColor": "oklch(72.0% 0.135 165.0 / 1)"
   }
 ]


### PR DESCRIPTION
## Summary
Add two new color themes:\n- Sakurajima Ash: Volcanic ash-inspired dark theme\n- Wind God: Fujin-inspired flowing green theme\n\n## Changes\n- Added sakurajima-ash theme (dark purple/volcanic)\n- Added wind-god theme (green with flowing colors)\n\n## Linked Issues\nCloses #10286\nCloses #10254\n/claim #10286\n/claim #10254