### PR TITLE
content: add japan fact #204 - yorimichi detour concept

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -74,5 +74,6 @@
   "Japan has 'pocky day' on November 11 (11/11) because the date looks like four Pocky sticks standing in a row.",
   "Japan has smart toilets that analyze your waste and display health metrics on a screen - some even save data to apps.",
   "The word 'utsukushii' (美しい) means beautiful but implies something naturally elegant rather than artificially pretty.",
-  "There's a Japanese word 'waku-waku' (わくわく) for excited anticipation - the tingly feeling of looking forward to something."
+  "There's a Japanese word 'waku-waku' (わくわく) for excited anticipation - the tingly feeling of looking forward to something.",
+  "The Japanese word 'yorimichi' (寄り道) means taking a pleasant detour on the way home just because."
 ]


### PR DESCRIPTION
Adds Japan Fact #204 to the collection.

**Fact added:**
> The Japanese word 'yorimichi' (寄り道) means taking a pleasant detour on the way home just because.

Closes #12620