### PR TITLE
content: add japan fact #40

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -75,5 +75,6 @@
   "Japan has smart toilets that analyze your waste and display health metrics on a screen - some even save data to apps.",
   "The word 'utsukushii' (美しい) means beautiful but implies something naturally elegant rather than artificially pretty.",
   "There's a Japanese word 'waku-waku' (わくわく) for excited anticipation - the tingly feeling of looking forward to something.",
-  "There's a Japanese concept 'ningensei' (人間性) meaning humanity or human nature - the qualities that make us human."
+  "There's a Japanese concept 'ningensei' (人間性) meaning humanity or human nature - the qualities that make us human.",
+  "There are over 200 different KitKat flavors created for Japan including sake, wasabi, sweet potato, and cherry blossom."
 ]


### PR DESCRIPTION
Add a fun fact about Japan's KitKat variety for the community content collection.

## Changes
- Added fact to `community/content/japan-facts.json`

## Fact Added
> There are over 200 different KitKat flavors created for Japan including sake, wasabi, sweet potato, and cherry blossom.

Closes #12704