### PR TITLE
content: add Japan fact about Naoshima art island

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -68,5 +68,6 @@
   "Japan has 'gravure idols' - models who pose in bikinis and lingerie for magazines, calendars, and trading cards.",
   "Japan’s 'shimenawa' (注連縄) sacred ropes are hung at shrines and homes to mark purified, protected spaces.",
   "Japan has a phenomenon called 'Paris Syndrome' - Japanese tourists experiencing severe shock when Paris doesn't match their idealized expectations.",
-  "There's a Japanese practice 'natsukashii' (懐かしい) experience parties - rooms designed to trigger nostalgia from specific eras."
+  "There's a Japanese practice 'natsukashii' (懐かしい) experience parties - rooms designed to trigger nostalgia from specific eras.",
+  "Japan has an island dedicated entirely to art museums - Naoshima, where Tadao Ando's architecture blends with nature."
 ]


### PR DESCRIPTION
## Summary
- Adds a new fact to `community/content/japan-facts.json`
- Fact: "Japan has an island dedicated entirely to art museums - Naoshima, where Tadao Ando's architecture blends with nature."

## Verification
- JSON validated with Python's `json.load()` — no syntax errors

Closes #11724