### PR TITLE
content: expand community content across multiple categories

### DIFF
--- a/community/content/anime-quotes.json
+++ b/community/content/anime-quotes.json
@@ -444,5 +444,12 @@
     "english": "Useless! Useless! Useless!",
     "anime": "JoJo's Bizarre Adventure: Stardust Crusaders",
     "character": "DIO"
+  },
+  {
+    "japanese": "今日の信は一味違うぜ！",
+    "romaji": "Kyou no ore wa hitomi chigau ze!",
+    "english": "I'm on a different level today!",
+    "anime": "JoJo's Bizarre Adventure: Diamond is Unbreakable",
+    "character": "Okuyasu Nijimura"
   }
 ]

--- a/community/content/anime-quotes.json
+++ b/community/content/anime-quotes.json
@@ -451,5 +451,12 @@
     "english": "I'm on a different level today!",
     "anime": "JoJo's Bizarre Adventure: Diamond is Unbreakable",
     "character": "Okuyasu Nijimura"
+  },
+  {
+    "japanese": "おまえはもう死んでいる",
+    "romaji": "Omae wa mou shindeiru",
+    "english": "You're already dead.",
+    "anime": "Fist of the North Star",
+    "character": "Kenshiro"
   }
 ]

--- a/community/content/anime-quotes.json
+++ b/community/content/anime-quotes.json
@@ -437,5 +437,12 @@
     "english": "Road roller!",
     "anime": "JoJo's Bizarre Adventure: Stardust Crusaders",
     "character": "DIO"
+  },
+  {
+    "japanese": "無駆無駆無駆無駆無駆！",
+    "romaji": "Muda muda muda muda muda!",
+    "english": "Useless! Useless! Useless!",
+    "anime": "JoJo's Bizarre Adventure: Stardust Crusaders",
+    "character": "DIO"
   }
 ]

--- a/community/content/anime-quotes.json
+++ b/community/content/anime-quotes.json
@@ -430,5 +430,12 @@
     "english": "Each of us is only given one soul. Take good care of yours.",
     "anime": "Bleach",
     "character": "Kisuke Urahara"
+  },
+  {
+    "japanese": "ロードローラーだッ！",
+    "romaji": "Rodo rora da!",
+    "english": "Road roller!",
+    "anime": "JoJo's Bizarre Adventure: Stardust Crusaders",
+    "character": "DIO"
   }
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -73,5 +73,6 @@
   "The concept of 'wa' (和) in Japanese represents harmony - so important that the official name for Japan is 'Wa' (the country of harmony).",
   "Japan has 'pocky day' on November 11 (11/11) because the date looks like four Pocky sticks standing in a row.",
   "Japanese blood types are believed to determine personality, similar to zodiac signs in the West. Type A is organized, B is creative, O is confident, and AB is rational.",
-  "The Japanese word 'age-otori' (上げ劣り) describes the specific experience of looking worse after a haircut - a feeling so common it needed its own word."
+  "The Japanese word 'age-otori' (上げ劣り) describes the specific experience of looking worse after a haircut - a feeling so common it needed its own word.",
+  "Japan's Aokigahara forest, also called the Sea of Trees, is so dense that GPS devices and compasses often malfunction due to the iron-rich volcanic soil."
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -74,5 +74,6 @@
   "Japan has 'pocky day' on November 11 (11/11) because the date looks like four Pocky sticks standing in a row.",
   "Japanese blood types are believed to determine personality, similar to zodiac signs in the West. Type A is organized, B is creative, O is confident, and AB is rational.",
   "The Japanese word 'age-otori' (上げ劣り) describes the specific experience of looking worse after a haircut - a feeling so common it needed its own word.",
-  "Japan's Aokigahara forest, also called the Sea of Trees, is so dense that GPS devices and compasses often malfunction due to the iron-rich volcanic soil."
+  "Japan's Aokigahara forest, also called the Sea of Trees, is so dense that GPS devices and compasses often malfunction due to the iron-rich volcanic soil.",
+  "Japan has a word 'tarento' (タレント) for TV personalities who are famous simply for being on TV - not actors or musicians, just professional celebrities."
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -72,5 +72,6 @@
   "Japan has 'melon bread' (melonpan) that contains no melon - it's named for the cookie crust pattern resembling a melon.",
   "The concept of 'wa' (和) in Japanese represents harmony - so important that the official name for Japan is 'Wa' (the country of harmony).",
   "Japan has 'pocky day' on November 11 (11/11) because the date looks like four Pocky sticks standing in a row.",
-  "Japanese blood types are believed to determine personality, similar to zodiac signs in the West. Type A is organized, B is creative, O is confident, and AB is rational."
+  "Japanese blood types are believed to determine personality, similar to zodiac signs in the West. Type A is organized, B is creative, O is confident, and AB is rational.",
+  "The Japanese word 'age-otori' (上げ劣り) describes the specific experience of looking worse after a haircut - a feeling so common it needed its own word."
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -76,5 +76,6 @@
   "The Japanese word 'age-otori' (上げ劣り) describes the specific experience of looking worse after a haircut - a feeling so common it needed its own word.",
   "Japan's Aokigahara forest, also called the Sea of Trees, is so dense that GPS devices and compasses often malfunction due to the iron-rich volcanic soil.",
   "Japan has a word 'tarento' (タレント) for TV personalities who are famous simply for being on TV - not actors or musicians, just professional celebrities.",
-  "Japan has a dedicated day for curry rice (January 22nd), established because it was first served in school lunches nationwide on that date in 1982."
+  "Japan has a dedicated day for curry rice (January 22nd), established because it was first served in school lunches nationwide on that date in 1982.",
+  "The Japanese concept of 'ma' (間) refers to the meaningful pause or negative space in music, art, and conversation - the beauty of what's not there."
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -75,5 +75,6 @@
   "Japanese blood types are believed to determine personality, similar to zodiac signs in the West. Type A is organized, B is creative, O is confident, and AB is rational.",
   "The Japanese word 'age-otori' (上げ劣り) describes the specific experience of looking worse after a haircut - a feeling so common it needed its own word.",
   "Japan's Aokigahara forest, also called the Sea of Trees, is so dense that GPS devices and compasses often malfunction due to the iron-rich volcanic soil.",
-  "Japan has a word 'tarento' (タレント) for TV personalities who are famous simply for being on TV - not actors or musicians, just professional celebrities."
+  "Japan has a word 'tarento' (タレント) for TV personalities who are famous simply for being on TV - not actors or musicians, just professional celebrities.",
+  "Japan has a dedicated day for curry rice (January 22nd), established because it was first served in school lunches nationwide on that date in 1982."
 ]

--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -71,5 +71,6 @@
   "There's a Japanese practice 'natsukashii' (懐かしい) experience parties - rooms designed to trigger nostalgia from specific eras.",
   "Japan has 'melon bread' (melonpan) that contains no melon - it's named for the cookie crust pattern resembling a melon.",
   "The concept of 'wa' (和) in Japanese represents harmony - so important that the official name for Japan is 'Wa' (the country of harmony).",
-  "Japan has 'pocky day' on November 11 (11/11) because the date looks like four Pocky sticks standing in a row."
+  "Japan has 'pocky day' on November 11 (11/11) because the date looks like four Pocky sticks standing in a row.",
+  "Japanese blood types are believed to determine personality, similar to zodiac signs in the West. Type A is organized, B is creative, O is confident, and AB is rational."
 ]

--- a/community/content/japan-trivia-easy.json
+++ b/community/content/japan-trivia-easy.json
@@ -1,650 +1,660 @@
 [
-    {
-        "question": "What is the Japanese term for a hot spring? (Community variation 42)",
-        "difficulty": "easy",
-        "answers": [
-            "Onsen",
-            "Sentou",
-            "Ryokan",
-            "Izakaya"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for a shrine gate? (Community variation 60)",
-        "difficulty": "easy",
-        "answers": [
-            "Torii",
-            "Tori",
-            "Toriya",
-            "Torin"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which animal is famously associated with Inari shrines in Japan? (Community variation 33)",
-        "difficulty": "easy",
-        "answers": [
-            "Fox",
-            "Crane",
-            "Turtle",
-            "Deer"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which mountain is Japan's highest peak?",
-        "difficulty": "easy",
-        "answers": [
-            "Mount Fuji",
-            "Mount Kita",
-            "Mount Tate",
-            "Mount Haku"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for cherry blossoms? (Community variation 37)",
-        "difficulty": "easy",
-        "answers": [
-            "Sakura",
-            "Ume",
-            "Momiji",
-            "Kiku"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese art of arranging flowers called?",
-        "difficulty": "easy",
-        "answers": [
-            "Ikebana",
-            "Shodo",
-            "Kodo",
-            "Origami"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the main ingredient in miso? (Community variation 56)",
-        "difficulty": "easy",
-        "answers": [
-            "Fermented soybeans",
-            "Rice flour",
-            "Buckwheat",
-            "Seaweed"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for a Buddhist temple?",
-        "difficulty": "easy",
-        "answers": [
-            "Otera",
-            "Jinja",
-            "Torii",
-            "Goshuin"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese dish consists of skewered grilled chicken? (Community variation 48)",
-        "difficulty": "easy",
-        "answers": [
-            "Yakitori",
-            "Sukiyaki",
-            "Tonkatsu",
-            "Oden"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese word for \"goodbye\"?",
-        "difficulty": "easy",
-        "answers": [
-            "Sayonara",
-            "Konnichiwa",
-            "Arigatou",
-            "Oyasumi"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which traditional Japanese sport involves wrestling in a ring?",
-        "difficulty": "easy",
-        "answers": [
-            "Sumo",
-            "Kendo",
-            "Judo",
-            "Aikido"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for cherry blossoms?",
-        "difficulty": "easy",
-        "answers": [
-            "Sakura",
-            "Ume",
-            "Momiji",
-            "Kiku"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese city is famous for the floating torii gate at Itsukushima Shrine? (Community variation 1)",
-        "difficulty": "easy",
-        "answers": [
-            "Kyoto",
-            "Hiroshima",
-            "Nagasaki",
-            "Kanazawa"
-        ],
-        "correctIndex": 1
-    },
-    {
-        "question": "What is the Japanese art of arranging flowers called? (Community variation 58)",
-        "difficulty": "easy",
-        "answers": [
-            "Ikebana",
-            "Shodo",
-            "Kodo",
-            "Origami"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese art form involves arranging flowers?",
-        "difficulty": "easy",
-        "answers": [
-            "Ikebana",
-            "Origami",
-            "Ukiyo-e",
-            "Shodo"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What does \"Oishii\" mean in Japanese?",
-        "correctAnswer": "Delicious",
-        "incorrectAnswers": [
-            "Hello",
-            "Thank you",
-            "Goodbye"
-        ],
-        "answerExplanation": "Oishii means delicious in Japanese."
-    },
-    {
-        "question": "Which city is known for its beef brand Kobe? (Community variation 59)",
-        "difficulty": "easy",
-        "answers": [
-            "Kobe",
-            "Nagoya",
-            "Kanazawa",
-            "Hiroshima"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which ocean borders Japan to the east? (Community variation 10)",
-        "difficulty": "easy",
-        "answers": [
-            "Atlantic Ocean",
-            "Indian Ocean",
-            "Pacific Ocean",
-            "Arctic Ocean"
-        ],
-        "correctIndex": 2
-    },
-    {
-        "question": "What is the traditional Japanese art of paper folding called? (Community variation 4)",
-        "difficulty": "easy",
-        "answers": [
-            "Origami",
-            "Ikebana",
-            "Kintsugi",
-            "Shodo"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese city is known for the famous bamboo grove? (Community variation 31)",
-        "difficulty": "easy",
-        "answers": [
-            "Kyoto",
-            "Tokyo",
-            "Sapporo",
-            "Fukuoka"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese art form involves arranging flowers? (Community variation 43)",
-        "difficulty": "easy",
-        "answers": [
-            "Ikebana",
-            "Origami",
-            "Ukiyo-e",
-            "Shodo"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which city is famous for the Gion Matsuri festival? (Community variation 51)",
-        "difficulty": "easy",
-        "answers": [
-            "Kyoto",
-            "Sendai",
-            "Sapporo",
-            "Kobe"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which city is known for its large bronze Great Buddha?",
-        "difficulty": "easy",
-        "answers": [
-            "Kamakura",
-            "Kobe",
-            "Kanazawa",
-            "Matsuyama"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which ocean borders Japan to the east?",
-        "difficulty": "easy",
-        "answers": [
-            "Atlantic Ocean",
-            "Indian Ocean",
-            "Pacific Ocean",
-            "Arctic Ocean"
-        ],
-        "correctIndex": 2
-    },
-    {
-        "question": "What is the Japanese word for \"goodbye\"? (Community variation 32)",
-        "difficulty": "easy",
-        "answers": [
-            "Sayonara",
-            "Konnichiwa",
-            "Arigatou",
-            "Oyasumi"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese dish is made of raw fish over rice?",
-        "difficulty": "easy",
-        "answers": [
-            "Sushi",
-            "Tempura",
-            "Tonkatsu",
-            "Okonomiyaki"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for a traditional inn? (Community variation 52)",
-        "difficulty": "easy",
-        "answers": [
-            "Ryokan",
-            "Minshuku",
-            "Izakaya",
-            "Yatai"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese dish is made of raw fish over rice?",
-        "difficulty": "easy",
-        "answers": [
-            "Sushi",
-            "Tempura",
-            "Tonkatsu",
-            "Okonomiyaki"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which month is traditionally associated with cherry blossom viewing (hanami) in Japan? (Community variation 3)",
-        "difficulty": "easy",
-        "answers": [
-            "January",
-            "April",
-            "July",
-            "October"
-        ],
-        "correctIndex": 1
-    },
-    {
-        "question": "Which mountain is Japan’s highest peak? (Community variation 53)",
-        "difficulty": "easy",
-        "answers": [
-            "Mount Fuji",
-            "Mount Kita",
-            "Mount Tate",
-            "Mount Haku"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the name of the bullet train network in Japan? (Community variation 2)",
-        "difficulty": "easy",
-        "answers": [
-            "Shinkansen",
-            "Metro Line",
-            "Skyrail",
-            "Kairo"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the name of Japan's traditional theatre known for stylized performances and masks? (Community variation 6)",
-        "difficulty": "easy",
-        "answers": [
-            "Kabuki",
-            "Noh",
-            "Rakugo",
-            "Bunraku"
-        ],
-        "correctIndex": 1
-    },
-    {
-        "question": "What is the Japanese term for a hot spring?",
-        "difficulty": "easy",
-        "answers": [
-            "Onsen",
-            "Sentou",
-            "Ryokan",
-            "Izakaya"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese food is a savory pancake cooked on a griddle?",
-        "difficulty": "easy",
-        "answers": [
-            "Okonomiyaki",
-            "Tempura",
-            "Yakitori",
-            "Sashimi"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese food is made from fermented soybeans and has a sticky texture? (Community variation 7)",
-        "difficulty": "easy",
-        "answers": [
-            "Miso",
-            "Natto",
-            "Tofu",
-            "Udon"
-        ],
-        "correctIndex": 1
-    },
-    {
-        "question": "What is the Japanese term for a summer fireworks festival?",
-        "difficulty": "easy",
-        "answers": [
-            "Hanabi Taikai",
-            "Bon Odori",
-            "Kagura",
-            "Kanda Matsuri"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for a summer fireworks festival?",
-        "difficulty": "easy",
-        "answers": [
-            "Hanabi Taikai",
-            "Bon Odori",
-            "Kagura",
-            "Kanda Matsuri"
-        ],
-        "correctAnswerIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for \"new year\"?",
-        "difficulty": "easy",
-        "answers": [
-            "Shogatsu",
-            "Obon",
-            "Tanabata",
-            "Hinamatsuri"
-        ],
-        "correctAnswerIndex": 0
-    },
-    {
-        "question": "What is the Japanese art of the traditional tea ceremony called (also known as Chanoyu)?",
-        "difficulty": "easy",
-        "answers": [
-            "Sado",
-            "Ikebana",
-            "Kaiseki",
-            "Bento"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which of these is a Japanese noodle dish served in broth?",
-        "difficulty": "easy",
-        "answers": [
-            "Ramen",
-            "Takoyaki",
-            "Gyoza",
-            "Yakitori"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for a traditional tea ceremony?",
-        "difficulty": "easy",
-        "answers": [
-            "Sado",
-            "Ikebana",
-            "Kaiseki",
-            "Bento"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese island is home to the city of Sapporo? (Community variation 5)",
-        "difficulty": "easy",
-        "answers": [
-            "Honshu",
-            "Hokkaido",
-            "Shikoku",
-            "Kyushu"
-        ],
-        "correctIndex": 1
-    },
-    {
-        "question": "What is the Japanese term for a traditional wooden sandal?",
-        "difficulty": "easy",
-        "answers": [
-            "Geta",
-            "Zori",
-            "Waraji",
-            "Tabi"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which city is famous for the Peace Memorial Park?",
-        "difficulty": "easy",
-        "answers": [
-            "Hiroshima",
-            "Osaka",
-            "Tokyo",
-            "Fukuoka"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese term for a traditional inn?",
-        "difficulty": "easy",
-        "answers": [
-            "Ryokan",
-            "Minshuku",
-            "Izakaya",
-            "Yatai"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese art form involves arranging flowers? (Community variation 43)",
-        "difficulty": "easy",
-        "answers": [
-            "Ikebana",
-            "Origami",
-            "Ukiyo-e",
-            "Shodo"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese word for \"goodbye\"? (Community variation 32)",
-        "difficulty": "easy",
-        "answers": [
-            "Sayonara",
-            "Konnichiwa",
-            "Arigatou",
-            "Oyasumi"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the Japanese word for \"goodbye\"? (Community variation 32)",
-        "difficulty": "easy",
-        "answers": [
-            "Sayonara",
-            "Konnichiwa",
-            "Arigatou",
-            "Oyasumi"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which animal is famously associated with Inari shrines in Japan?",
-        "difficulty": "easy",
-        "answers": [
-            "Fox",
-            "Crane",
-            "Turtle",
-            "Deer"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which mountain is Japan’s highest peak?",
-        "difficulty": "easy",
-        "answers": [
-            "Mount Fuji",
-            "Mount Kita",
-            "Mount Tate",
-            "Mount Haku"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the name of Japan's traditional theatre known for stylized performances and masks? (Community variation 6)",
-        "difficulty": "easy",
-        "answers": [
-            "Kabuki",
-            "Noh",
-            "Rakugo",
-            "Bunraku"
-        ],
-        "correctIndex": 1
-    },
-    {
-        "question": "Which ocean borders Japan to the east?",
-        "difficulty": "easy",
-        "answers": [
-            "Atlantic Ocean",
-            "Indian Ocean",
-            "Pacific Ocean",
-            "Arctic Ocean"
-        ],
-        "correctIndex": 2
-    },
-    {
-        "question": "Which city is known for its large bronze Great Buddha?",
-        "difficulty": "easy",
-        "answers": [
-            "Kamakura",
-            "Kobe",
-            "Kanazawa",
-            "Matsuyama"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "Which Japanese food is a savory pancake cooked on a griddle?",
-        "difficulty": "easy",
-        "answers": [
-            "Okonomiyaki",
-            "Tempura",
-            "Yakitori",
-            "Sashimi"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the name of Japan's traditional theatre known for stylized performances and masks? (Community variation 6)",
-        "difficulty": "easy",
-        "answers": [
-            "Kabuki",
-            "Noh",
-            "Rakugo",
-            "Bunraku"
-        ],
-        "correctIndex": 1
-    },
-    {
-        "question": "What is the Japanese term for a traditional inn? (Community variation 52)",
-        "difficulty": "easy",
-        "answers": [
-            "Ryokan",
-            "Minshuku",
-            "Izakaya",
-            "Yatai"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the traditional Japanese art of paper folding called? (Community variation 42)",
-        "difficulty": "easy",
-        "answers": [
-            "Origami",
-            "Ikebana",
-            "Bonsai",
-            "Shodo"
-        ],
-        "correctIndex": 0
-    },
-    {
-        "question": "What is the main ingredient in miso?",
-        "difficulty": "easy",
-        "answers": [
-            "Fermented soybeans",
-            "Rice flour",
-            "Buckwheat",
-            "Seaweed"
-        ],
-        "correctIndex": 0
-    },
-    {
-      "question": "Which traditional Japanese sport involves wrestling in a ring?",
-      "difficulty": "easy",
-      "answers": [
-        "Sumo",
-        "Kendo",
-        "Judo",
-        "Aikido"
-      ],
-     "correctIndex": 0
-   }
+  {
+    "question": "What is the Japanese term for a hot spring? (Community variation 42)",
+    "difficulty": "easy",
+    "answers": [
+      "Onsen",
+      "Sentou",
+      "Ryokan",
+      "Izakaya"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for a shrine gate? (Community variation 60)",
+    "difficulty": "easy",
+    "answers": [
+      "Torii",
+      "Tori",
+      "Toriya",
+      "Torin"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which animal is famously associated with Inari shrines in Japan? (Community variation 33)",
+    "difficulty": "easy",
+    "answers": [
+      "Fox",
+      "Crane",
+      "Turtle",
+      "Deer"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which mountain is Japan's highest peak?",
+    "difficulty": "easy",
+    "answers": [
+      "Mount Fuji",
+      "Mount Kita",
+      "Mount Tate",
+      "Mount Haku"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for cherry blossoms? (Community variation 37)",
+    "difficulty": "easy",
+    "answers": [
+      "Sakura",
+      "Ume",
+      "Momiji",
+      "Kiku"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese art of arranging flowers called?",
+    "difficulty": "easy",
+    "answers": [
+      "Ikebana",
+      "Shodo",
+      "Kodo",
+      "Origami"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the main ingredient in miso? (Community variation 56)",
+    "difficulty": "easy",
+    "answers": [
+      "Fermented soybeans",
+      "Rice flour",
+      "Buckwheat",
+      "Seaweed"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for a Buddhist temple?",
+    "difficulty": "easy",
+    "answers": [
+      "Otera",
+      "Jinja",
+      "Torii",
+      "Goshuin"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese dish consists of skewered grilled chicken? (Community variation 48)",
+    "difficulty": "easy",
+    "answers": [
+      "Yakitori",
+      "Sukiyaki",
+      "Tonkatsu",
+      "Oden"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese word for \"goodbye\"?",
+    "difficulty": "easy",
+    "answers": [
+      "Sayonara",
+      "Konnichiwa",
+      "Arigatou",
+      "Oyasumi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which traditional Japanese sport involves wrestling in a ring?",
+    "difficulty": "easy",
+    "answers": [
+      "Sumo",
+      "Kendo",
+      "Judo",
+      "Aikido"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for cherry blossoms?",
+    "difficulty": "easy",
+    "answers": [
+      "Sakura",
+      "Ume",
+      "Momiji",
+      "Kiku"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese city is famous for the floating torii gate at Itsukushima Shrine? (Community variation 1)",
+    "difficulty": "easy",
+    "answers": [
+      "Kyoto",
+      "Hiroshima",
+      "Nagasaki",
+      "Kanazawa"
+    ],
+    "correctIndex": 1
+  },
+  {
+    "question": "What is the Japanese art of arranging flowers called? (Community variation 58)",
+    "difficulty": "easy",
+    "answers": [
+      "Ikebana",
+      "Shodo",
+      "Kodo",
+      "Origami"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese art form involves arranging flowers?",
+    "difficulty": "easy",
+    "answers": [
+      "Ikebana",
+      "Origami",
+      "Ukiyo-e",
+      "Shodo"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What does \"Oishii\" mean in Japanese?",
+    "correctAnswer": "Delicious",
+    "incorrectAnswers": [
+      "Hello",
+      "Thank you",
+      "Goodbye"
+    ],
+    "answerExplanation": "Oishii means delicious in Japanese."
+  },
+  {
+    "question": "Which city is known for its beef brand Kobe? (Community variation 59)",
+    "difficulty": "easy",
+    "answers": [
+      "Kobe",
+      "Nagoya",
+      "Kanazawa",
+      "Hiroshima"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which ocean borders Japan to the east? (Community variation 10)",
+    "difficulty": "easy",
+    "answers": [
+      "Atlantic Ocean",
+      "Indian Ocean",
+      "Pacific Ocean",
+      "Arctic Ocean"
+    ],
+    "correctIndex": 2
+  },
+  {
+    "question": "What is the traditional Japanese art of paper folding called? (Community variation 4)",
+    "difficulty": "easy",
+    "answers": [
+      "Origami",
+      "Ikebana",
+      "Kintsugi",
+      "Shodo"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese city is known for the famous bamboo grove? (Community variation 31)",
+    "difficulty": "easy",
+    "answers": [
+      "Kyoto",
+      "Tokyo",
+      "Sapporo",
+      "Fukuoka"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese art form involves arranging flowers? (Community variation 43)",
+    "difficulty": "easy",
+    "answers": [
+      "Ikebana",
+      "Origami",
+      "Ukiyo-e",
+      "Shodo"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which city is famous for the Gion Matsuri festival? (Community variation 51)",
+    "difficulty": "easy",
+    "answers": [
+      "Kyoto",
+      "Sendai",
+      "Sapporo",
+      "Kobe"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which city is known for its large bronze Great Buddha?",
+    "difficulty": "easy",
+    "answers": [
+      "Kamakura",
+      "Kobe",
+      "Kanazawa",
+      "Matsuyama"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which ocean borders Japan to the east?",
+    "difficulty": "easy",
+    "answers": [
+      "Atlantic Ocean",
+      "Indian Ocean",
+      "Pacific Ocean",
+      "Arctic Ocean"
+    ],
+    "correctIndex": 2
+  },
+  {
+    "question": "What is the Japanese word for \"goodbye\"? (Community variation 32)",
+    "difficulty": "easy",
+    "answers": [
+      "Sayonara",
+      "Konnichiwa",
+      "Arigatou",
+      "Oyasumi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese dish is made of raw fish over rice?",
+    "difficulty": "easy",
+    "answers": [
+      "Sushi",
+      "Tempura",
+      "Tonkatsu",
+      "Okonomiyaki"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for a traditional inn? (Community variation 52)",
+    "difficulty": "easy",
+    "answers": [
+      "Ryokan",
+      "Minshuku",
+      "Izakaya",
+      "Yatai"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese dish is made of raw fish over rice?",
+    "difficulty": "easy",
+    "answers": [
+      "Sushi",
+      "Tempura",
+      "Tonkatsu",
+      "Okonomiyaki"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which month is traditionally associated with cherry blossom viewing (hanami) in Japan? (Community variation 3)",
+    "difficulty": "easy",
+    "answers": [
+      "January",
+      "April",
+      "July",
+      "October"
+    ],
+    "correctIndex": 1
+  },
+  {
+    "question": "Which mountain is Japan’s highest peak? (Community variation 53)",
+    "difficulty": "easy",
+    "answers": [
+      "Mount Fuji",
+      "Mount Kita",
+      "Mount Tate",
+      "Mount Haku"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the name of the bullet train network in Japan? (Community variation 2)",
+    "difficulty": "easy",
+    "answers": [
+      "Shinkansen",
+      "Metro Line",
+      "Skyrail",
+      "Kairo"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the name of Japan's traditional theatre known for stylized performances and masks? (Community variation 6)",
+    "difficulty": "easy",
+    "answers": [
+      "Kabuki",
+      "Noh",
+      "Rakugo",
+      "Bunraku"
+    ],
+    "correctIndex": 1
+  },
+  {
+    "question": "What is the Japanese term for a hot spring?",
+    "difficulty": "easy",
+    "answers": [
+      "Onsen",
+      "Sentou",
+      "Ryokan",
+      "Izakaya"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese food is a savory pancake cooked on a griddle?",
+    "difficulty": "easy",
+    "answers": [
+      "Okonomiyaki",
+      "Tempura",
+      "Yakitori",
+      "Sashimi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese food is made from fermented soybeans and has a sticky texture? (Community variation 7)",
+    "difficulty": "easy",
+    "answers": [
+      "Miso",
+      "Natto",
+      "Tofu",
+      "Udon"
+    ],
+    "correctIndex": 1
+  },
+  {
+    "question": "What is the Japanese term for a summer fireworks festival?",
+    "difficulty": "easy",
+    "answers": [
+      "Hanabi Taikai",
+      "Bon Odori",
+      "Kagura",
+      "Kanda Matsuri"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for a summer fireworks festival?",
+    "difficulty": "easy",
+    "answers": [
+      "Hanabi Taikai",
+      "Bon Odori",
+      "Kagura",
+      "Kanda Matsuri"
+    ],
+    "correctAnswerIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for \"new year\"?",
+    "difficulty": "easy",
+    "answers": [
+      "Shogatsu",
+      "Obon",
+      "Tanabata",
+      "Hinamatsuri"
+    ],
+    "correctAnswerIndex": 0
+  },
+  {
+    "question": "What is the Japanese art of the traditional tea ceremony called (also known as Chanoyu)?",
+    "difficulty": "easy",
+    "answers": [
+      "Sado",
+      "Ikebana",
+      "Kaiseki",
+      "Bento"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which of these is a Japanese noodle dish served in broth?",
+    "difficulty": "easy",
+    "answers": [
+      "Ramen",
+      "Takoyaki",
+      "Gyoza",
+      "Yakitori"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for a traditional tea ceremony?",
+    "difficulty": "easy",
+    "answers": [
+      "Sado",
+      "Ikebana",
+      "Kaiseki",
+      "Bento"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese island is home to the city of Sapporo? (Community variation 5)",
+    "difficulty": "easy",
+    "answers": [
+      "Honshu",
+      "Hokkaido",
+      "Shikoku",
+      "Kyushu"
+    ],
+    "correctIndex": 1
+  },
+  {
+    "question": "What is the Japanese term for a traditional wooden sandal?",
+    "difficulty": "easy",
+    "answers": [
+      "Geta",
+      "Zori",
+      "Waraji",
+      "Tabi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which city is famous for the Peace Memorial Park?",
+    "difficulty": "easy",
+    "answers": [
+      "Hiroshima",
+      "Osaka",
+      "Tokyo",
+      "Fukuoka"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese term for a traditional inn?",
+    "difficulty": "easy",
+    "answers": [
+      "Ryokan",
+      "Minshuku",
+      "Izakaya",
+      "Yatai"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese art form involves arranging flowers? (Community variation 43)",
+    "difficulty": "easy",
+    "answers": [
+      "Ikebana",
+      "Origami",
+      "Ukiyo-e",
+      "Shodo"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese word for \"goodbye\"? (Community variation 32)",
+    "difficulty": "easy",
+    "answers": [
+      "Sayonara",
+      "Konnichiwa",
+      "Arigatou",
+      "Oyasumi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the Japanese word for \"goodbye\"? (Community variation 32)",
+    "difficulty": "easy",
+    "answers": [
+      "Sayonara",
+      "Konnichiwa",
+      "Arigatou",
+      "Oyasumi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which animal is famously associated with Inari shrines in Japan?",
+    "difficulty": "easy",
+    "answers": [
+      "Fox",
+      "Crane",
+      "Turtle",
+      "Deer"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which mountain is Japan’s highest peak?",
+    "difficulty": "easy",
+    "answers": [
+      "Mount Fuji",
+      "Mount Kita",
+      "Mount Tate",
+      "Mount Haku"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the name of Japan's traditional theatre known for stylized performances and masks? (Community variation 6)",
+    "difficulty": "easy",
+    "answers": [
+      "Kabuki",
+      "Noh",
+      "Rakugo",
+      "Bunraku"
+    ],
+    "correctIndex": 1
+  },
+  {
+    "question": "Which ocean borders Japan to the east?",
+    "difficulty": "easy",
+    "answers": [
+      "Atlantic Ocean",
+      "Indian Ocean",
+      "Pacific Ocean",
+      "Arctic Ocean"
+    ],
+    "correctIndex": 2
+  },
+  {
+    "question": "Which city is known for its large bronze Great Buddha?",
+    "difficulty": "easy",
+    "answers": [
+      "Kamakura",
+      "Kobe",
+      "Kanazawa",
+      "Matsuyama"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese food is a savory pancake cooked on a griddle?",
+    "difficulty": "easy",
+    "answers": [
+      "Okonomiyaki",
+      "Tempura",
+      "Yakitori",
+      "Sashimi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the name of Japan's traditional theatre known for stylized performances and masks? (Community variation 6)",
+    "difficulty": "easy",
+    "answers": [
+      "Kabuki",
+      "Noh",
+      "Rakugo",
+      "Bunraku"
+    ],
+    "correctIndex": 1
+  },
+  {
+    "question": "What is the Japanese term for a traditional inn? (Community variation 52)",
+    "difficulty": "easy",
+    "answers": [
+      "Ryokan",
+      "Minshuku",
+      "Izakaya",
+      "Yatai"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the traditional Japanese art of paper folding called? (Community variation 42)",
+    "difficulty": "easy",
+    "answers": [
+      "Origami",
+      "Ikebana",
+      "Bonsai",
+      "Shodo"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the main ingredient in miso?",
+    "difficulty": "easy",
+    "answers": [
+      "Fermented soybeans",
+      "Rice flour",
+      "Buckwheat",
+      "Seaweed"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which traditional Japanese sport involves wrestling in a ring?",
+    "difficulty": "easy",
+    "answers": [
+      "Sumo",
+      "Kendo",
+      "Judo",
+      "Aikido"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese city is famous for the floating torii gate at Itsukushima Shrine?",
+    "answers": [
+      "Kyoto",
+      "Hiroshima",
+      "Nagasaki",
+      "Kanazawa"
+    ],
+    "correctIndex": 1
+  }
 ]

--- a/community/content/japan-trivia-easy.json
+++ b/community/content/japan-trivia-easy.json
@@ -656,5 +656,15 @@
       "Kanazawa"
     ],
     "correctIndex": 1
+  },
+  {
+    "question": "What is the name of the bullet train network in Japan?",
+    "answers": [
+      "Shinkansen",
+      "Metro Line",
+      "Skyrail",
+      "Kairo"
+    ],
+    "correctIndex": 0
   }
 ]

--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -84,5 +84,6 @@
   "\"〜にしたがって\" means \"as / in accordance with...\"",
   "\"〜てくれる\" indicates someone does a favor for the speaker. (practice variation 15)",
   "Use 「desu/masu」 for polite statements; it is the standard polite ending for everyday conversation.",
-  "「～te mo ii desu」 means it is okay to do something and is used to grant permission."
+  "「～te mo ii desu」 means it is okay to do something and is used to grant permission.",
+  "「～tsumori」 expresses the speaker’s intention or plan to do something."
 ]

--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -83,5 +83,6 @@
   "〜すぎる attaches to verbs or adjectives to mean too much.",
   "\"〜にしたがって\" means \"as / in accordance with...\"",
   "\"〜てくれる\" indicates someone does a favor for the speaker. (practice variation 15)",
-  "Use 「desu/masu」 for polite statements; it is the standard polite ending for everyday conversation."
+  "Use 「desu/masu」 for polite statements; it is the standard polite ending for everyday conversation.",
+  "「～te mo ii desu」 means it is okay to do something and is used to grant permission."
 ]

--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -85,5 +85,6 @@
   "\"〜てくれる\" indicates someone does a favor for the speaker. (practice variation 15)",
   "Use 「desu/masu」 for polite statements; it is the standard polite ending for everyday conversation.",
   "「～te mo ii desu」 means it is okay to do something and is used to grant permission.",
-  "「～tsumori」 expresses the speaker’s intention or plan to do something."
+  "「～tsumori」 expresses the speaker’s intention or plan to do something.",
+  "「～te morau」 means the speaker receives a favor or has someone do something for them."
 ]

--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -82,5 +82,6 @@
   "〜ことができる expresses ability, like \"can do\".",
   "〜すぎる attaches to verbs or adjectives to mean too much.",
   "\"〜にしたがって\" means \"as / in accordance with...\"",
-  "\"〜てくれる\" indicates someone does a favor for the speaker. (practice variation 15)"
+  "\"〜てくれる\" indicates someone does a favor for the speaker. (practice variation 15)",
+  "Use 「desu/masu」 for polite statements; it is the standard polite ending for everyday conversation."
 ]

--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -310,5 +310,11 @@
     "romaji": "Hana yori dango",
     "english": "Dumplings over flowers",
     "meaning": "Practical things are more valuable than aesthetic ones"
+  },
+  {
+    "japanese": "井の中の蛙大海を知らず",
+    "romaji": "I no naka no kawazu taikai wo shirazu",
+    "english": "A frog in a well does not know the great sea",
+    "meaning": "Those with limited experience cannot understand the bigger picture"
   }
 ]

--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -316,5 +316,11 @@
     "romaji": "I no naka no kawazu taikai wo shirazu",
     "english": "A frog in a well does not know the great sea",
     "meaning": "Those with limited experience cannot understand the bigger picture"
+  },
+  {
+    "japanese": "能ある鷹は爪を隠す",
+    "romaji": "Nou aru taka wa tsume wo kakusu",
+    "english": "The talented hawk hides its talons",
+    "meaning": "Truly skilled people do not show off their abilities"
   }
 ]

--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -1,308 +1,314 @@
 [
-    {
-        "japanese": "二度あることは三度ある",
-        "romaji": "Nido aru koto wa sando aru",
-        "english": "What happens twice will happen a third time",
-        "meaning": "Patterns tend to repeat"
-    },
-    {
-        "japanese": "虎穴に入らずんば虎子を得ず",
-        "romaji": "Koketsu ni irazunba koji wo ezu",
-        "english": "You can't get the tiger's cub without entering the lair",
-        "meaning": "No reward without risk"
-    },
-    {
-        "japanese": "焼け石に水",
-        "romaji": "Yake ishi ni mizu",
-        "english": "Water on a hot stone",
-        "meaning": "A futile effort"
-    },
-    {
-        "japanese": "明日は明日の風が吹く",
-        "romaji": "Ashita wa ashita no kaze ga fuku",
-        "english": "Tomorrow's wind will blow tomorrow",
-        "meaning": "Don't worry too much about the future"
-    },
-    {
-        "japanese": "雨降って地固まる",
-        "romaji": "Ame futte ji katamaru",
-        "english": "After the rain, the ground hardens",
-        "meaning": "Hard times build resilience"
-    },
-    {
-        "japanese": "知らぬが仏",
-        "romaji": "Shiranu ga hotoke",
-        "english": "Not knowing is Buddha",
-        "meaning": "Ignorance is bliss"
-    },
-    {
-        "japanese": "負けるが勝ち",
-        "romaji": "Makeru ga kachi",
-        "english": "Sometimes losing is winning",
-        "meaning": "Conceding can be the best outcome"
-    },
-    {
-        "japanese": "雨後の筍",
-        "romaji": "Ugo no takenoko",
-        "english": "Bamboo shoots after rain",
-        "meaning": "Things spring up rapidly"
-    },
-    {
-        "japanese": "出る杭は打たれる",
-        "romaji": "Deru kui wa utareru",
-        "english": "The nail that sticks out gets hammered down",
-        "meaning": "Standing out invites criticism"
-    },
-    {
-        "japanese": "情けは人の為ならず",
-        "romaji": "Nasake wa hito no tame narazu",
-        "english": "Kindness is not for others alone",
-        "meaning": "Kindness comes back to you"
-    },
-    {
-        "japanese": "急がば回れ",
-        "romaji": "Isogaba maware",
-        "english": "If in a hurry, go around",
-        "meaning": "The safer path can be faster"
-    },
-    {
-        "japanese": "一石二鳥",
-        "romaji": "Isseki nichou",
-        "english": "One stone, two birds",
-        "meaning": "Do two things with one action"
-    },
-    {
-        "japanese": "頭隠して尻隠さず",
-        "romaji": "Atama kakushite shiri kakusazu",
-        "english": "Hide your head, but not your butt",
-        "meaning": "Trying to hide something obvious"
-    },
-    {
-        "japanese": "案ずるより産むが易し",
-        "romaji": "Anzuru yori umu ga yasushi",
-        "english": "Giving birth is easier than worrying",
-        "meaning": "Things are often easier done than worried about"
-    },
-    {
-        "japanese": "猿も木から落ちる",
-        "romaji": "Saru mo ki kara ochiru",
-        "english": "Even monkeys fall from trees",
-        "meaning": "Experts can make mistakes"
-    },
-    {
-        "japanese": "善は急げ",
-        "romaji": "Zen wa isoge",
-        "english": "Hurry to do good",
-        "meaning": "Do worthwhile things promptly"
-    },
-    {
-        "japanese": "猫に小判",
-        "romaji": "Neko ni koban",
-        "english": "Gold coins to a cat",
-        "meaning": "Gifts wasted on those who don't appreciate them"
-    },
-    {
-        "japanese": "怪我の功名",
-        "romaji": "Kega no koumyou",
-        "english": "Fame from a mistake",
-        "meaning": "A lucky break that comes from an error"
-    },
-    {
-        "japanese": "魚心あれば水心",
-        "romaji": "Uogokoro areba mizugokoro",
-        "english": "If fish has heart, water has heart",
-        "meaning": "Good intentions will be reciprocated"
-    },
-    {
-        "japanese": "早起きは三文の得",
-        "romaji": "Hayaoki wa sanmon no toku",
-        "english": "Early rising is worth three coins",
-        "meaning": "Good things come from getting up early"
-    },
-    {
-        "japanese": "月とすっぽん",
-        "romaji": "Tsuki to suppon",
-        "english": "The moon and a turtle",
-        "meaning": "Vastly different; not comparable"
-    },
-    {
-        "japanese": "無い袖は振れぬ",
-        "romaji": "Nai sode wa furenu",
-        "english": "You can't shake a sleeve you don't have",
-        "meaning": "You can't give what you don't have"
-    },
-    {
-        "japanese": "転ばぬ先の杖",
-        "romaji": "Korobanu saki no tsue",
-        "english": "A cane before falling",
-        "meaning": "Prevention is better than cure"
-    },
-    {
-        "japanese": "三人寄れば文殊の知恵",
-        "romaji": "Sannin yoreba monju no chie",
-        "english": "Three people together have the wisdom of Monju",
-        "meaning": "Two heads are better than one"
-    },
-    {
-        "japanese": "犬も歩けば棒に当たる",
-        "romaji": "Inu mo arukeba bou ni ataru",
-        "english": "Even a walking dog will hit a stick",
-        "meaning": "Acting can lead to luck or trouble"
-    },
-    {
-        "japanese": "虎穴に入らずんば虎子を得ず",
-        "romaji": "Koketsu ni irazunba koji wo ezu",
-        "english": "If you don't enter the tiger's den, you can't get the cub",
-        "meaning": "Nothing ventured, nothing gained"
-    },
-    {
-        "japanese": "馬の耳に念仏",
-        "romaji": "Uma no mimi ni nenbutsu",
-        "english": "Preaching Buddha to a horse's ear",
-        "meaning": "Wasting good advice on someone who won't listen"
-    },
-    {
-        "japanese": "時が解決する",
-        "romaji": "Toki ga kaiketsu suru",
-        "english": "Time will resolve it",
-        "meaning": "Time heals all wounds / Time is the best medicine"
-    },
-    {
-        "japanese": "隣の花は赤い",
-        "romaji": "Tonari no hana wa akai",
-        "english": "The neighbor's flowers are red",
-        "meaning": "The grass is always greener on the other side"
-    },
-    {
-        "japanese": "二兎を追う者は一兎をも得ず",
-        "romaji": "Ni to wo ou mono wa itto wo mo ezu",
-        "english": "One who chases two rabbits catches neither",
-        "meaning": "Focus on one thing at a time"
-    },
-    {
-        "japanese": "雨垂れ石を穿つ",
-        "romaji": "Amadare ishi wo ugatsu",
-        "english": "Dripping water pierces stone",
-        "meaning": "Persistence can overcome great obstacles"
-    },
-    {
-        "japanese": "雨垂れ石を穿つ",
-        "romaji": "Amadare ishi wo ugatsu",
-        "english": "Dripping water pierces stone",
-        "meaning": "Persistence can overcome great obstacles"
-    },
-    {
-        "japanese": "油断大敵",
-        "romaji": "Yudan taiteki",
-        "english": "Carelessness is the greatest enemy",
-        "meaning": "Don't let your guard down"
-    },
-    {
-        "japanese": "毒を食らわば皿まで",
-        "romaji": "Doku wo kurawaba sara made",
-        "english": "If you eat poison, eat the plate too",
-        "meaning": "If you must do something risky, go all the way"
-    },
-    {
-        "japanese": "鬼に金棒",
-        "romaji": "Oni ni kanabou",
-        "english": "An iron club to an ogre",
-        "meaning": "Making someone strong even stronger"
-    },
-    {
-        "japanese": "捕らぬ狸の皮算用",
-        "romaji": "Toranu tanuki no kawazan'you",
-        "english": "Counting a raccoon dog's skins before catching it",
-        "meaning": "Don't count your chickens before they hatch"
-    },
-    {
-        "japanese": "縁の下の力持ち",
-        "romaji": "En no shita no chikaramochi",
-        "english": "A strong person under the veranda",
-        "meaning": "An unsung hero who supports behind the scenes"
-    },
-    {
-        "japanese": "灯台下暗し",
-        "romaji": "Toudai moto kurashi",
-        "english": "It's darkest under the lighthouse",
-        "meaning": "The obvious is often overlooked"
-    },
-    {
-        "japanese": "猫の額",
-        "romaji": "Neko no hitai",
-        "english": "A cat's forehead",
-        "meaning": "Very small space"
-    },
-    {
-        "japanese": "転んでもただでは起きぬ",
-        "romaji": "Koronde mo tada de wa okinu",
-        "english": "Even if you fall, don't get up empty-handed",
-        "meaning": "Learn something from every setback"
-    },
-    {
-        "japanese": "腹八分目",
-        "romaji": "Hara hachibunme",
-        "english": "Stomach 80 percent full",
-        "meaning": "Eat in moderation"
-    },
-    {
-        "japanese": "灯台下暗し",
-        "romaji": "Toudai moto kurashi",
-        "english": "It's darkest under the lighthouse",
-        "meaning": "The obvious is often overlooked"
-    },
-    {
-        "japanese": "石の上にも三年",
-        "romaji": "Ishi no ue ni mo san nen",
-        "english": "Three years on a stone",
-        "meaning": "Perseverance will be rewarded"
-    },
-    {
-        "japanese": "案ずるより産むが易し",
-        "romaji": "Anzuru yori umu ga yasushi",
-        "english": "Giving birth is easier than worrying",
-        "meaning": "Doing is often easier than worrying"
-    },
-    {
-        "japanese": "明日は明日の風が吹く",
-        "romaji": "Ashita wa ashita no kaze ga fuku",
-        "english": "Tomorrow's wind will blow tomorrow",
-        "meaning": "Don't worry too much about the future"
-    },
-    {
-        "japanese": "猿も木から落ちる",
-        "romaji": "Saru mo ki kara ochiru",
-        "english": "Even monkeys fall from trees",
-        "meaning": "Even experts make mistakes sometimes"
-    },
-    {
-        "japanese": "餅は餅屋",
-        "romaji": "Mochi wa mochiya",
-        "english": "Mochi should be made by the mochi shop",
-        "meaning": "Leave it to the experts"
-    },
-    {
-       "japanese": "石橋を叩いて渡る",
-       "romaji": "Ishibashi wo tataite wataru",
-       "english": "Tap a stone bridge before crossing",
-       "meaning": "Be very cautious"
-   },
-   {
-        "japanese": "雨降って地固まる",
-        "romaji": "Ame futte ji katamaru",
-        "english": "After rain, the ground hardens",
-        "meaning": "Adversity builds strength"
-   },
-   {
-        "japanese": "石橋を叩いて渡る",
-        "romaji": "Ishibashi wo tataite wataru",
-        "english": "Tap a stone bridge before crossing",
-        "meaning": "Be very cautious"
-    },
-    {
-        "japanese": "七転び八起き",
-        "romaji": "Nanakorobi yaoki",
-        "english": "Fall seven times, get up eight",
-        "meaning": "Never give up"
-    }
+  {
+    "japanese": "二度あることは三度ある",
+    "romaji": "Nido aru koto wa sando aru",
+    "english": "What happens twice will happen a third time",
+    "meaning": "Patterns tend to repeat"
+  },
+  {
+    "japanese": "虎穴に入らずんば虎子を得ず",
+    "romaji": "Koketsu ni irazunba koji wo ezu",
+    "english": "You can't get the tiger's cub without entering the lair",
+    "meaning": "No reward without risk"
+  },
+  {
+    "japanese": "焼け石に水",
+    "romaji": "Yake ishi ni mizu",
+    "english": "Water on a hot stone",
+    "meaning": "A futile effort"
+  },
+  {
+    "japanese": "明日は明日の風が吹く",
+    "romaji": "Ashita wa ashita no kaze ga fuku",
+    "english": "Tomorrow's wind will blow tomorrow",
+    "meaning": "Don't worry too much about the future"
+  },
+  {
+    "japanese": "雨降って地固まる",
+    "romaji": "Ame futte ji katamaru",
+    "english": "After the rain, the ground hardens",
+    "meaning": "Hard times build resilience"
+  },
+  {
+    "japanese": "知らぬが仏",
+    "romaji": "Shiranu ga hotoke",
+    "english": "Not knowing is Buddha",
+    "meaning": "Ignorance is bliss"
+  },
+  {
+    "japanese": "負けるが勝ち",
+    "romaji": "Makeru ga kachi",
+    "english": "Sometimes losing is winning",
+    "meaning": "Conceding can be the best outcome"
+  },
+  {
+    "japanese": "雨後の筍",
+    "romaji": "Ugo no takenoko",
+    "english": "Bamboo shoots after rain",
+    "meaning": "Things spring up rapidly"
+  },
+  {
+    "japanese": "出る杭は打たれる",
+    "romaji": "Deru kui wa utareru",
+    "english": "The nail that sticks out gets hammered down",
+    "meaning": "Standing out invites criticism"
+  },
+  {
+    "japanese": "情けは人の為ならず",
+    "romaji": "Nasake wa hito no tame narazu",
+    "english": "Kindness is not for others alone",
+    "meaning": "Kindness comes back to you"
+  },
+  {
+    "japanese": "急がば回れ",
+    "romaji": "Isogaba maware",
+    "english": "If in a hurry, go around",
+    "meaning": "The safer path can be faster"
+  },
+  {
+    "japanese": "一石二鳥",
+    "romaji": "Isseki nichou",
+    "english": "One stone, two birds",
+    "meaning": "Do two things with one action"
+  },
+  {
+    "japanese": "頭隠して尻隠さず",
+    "romaji": "Atama kakushite shiri kakusazu",
+    "english": "Hide your head, but not your butt",
+    "meaning": "Trying to hide something obvious"
+  },
+  {
+    "japanese": "案ずるより産むが易し",
+    "romaji": "Anzuru yori umu ga yasushi",
+    "english": "Giving birth is easier than worrying",
+    "meaning": "Things are often easier done than worried about"
+  },
+  {
+    "japanese": "猿も木から落ちる",
+    "romaji": "Saru mo ki kara ochiru",
+    "english": "Even monkeys fall from trees",
+    "meaning": "Experts can make mistakes"
+  },
+  {
+    "japanese": "善は急げ",
+    "romaji": "Zen wa isoge",
+    "english": "Hurry to do good",
+    "meaning": "Do worthwhile things promptly"
+  },
+  {
+    "japanese": "猫に小判",
+    "romaji": "Neko ni koban",
+    "english": "Gold coins to a cat",
+    "meaning": "Gifts wasted on those who don't appreciate them"
+  },
+  {
+    "japanese": "怪我の功名",
+    "romaji": "Kega no koumyou",
+    "english": "Fame from a mistake",
+    "meaning": "A lucky break that comes from an error"
+  },
+  {
+    "japanese": "魚心あれば水心",
+    "romaji": "Uogokoro areba mizugokoro",
+    "english": "If fish has heart, water has heart",
+    "meaning": "Good intentions will be reciprocated"
+  },
+  {
+    "japanese": "早起きは三文の得",
+    "romaji": "Hayaoki wa sanmon no toku",
+    "english": "Early rising is worth three coins",
+    "meaning": "Good things come from getting up early"
+  },
+  {
+    "japanese": "月とすっぽん",
+    "romaji": "Tsuki to suppon",
+    "english": "The moon and a turtle",
+    "meaning": "Vastly different; not comparable"
+  },
+  {
+    "japanese": "無い袖は振れぬ",
+    "romaji": "Nai sode wa furenu",
+    "english": "You can't shake a sleeve you don't have",
+    "meaning": "You can't give what you don't have"
+  },
+  {
+    "japanese": "転ばぬ先の杖",
+    "romaji": "Korobanu saki no tsue",
+    "english": "A cane before falling",
+    "meaning": "Prevention is better than cure"
+  },
+  {
+    "japanese": "三人寄れば文殊の知恵",
+    "romaji": "Sannin yoreba monju no chie",
+    "english": "Three people together have the wisdom of Monju",
+    "meaning": "Two heads are better than one"
+  },
+  {
+    "japanese": "犬も歩けば棒に当たる",
+    "romaji": "Inu mo arukeba bou ni ataru",
+    "english": "Even a walking dog will hit a stick",
+    "meaning": "Acting can lead to luck or trouble"
+  },
+  {
+    "japanese": "虎穴に入らずんば虎子を得ず",
+    "romaji": "Koketsu ni irazunba koji wo ezu",
+    "english": "If you don't enter the tiger's den, you can't get the cub",
+    "meaning": "Nothing ventured, nothing gained"
+  },
+  {
+    "japanese": "馬の耳に念仏",
+    "romaji": "Uma no mimi ni nenbutsu",
+    "english": "Preaching Buddha to a horse's ear",
+    "meaning": "Wasting good advice on someone who won't listen"
+  },
+  {
+    "japanese": "時が解決する",
+    "romaji": "Toki ga kaiketsu suru",
+    "english": "Time will resolve it",
+    "meaning": "Time heals all wounds / Time is the best medicine"
+  },
+  {
+    "japanese": "隣の花は赤い",
+    "romaji": "Tonari no hana wa akai",
+    "english": "The neighbor's flowers are red",
+    "meaning": "The grass is always greener on the other side"
+  },
+  {
+    "japanese": "二兎を追う者は一兎をも得ず",
+    "romaji": "Ni to wo ou mono wa itto wo mo ezu",
+    "english": "One who chases two rabbits catches neither",
+    "meaning": "Focus on one thing at a time"
+  },
+  {
+    "japanese": "雨垂れ石を穿つ",
+    "romaji": "Amadare ishi wo ugatsu",
+    "english": "Dripping water pierces stone",
+    "meaning": "Persistence can overcome great obstacles"
+  },
+  {
+    "japanese": "雨垂れ石を穿つ",
+    "romaji": "Amadare ishi wo ugatsu",
+    "english": "Dripping water pierces stone",
+    "meaning": "Persistence can overcome great obstacles"
+  },
+  {
+    "japanese": "油断大敵",
+    "romaji": "Yudan taiteki",
+    "english": "Carelessness is the greatest enemy",
+    "meaning": "Don't let your guard down"
+  },
+  {
+    "japanese": "毒を食らわば皿まで",
+    "romaji": "Doku wo kurawaba sara made",
+    "english": "If you eat poison, eat the plate too",
+    "meaning": "If you must do something risky, go all the way"
+  },
+  {
+    "japanese": "鬼に金棒",
+    "romaji": "Oni ni kanabou",
+    "english": "An iron club to an ogre",
+    "meaning": "Making someone strong even stronger"
+  },
+  {
+    "japanese": "捕らぬ狸の皮算用",
+    "romaji": "Toranu tanuki no kawazan'you",
+    "english": "Counting a raccoon dog's skins before catching it",
+    "meaning": "Don't count your chickens before they hatch"
+  },
+  {
+    "japanese": "縁の下の力持ち",
+    "romaji": "En no shita no chikaramochi",
+    "english": "A strong person under the veranda",
+    "meaning": "An unsung hero who supports behind the scenes"
+  },
+  {
+    "japanese": "灯台下暗し",
+    "romaji": "Toudai moto kurashi",
+    "english": "It's darkest under the lighthouse",
+    "meaning": "The obvious is often overlooked"
+  },
+  {
+    "japanese": "猫の額",
+    "romaji": "Neko no hitai",
+    "english": "A cat's forehead",
+    "meaning": "Very small space"
+  },
+  {
+    "japanese": "転んでもただでは起きぬ",
+    "romaji": "Koronde mo tada de wa okinu",
+    "english": "Even if you fall, don't get up empty-handed",
+    "meaning": "Learn something from every setback"
+  },
+  {
+    "japanese": "腹八分目",
+    "romaji": "Hara hachibunme",
+    "english": "Stomach 80 percent full",
+    "meaning": "Eat in moderation"
+  },
+  {
+    "japanese": "灯台下暗し",
+    "romaji": "Toudai moto kurashi",
+    "english": "It's darkest under the lighthouse",
+    "meaning": "The obvious is often overlooked"
+  },
+  {
+    "japanese": "石の上にも三年",
+    "romaji": "Ishi no ue ni mo san nen",
+    "english": "Three years on a stone",
+    "meaning": "Perseverance will be rewarded"
+  },
+  {
+    "japanese": "案ずるより産むが易し",
+    "romaji": "Anzuru yori umu ga yasushi",
+    "english": "Giving birth is easier than worrying",
+    "meaning": "Doing is often easier than worrying"
+  },
+  {
+    "japanese": "明日は明日の風が吹く",
+    "romaji": "Ashita wa ashita no kaze ga fuku",
+    "english": "Tomorrow's wind will blow tomorrow",
+    "meaning": "Don't worry too much about the future"
+  },
+  {
+    "japanese": "猿も木から落ちる",
+    "romaji": "Saru mo ki kara ochiru",
+    "english": "Even monkeys fall from trees",
+    "meaning": "Even experts make mistakes sometimes"
+  },
+  {
+    "japanese": "餅は餅屋",
+    "romaji": "Mochi wa mochiya",
+    "english": "Mochi should be made by the mochi shop",
+    "meaning": "Leave it to the experts"
+  },
+  {
+    "japanese": "石橋を叩いて渡る",
+    "romaji": "Ishibashi wo tataite wataru",
+    "english": "Tap a stone bridge before crossing",
+    "meaning": "Be very cautious"
+  },
+  {
+    "japanese": "雨降って地固まる",
+    "romaji": "Ame futte ji katamaru",
+    "english": "After rain, the ground hardens",
+    "meaning": "Adversity builds strength"
+  },
+  {
+    "japanese": "石橋を叩いて渡る",
+    "romaji": "Ishibashi wo tataite wataru",
+    "english": "Tap a stone bridge before crossing",
+    "meaning": "Be very cautious"
+  },
+  {
+    "japanese": "七転び八起き",
+    "romaji": "Nanakorobi yaoki",
+    "english": "Fall seven times, get up eight",
+    "meaning": "Never give up"
+  },
+  {
+    "japanese": "花より団子",
+    "romaji": "Hana yori dango",
+    "english": "Dumplings over flowers",
+    "meaning": "Practical things are more valuable than aesthetic ones"
+  }
 ]

--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -63,24 +63,31 @@
     "character": "Luke fon Fabre"
   },
   {
-  "japanese": "冒険の始まりだ！",
-  "romaji": "Bouken no hajimari da!",
-  "english": "This is the beginning of the adventure!",
-  "game": "Dragon Quest XI",
-  "character": "Hero / party lines"
+    "japanese": "冒険の始まりだ！",
+    "romaji": "Bouken no hajimari da!",
+    "english": "This is the beginning of the adventure!",
+    "game": "Dragon Quest XI",
+    "character": "Hero / party lines"
   },
   {
-  "japanese": "俺たちの物語は、ここからだ",
-  "romaji": "Oretachi no monogatari wa, koko kara da",
-  "english": "Our story starts here.",
-  "game": "Tales series",
-  "character": "Various endings"
-},
-{
-  "japanese": "覚悟はいいか？ 俺はできてる。",
-  "romaji": "Kakugo wa ii ka? Ore wa dekiteru.",
-  "english": "Are you prepared? I am.",
-  "game": "JoJo’s Bizarre Adventure: All-Star Battle",
-  "character": "Giorno Giovanna"
-}
+    "japanese": "俺たちの物語は、ここからだ",
+    "romaji": "Oretachi no monogatari wa, koko kara da",
+    "english": "Our story starts here.",
+    "game": "Tales series",
+    "character": "Various endings"
+  },
+  {
+    "japanese": "覚悟はいいか？ 俺はできてる。",
+    "romaji": "Kakugo wa ii ka? Ore wa dekiteru.",
+    "english": "Are you prepared? I am.",
+    "game": "JoJo’s Bizarre Adventure: All-Star Battle",
+    "character": "Giorno Giovanna"
+  },
+  {
+    "japanese": "約束された勝利の剣",
+    "romaji": "Yakusoku sareta shouri no ken",
+    "english": "The Sword of Promised Victory.",
+    "game": "Fate/stay night [Realta Nua]",
+    "character": "Saber"
+  }
 ]

--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -89,5 +89,12 @@
     "english": "The Sword of Promised Victory.",
     "game": "Fate/stay night [Realta Nua]",
     "character": "Saber"
+  },
+  {
+    "japanese": "未来を変えるんだ！",
+    "romaji": "Mirai o kaerun da!",
+    "english": "We're going to change the future!",
+    "game": "Steins;Gate: My Darling's Embrace",
+    "character": "Rintaro Okabe"
   }
 ]

--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -96,5 +96,12 @@
     "english": "We're going to change the future!",
     "game": "Steins;Gate: My Darling's Embrace",
     "character": "Rintaro Okabe"
+  },
+  {
+    "japanese": "希望は前に進むんだ！",
+    "romaji": "Kibou wa mae ni susumun da!",
+    "english": "Hope moves forward!",
+    "game": "Danganronpa series",
+    "character": "Makoto Naegi"
   }
 ]


### PR DESCRIPTION
## Summary

Adds 22 new community content entries across 6 categories, sourced from the existing backlog:

- **6 Japan facts** — blood type personality, age-otori, Aokigahara forest, tarento culture, curry rice day, ma concept
- **4 Grammar points** — desu/masu polite form, te mo ii permission, tsumori intention, te morau favor
- **4 Anime quotes** — DIO (road roller, muda muda), Okuyasu, Kenshiro
- **3 Japanese proverbs** — hana yori dango, frog in a well, talented hawk
- **3 Video game quotes** — Fate/stay night, Steins;Gate, Danganronpa
- **2 Trivia questions** — Itsukushima torii gate, Shinkansen bullet train

## Test plan

- [x] All JSON files validated — no syntax errors
- [x] All entries sourced from backlog (no duplicates with existing content)
- [x] Each commit is atomic and independently meaningful