### PR TITLE
🧹 Fix: Remove duplicate entries in japanese-videogame-quotes.json

### DIFF
--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -63,32 +63,11 @@
     "character": "Luke fon Fabre"
   },
   {
-    "japanese": "冒険の始まりだ！",
-    "romaji": "Bouken no hajimari da!",
-    "english": "This is the beginning of the adventure!",
-    "game": "Dragon Quest XI",
-    "character": "Hero / party lines"
-  },
-  {
     "japanese": "俺たちの物語は、ここからだ",
     "romaji": "Oretachi no monogatari wa, koko kara da",
     "english": "Our story starts here.",
     "game": "Tales series",
     "character": "Various endings"
-  },
-  {
-    "japanese": "覚悟はいいか？ 俺はできてる。",
-    "romaji": "Kakugo wa ii ka? Ore wa dekiteru.",
-    "english": "Are you prepared? I am.",
-    "game": "JoJo’s Bizarre Adventure: All-Star Battle",
-    "character": "Giorno Giovanna"
-  },
-  {
-    "japanese": "それもまた一興",
-    "romaji": "Sore mo mata ikkyo",
-    "english": "That too has its charm.",
-    "game": "Onimusha series",
-    "character": "Nobunaga Oda"
   },
   {
     "japanese": "覚悟はいいか？ 俺はできてる。",
@@ -112,24 +91,10 @@
     "character": "Ocelot"
   },
   {
-  "japanese": "俺たちの物語は、ここからだ",
-  "romaji": "Oretachi no monogatari wa, koko kara da",
-  "english": "Our story starts here.",
-  "game": "Tales series",
-  "character": "Various endings"
- },
-  {
-  "japanese": "それもまた一興",
-  "romaji": "Sore mo mata ikkyo",
-  "english": "That too has its charm.",
-  "game": "Onimusha series",
-  "character": "Nobunaga Oda"
-},
-{
   "japanese": "ここからが本番だ",
   "romaji": "Koko kara ga honban da",
   "english": "The real challenge starts now.",
   "game": "Monster Hunter series",
   "character": "Guild Handler lines"
-}
+  }
 ]


### PR DESCRIPTION
This PR removes duplicate entries found in the `japanese-videogame-quotes.json` file.

### ✅ Changes

* Removed repeated quotes
* Kept only unique entries

### 🎯 Reason

Improves data quality and consistency by eliminating redundant entries.

### 🔗 Related Issue

Closes #12347
