### PR TITLE
feat(theme): add Sumo Strength theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -352,5 +352,11 @@
   "backgroundColor": "oklch(19.0% 0.020 250.0 / 1)",
   "mainColor": "oklch(72.0% 0.050 215.0 / 1)",
   "secondaryColor": "oklch(60.0% 0.040 230.0 / 1)"
+  },
+  {
+    "id": "sumo-strength",
+    "backgroundColor": "oklch(20.0% 0.022 35.0 / 1)",
+    "mainColor": "oklch(72.0% 0.065 75.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.185 20.0 / 1)"
   }
 ]


### PR DESCRIPTION
## Summary

Adds the **Sumo Strength** color theme to `community/content/community-themes.json`.

| Property | Value |
|----------|-------|
| **ID** | `sumo-strength` |
| **Background** | `oklch(20.0% 0.022 35.0 / 1)` |
| **Main Color** | `oklch(72.0% 0.065 75.0 / 1)` |
| **Secondary** | `oklch(60.0% 0.185 20.0 / 1)` |

> 💡 Vibe: Power and tradition in the ring

Closes #12943