### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -61,5 +61,6 @@
   "The concept 'doryoku' (努力) means hard work as a core value - success without effort is considered somehow lesser.",
   "The word 'yoroshiku' (よろしく) has no direct translation - it's used for introductions, requests, and meaning 'please treat me well'.",
   "Japanese toilet seats often have built-in bidets with heated seats, air dryers, and sound effects to mask embarrassing noises.",
-  "The Japanese term 'matsuri' (祭り) broadly means festival, and many neighborhoods host their own with portable shrines ('mikoshi')."
+  "The Japanese term 'matsuri' (祭り) broadly means festival, and many neighborhoods host their own with portable shrines ('mikoshi').",
+  "The word 'otsukaresama' (お疲れ様) literally means 'you're tired' but is used to acknowledge someone's hard work."
 ]


### PR DESCRIPTION
  ## 📝 Description

  Added a new Japan fact to `community/content/japan-facts.json`.

  New fact added:
  "The word 'otsukaresama' (お疲れ様) literally means 'you're tired' but is used to acknowledge someone's hard work."

  ## 🔗 Related Issue

  Closes #10582

  ## 🎯 Type of Change

  - [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
  - [ ] `feat`: New feature (non-breaking change which adds functionality)
  - [ ] `docs`: Documentation update (e.g., this file, README)
  - [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
  - [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
  - [ ] `refactor`: Code refactor (no functional changes)
  - [ ] `test`: Test update (adding missing tests or correcting existing tests)
  - [ ] `chore`: Build, CI/CD, or dependency updates

  ## 🧪 How Has This Been Tested?

  **Test Steps:**

  1. Opened `community/content/japan-facts.json`
  2. Added the new fact string at the end of the array
  3. Confirmed the JSON remains valid

  **Manual Test Checklist:**

  - [ ] Tested in **Kana** dojo
  - [ ] Tested in **Kanji** dojo
  - [ ] Tested in **Vocabulary** dojo
  - [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
  - [x] JSON array updated correctly
  - [x] File formatting preserved

  ## 📸 Screenshots/Videos (if applicable)

  N/A

  ## ✅ Pre-Submission Checklist

  - [ ] My code follows the project's code style and uses `cn()` utility where needed.
  - [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors.
  - [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
  - [ ] I have updated the documentation (if applicable).
  - [x] This PR is against the `main` branch.

  **Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

  ## 📦 Additional Context

  This is a browser-only content contribution, so no local setup or runtime testing was performed.
