### PR TITLE
content: add new japanese false friend

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -10,5 +10,11 @@
     "termB": "seal (animal)",
     "explanation": "シール usually means sticker/label, not the animal seal.",
     "example": "ノートにシールを貼った。"
+  },
+  {
+  "termA": "ナンバー (nanbaa)",
+  "termB": "number (English)",
+  "explanation": "Can mean ranking position in Japanese usage. (Set 2)",
+  "example": "彼はチームのナンバー1だ。"
   }
 ]


### PR DESCRIPTION
## 📝 Description

Added a new Japanese false friend pair: ナンバー (nanbaa) vs number (English).
This highlights that ナンバー is often used to indicate ranking (e.g., ナンバー1) rather than just a numeric value.

## 🔗 Related Issue

Closes #10722

## 🎯 Type of Change

* [x] content

## 📦 Additional Context

This is a simple content update to help learners avoid common Japanese-English confusion.