### PR TITLE
content: add Japanese false friend pair 42

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -52,5 +52,11 @@
   "termB": "PET bottle",
   "explanation": "Common term for plastic drink bottle. (Set 6)",
   "example": "ペットボトルは分別して捨てる。"
+},
+  {
+  "termA": "マンション (manshon)",
+  "termB": "mansion (English)",
+  "explanation": "マンション means apartment building in Japanese. (Set 3)",
+  "example": "駅前のマンションに住んでいます。"
 }
 ]


### PR DESCRIPTION
## What changed?

Added the Japanese false friend pair for マンション (manshon) / mansion (English) to the false friends content file.

## Related issue

Fixes #10932

## How did you test it?

- Verified JSON is valid and matches the existing entry format
- Confirmed entry format is consistent with all other entries in the file

## Notes

Straightforward content addition. No logic or UI changes.