### PR TITLE
content: add japanese proverb #118 — 覆水盆に返らず

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -490,5 +490,11 @@
     "romaji": "Inu mo arukeba bou ni ataru",
     "english": "Even a walking dog will hit a stick",
     "meaning": "Acting can lead to luck (or trouble)"
+  },
+  {
+    "japanese": "覆水盆に返らず",
+    "romaji": "Fukusui bon ni kaerazu",
+    "english": "Spilled water will not return to the tray",
+    "meaning": "What is done cannot be undone"
   }
 ]


### PR DESCRIPTION
## Summary

Adds classic Japanese proverb #118 to the community content library.

- **Proverb:** 覆水盆に返らず
- **Reading:** Fukusui bon ni kaerazu
- **Meaning:** What is done cannot be undone

Closes #12946

## Test plan

- [ ] JSON file parses without errors
- [ ] New entry follows existing schema (`japanese`, `romaji`, `english`, `meaning`)
- [ ] Entry appended at end of array with correct comma placement

🤖 Generated with [Claude Code](https://claude.com/claude-code)