### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -53,5 +53,6 @@
   "The practice of 'nemawashi' (根回し) means building consensus before a meeting so decisions appear unanimous - the actual negotiation happens beforehand.",
   "'Yozakura' (夜桜) means night-time cherry blossom viewing, often accompanied by lanterns and food stalls.",
   "The word 'kazaana' (風穴) refers to naturally cool caves used historically to store ice and preserve food in summer.",
-  "The Japanese concept 'kintsugi' (金継ぎ) repairs broken pottery with gold, making the piece more valuable by highlighting its history."
+  "The Japanese concept 'kintsugi' (金継ぎ) repairs broken pottery with gold, making the piece more valuable by highlighting its history.",
+  "The Japanese word 'arigatai' (ありがたい) originally meant 'rare and precious', which is why it became associated with gratitude."
 ]


### PR DESCRIPTION
Added Japan Fact #212 as requested in issue #10409.

The fact: The Japanese word 'arigatai' (ありがたい) originally meant 'rare and precious', which is why it became associated with gratitude.

Closes #10409