### PR TITLE
content: add Japan fact about machiya townhouses

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -68,5 +68,6 @@
   "Japan has 'gravure idols' - models who pose in bikinis and lingerie for magazines, calendars, and trading cards.",
   "Japan’s 'shimenawa' (注連縄) sacred ropes are hung at shrines and homes to mark purified, protected spaces.",
   "Japan has a phenomenon called 'Paris Syndrome' - Japanese tourists experiencing severe shock when Paris doesn't match their idealized expectations.",
-  "There's a Japanese practice 'natsukashii' (懐かしい) experience parties - rooms designed to trigger nostalgia from specific eras."
+  "There's a Japanese practice 'natsukashii' (懐かしい) experience parties - rooms designed to trigger nostalgia from specific eras.",
+  "The term 'machiya' (町家) refers to traditional wooden townhouses with storefronts on the first floor and living spaces above."
 ]


### PR DESCRIPTION
## Summary
- Adds a new fact to `community/content/japan-facts.json`
- Fact: Traditional machiya (町家) wooden townhouses with storefronts and living spaces

## Verification
- JSON validated — no syntax errors

Closes #11706