### PR TITLE
feat(theme): add Ruby Kabuki color palette

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -132,9 +132,9 @@
   "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
 },
   {
-  id: 'ruby-kabuki',
-  backgroundColor: 'oklch(16.0% 0.040 20.0 / 1)',
-  mainColor: 'oklch(70.0% 0.215 25.0 / 1)',
-  secondaryColor: 'oklch(85.0% 0.055 95.0 / 1)'
+  "id": "ruby-kabuki",
+  "backgroundColor": "oklch(16.0% 0.040 20.0 / 1)",
+  "mainColor": "oklch(70.0% 0.215 25.0 / 1)",
+  "secondaryColor": "oklch(85.0% 0.055 95.0 / 1)"
 }
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -130,5 +130,11 @@
   "backgroundColor": "oklch(96.0% 0.008 85.0 / 1)",
   "mainColor": "oklch(20.0% 0.015 270.0 / 1)",
   "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
+},
+  {
+  id: 'ruby-kabuki',
+  backgroundColor: 'oklch(16.0% 0.040 20.0 / 1)',
+  mainColor: 'oklch(70.0% 0.215 25.0 / 1)',
+  secondaryColor: 'oklch(85.0% 0.055 95.0 / 1)'
 }
 ]


### PR DESCRIPTION
## 📝 Description
This PR adds the Ruby Kabuki color theme to the community-themes.json registry. The theme features a dramatic red aesthetic using the oklch color space for perceptual uniformity across modern displays.

## 🔗 Related Issue

Closes #10910

## 🎯 Type of Change

- [✅ ] `feat`: New feature (non-breaking change which adds functionality)
- [✅ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Manually verified the JSON object syntax for trailing commas and brackets.
2.  Confirmed oklch values match the requested theme specifications in the issue

**Manual Test Checklist:**

Verified JSON validity in the browser editor.
Tested in Kana dojo
Tested in Kanji dojo
Tested in Vocabulary dojo

