### PR TITLE
docs: fix CLAUDE.md encoding and emoji

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ This file provides comprehensive guidance for AI coding assistants (GitHub Copil
 | i18n      | next-intl (namespace-based)              |
 | Testing   | Vitest with jsdom                        |
 
-**URLs**: [kanadojo.com](https://kanadojo.com) Â· [GitHub](https://github.com/lingdojo/kanadojo)
+**URLs**: [kanadojo.com](https://kanadojo.com) · [GitHub](https://github.com/lingdojo/kanadojo)
 
 ---
 
@@ -63,8 +63,8 @@ KanaDojo is organized by feature: app/, features/, shared/, core/. Keep business
 
 ### Do's / Don'ts (short)
 
-- âœ… Use TypeScript types, path aliases, and translations.
-- âŒ Donâ€™t add business logic to `app/` or create circular deps.
+- ✅ Use TypeScript types, path aliases, and translations.
+- ❌ Don’t add business logic to `app/` or create circular deps.
 
 ### Common tasks
 


### PR DESCRIPTION
This PR fixes minor encoding issues in `CLAUDE.md`:

- Replace `âœ…` and `âŒ` with proper emoji ✅ and ❌ in the "Do's / Don'ts" section.
- Fix `Â·` in the URLs line to a clean middot `·`.

These are purely cosmetic fixes; no guidance or behavior is changed.