### PR TITLE
feat(theme): add Shibuya Nights theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -274,5 +274,11 @@
     "backgroundColor": "oklch(15.0% 0.055 310.0 / 1)",
     "mainColor": "oklch(80.0% 0.210 345.0 / 1)",
     "secondaryColor": "oklch(85.0% 0.175 180.0 / 1)"
+  },
+  {
+    "id": "shibuya-nights",
+    "backgroundColor": "oklch(12.0% 0.045 290.0 / 1)",
+    "mainColor": "oklch(78.0% 0.225 330.0 / 1)",
+    "secondaryColor": "oklch(82.0% 0.180 200.0 / 1)"
   }
 ]


### PR DESCRIPTION
## Summary

Adds the Shibuya Nights color theme to `community/content/community-themes.json`.

- **ID**: `shibuya-nights`
- **Background**: `oklch(12.0% 0.045 290.0 / 1)` — deep midnight blue-violet
- **Main**: `oklch(78.0% 0.225 330.0 / 1)` — vibrant neon pink
- **Secondary**: `oklch(82.0% 0.180 200.0 / 1)` — electric cyan

Inspired by Tokyo's neon-lit Shibuya district after dark.

Closes #12415