### PR TITLE
fix(community): remove duplicate and placeholder entries in content files

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -49,21 +49,15 @@
   "Japan has had the same family on the Chrysanthemum Throne for over 2,600 years - the world's oldest continuous hereditary monarchy",
   "There's a Japanese word 'tasogare' (黄昏) specifically for the golden hour at dusk when it's hard to recognize faces.",
   "Japan’s 'michi-no-eki' (道の駅) are highway rest stops that double as local farmers’ markets and souvenir hubs.",
-  "Japan's Shibuya Crossing sees up to 3,000 people cross at once during peak times - making it the busiest pedestrian intersection in the world.",
   "Japan's mobile phones had emoji in 1999 - a full 11 years before the iPhone introduced them to the Western world.",
-  "The phrase 'yoroshiku onegaishimasu' (よろしくお願いします) is a versatile expression for \"please take care of me.\"",
   "Japanese toilet seats often have built-in bidets with heated seats, air dryers, and sound effects to mask embarrassing noises.",
   "The practice of 'nemawashi' (根回し) means building consensus before a meeting so decisions appear unanimous - the actual negotiation happens beforehand.",
-  "There's a Japanese word 'tasogare' (黄昏) specifically for the golden hour at dusk when it's hard to recognize faces.",
-  "Pehle se likha hua aakhri fact",
   "There's a Japanese practice called 'kuuki wo yomu' (空気を読む) - reading the air - understanding unspoken social cues.",
   "Japan has the world's oldest population - one in three Japanese citizens is over 60 years old, and the ratio is increasing.",
   "Japan has 'omikuji' (おみくじ) fortune slips at shrines; bad fortunes are often tied to a tree or rack to leave them behind.",
   "There's a Japanese practice of 'honne and tatemae' - your true feelings (honne) versus your public facade (tatemae) - both are considered valid.",
-  "There's a Japanese practice of 'honne and tatemae' - your true feelings (honne) versus your public facade (tatemae) - both are considered valid.",
   "Japan's 7-Eleven stores outnumber those in the US despite Japan being 26 times smaller - there's roughly one 7-Eleven for every 2,300 people.",
   "Japan has 'shuin' stamp books where visitors collect temple seals along with dates and handwritten calligraphy.",
-  "The Japanese word 'nomunication' combines 'nomu' (drink) and 'communication' - bonding with colleagues over after-work drinks.",
-  "The Japanese term 'shuudan ishiki' (集団意識) refers to strong group consciousness — prioritizing harmony within the group.",
-  "Japan’s 'hashioki' are chopstick rests, and many restaurants choose seasonal or themed designs."
+  "The Japanese word ‘nomunication’ combines ‘nomu’ (drink) and ‘communication’ - bonding with colleagues over after-work drinks.",
+  "Japan’s ‘hashioki’ are chopstick rests, and many restaurants choose seasonal or themed designs."
 ]

--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -74,7 +74,5 @@
   "〜に対して means \"toward / in contrast to,\" used to show comparison or directed action.",
   "〜ば〜ほど means \"as... increases, so does...\". (practice variation 55)",
   "〜ところ refers to a point in time, like \"about to\", \"in the middle of\", or \"just finished\". (practice variation 31)",
-  "〜わけではない means \"not necessarily\" or \"it's not that\". (practice variation 50)",
-  "\"〜わけではない\" means \"not necessarily\" or \"it's not that\". (practice variation 50)",
-  "\"〜ながらも\" means \"even while\" or \"though\" (contrast)."
+  "〜わけではない means \"not necessarily\" or \"it's not that\". (practice variation 50)"
 ]


### PR DESCRIPTION
## Summary

- Removes a Hindi placeholder string (`"Pehle se likha hua aakhri fact"`) from `community/content/japan-facts.json` that was mistakenly committed
- Removes 5 duplicate fact entries from `japan-facts.json`
- Removes 2 duplicate grammar entries (with extraneous surrounding quotes) from `community/content/japanese-grammar.json`

## Changes

### `community/content/japan-facts.json` (68 → 62 entries)

| Removed Entry | Reason |
|---|---|
| `"Pehle se likha hua aakhri fact"` | Hindi placeholder, not a real fact |
| Shibuya Crossing fact | Duplicate of existing entry |
| `tasogare` word fact | Duplicate of existing entry |
| `yoroshiku onegaishimasu` phrase | Near-duplicate (same content, different quoting) |
| `honne and tatemae` practice | Exact duplicate |
| `shuudan ishiki` term | Duplicate of existing entry |

### `community/content/japanese-grammar.json` (79 → 77 entries)

| Removed Entry | Reason |
|---|---|
| `"〜わけではない"...` (with surrounding quotes) | Duplicate of the entry without surrounding quotes |
| `"〜ながらも"...` (with surrounding quotes) | Duplicate of the entry without surrounding quotes |

## Test plan

- [x] Both JSON files validated with `node -e "JSON.parse(...)"` — no syntax errors
- [x] No remaining duplicate entries
- [x] Placeholder string removed