### PR TITLE
content: add new japan fact 311 — mono no aware

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -79,5 +79,6 @@
   "There's a Japanese practice 'teineisa' (丁寧さ) meaning politeness shown through meticulous attention to detail.",
   "Japan has 'salary men insurance' that pays out if you're transferred to a remote location away from your family.",
   "There's a Japanese concept 'on' (恩) - a debt of gratitude so deep it can never truly be repaid, only acknowledged.",
-  "Japan pioneered the concept of 'mukbang' content but calls it 'tabehoudai' (food challenge) which predates Korean streaming."
+  "Japan pioneered the concept of 'mukbang' content but calls it 'tabehoudai' (food challenge) which predates Korean streaming.",
+  "'Mono no aware' (物の哀れ) is an aesthetic of gentle sadness at the impermanence of things."
 ]


### PR DESCRIPTION
## Summary

Closes #12999

Adds Japan Fact #311 to `community/content/japan-facts.json` as requested in the issue.

**Fact added:**
> 'Mono no aware' (物の哀れ) is an aesthetic of gentle sadness at the impermanence of things.

## Checklist
- [x] Fact appended before the closing `]`
- [x] Comma added after the previous last entry
- [x] JSON validated (parses without errors)
- [x] No other files modified