### PR TITLE
Fix typo in README: Licence → License and some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ KanaDojo is an engaging and user-friendly web-based Japanese learning platform t
 
 Start with the [Beginner's Contribution Guide](./docs/CONTRIBUTING-BEGINNERS.md) for a step-by-step walkthrough that explains everything from creating a GitHub account to opening your first PR.
 
-### Not a beginner?
+### Not a Beginner?
 
 All contributions are welcome! Whether you're fixing bugs, adding features, improving documentation, or translating — check out [CONTRIBUTING.md](./CONTRIBUTING.md) to get started.
 
@@ -142,7 +142,7 @@ npm run check
 
 </div>
 
-## Licence
+## License
 
 This project is licensed under the AGPL 3.0 License — see [LICENSE.md](./LICENSE.md) for details.
 


### PR DESCRIPTION
## 📝 Description

This PR fixes minor inconsistencies in the README:
- Changed "Licence" to "License" for consistency
- Capitalized "Beginner" in the section heading

These are small documentation improvements with no functional impact.

## 🎯 Type of Change

- [x] `docs`: Documentation update (e.g., this file, README)

## 🧪 How Has This Been Tested?

Not applicable — documentation-only changes.

## 📸 Screenshots/Videos (if applicable)

Not applicable.

## ✅ Pre-Submission Checklist

- [x] My changes are minimal and focused only on documentation.
- [x] No functional code changes were made.
- [x] This PR is against the `main` branch.

## 📦 Additional Context

AI assistance was used to identify minor inconsistencies, and all changes were verified manually.