### PR TITLE
feat(theme): add Ruby Kabuki theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -358,5 +358,11 @@
     "backgroundColor": "oklch(92.0% 0.025 145.0 / 1)",
     "mainColor": "oklch(55.0% 0.175 145.0 / 1)",
     "secondaryColor": "oklch(45.0% 0.125 140.0 / 1)"
+  },
+  {
+    "id": "ruby-kabuki",
+    "backgroundColor": "oklch(16.0% 0.040 20.0 / 1)",
+    "mainColor": "oklch(70.0% 0.215 25.0 / 1)",
+    "secondaryColor": "oklch(85.0% 0.055 95.0 / 1)"
   }
 ]


### PR DESCRIPTION
Adds the **Ruby Kabuki** color theme to `community/content/community-themes.json`.

| Property | Value |
|----------|-------|
| **ID** | `ruby-kabuki` |
| **Background** | `oklch(16.0% 0.040 20.0 / 1)` |
| **Main Color** | `oklch(70.0% 0.215 25.0 / 1)` |
| **Secondary** | `oklch(85.0% 0.055 95.0 / 1)` |

Closes #12998