### PR TITLE
feat: add new Japan Fact 98

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -49,12 +49,13 @@
   "Japan has over 1,500 earthquakes every year because it sits on the Pacific Ring of Fire.",
   "Japan has 'chiiki matsuri' — neighborhood festivals run by local committees where residents carry portable shrines together.",
   "The phrase 'ichigo ichie' (一期一会) means 'one time, one meeting' - reminding people to treasure each encounter.",
-  "The Japanese word 'koi no yokan' (恋の予感) describes knowing you'll inevitably fall in love with someone you just met.",
+  "The Japanese word 'koi no yokan' (恋 of 予感) describes knowing you'll inevitably fall in love with someone you just met.",
   "In many Japanese cities, you can find public 'koban' (交番) — small neighborhood police boxes that help with directions and lost items.",
   "The concept 'taisetsu' (大切) means precious or important - often said about relationships and feelings, not objects.",
   "There's a Japanese word 'nekojita' (猫舌) meaning 'cat tongue' — someone who can't eat or drink hot things.",
   "Japan has a 15-meter tall Gundam robot in Yokohama that can actually move its arms, legs, and fingers.",
   "Japan has 'para-para' dancing - a synchronized hand-waving dance performed to eurobeat in nightclubs since the 1980s.",
   "The word 'shiawase' (幸せ) for happiness originally meant 'what happens' - suggesting happiness is accepting what comes.",
-  "Japan has a highway that passes directly through a building in Osaka - the Gate Tower Building has floors 5-7 as a tunnel."
+  "Japan has a highway that passes directly through a building in Osaka - the Gate Tower Building has floors 5-7 as a tunnel.",
+  "Nagoro, a village in Japan, is famous for its 'resident' dolls. A local artist created over 350 life-sized dolls to replace neighbors who passed away or moved, far outnumbering the remaining human residents."
 ]


### PR DESCRIPTION
This PR adds a new Japan Fact to the collection as requested.

Fact added:
- Nagoro, a village in Japan, is famous for its 'resident' dolls. A local artist created over 350 life-sized dolls to replace neighbors who passed away or moved, far outnumbering the remaining human residents.

Fixes #12978