### PR TITLE
feat(theme): add Ocean Tofu theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -310,5 +310,11 @@
     "backgroundColor": "oklch(17.0% 0.030 245.0 / 1)",
     "mainColor": "oklch(88.0% 0.055 230.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.145 210.0 / 1)"
+  },
+  {
+    "id": "ocean-tofu",
+    "backgroundColor": "oklch(21.0% 0.042 235.0 / 1)",
+    "mainColor": "oklch(92.0% 0.025 240.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.135 225.0 / 1)"
   }
 ]


### PR DESCRIPTION
Closes #12585

Added the Ocean Tofu color theme to `community/content/community-themes.json`.

Theme details:
- ID: `ocean-tofu`
- Background: `oklch(21.0% 0.042 235.0 / 1)`
- Main Color: `oklch(92.0% 0.025 240.0 / 1)`
- Secondary: `oklch(70.0% 0.135 225.0 / 1)`

Vibe: Soft whites and deep Pacific blues.