### PR TITLE
feat: add Japan Fact #93 - tekito (適当) dual meaning

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -79,5 +79,6 @@
   "There's a Japanese practice 'teineisa' (丁寧さ) meaning politeness shown through meticulous attention to detail.",
   "Japan has 'salary men insurance' that pays out if you're transferred to a remote location away from your family.",
   "There's a Japanese concept 'on' (恩) - a debt of gratitude so deep it can never truly be repaid, only acknowledged.",
-  "Japan pioneered the concept of 'mukbang' content but calls it 'tabehoudai' (food challenge) which predates Korean streaming."
+  "Japan pioneered the concept of 'mukbang' content but calls it 'tabehoudai' (food challenge) which predates Korean streaming.",
+  "The Japanese word 'tekito' (適当) means both 'appropriate' and 'whatever/random' depending on context and tone."
 ]


### PR DESCRIPTION
## Summary

Adds Japan Fact #93 as requested in issue #13012.

**The fact:**
> The Japanese word 'tekito' (適当) means both 'appropriate' and 'whatever/random' depending on context and tone.

- Appended to `community/content/japan-facts.json`
- JSON validated (82 facts total, all well-formed)
- Closes #13012

🤖 Generated with [Claude Code](https://claude.com/claude-code)