### PR TITLE
feat(theme): add Plum Blossom theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -376,5 +376,11 @@
   "backgroundColor": "oklch(23.0% 0.045 85.0 / 1)",
   "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
   "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
-}, 
+},
+{
+  "id": "plum-blossom",
+  "backgroundColor": "oklch(23.0% 0.042 340.0 / 1)",
+  "mainColor": "oklch(78.0% 0.165 350.0 / 1)",
+  "secondaryColor": "oklch(88.0% 0.095 85.0 / 1)"
+}
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -360,10 +360,10 @@
     "secondaryColor": "oklch(45.0% 0.125 140.0 / 1)"
   },
   {
-  id: 'coastal-breeze',
-  backgroundColor: 'oklch(20.0% 0.035 225.0 / 1)',
-  mainColor: 'oklch(80.0% 0.120 210.0 / 1)',
-  secondaryColor: 'oklch(70.0% 0.085 195.0 / 1)'
+  "id": "coastal-breeze",
+  "backgroundColor": "oklch(20.0% 0.035 225.0 / 1)",
+  "mainColor": "oklch(80.0% 0.120 210.0 / 1)",
+  "secondaryColor": "oklch(70.0% 0.085 195.0 / 1)"
 },
 {
   "id": "fuji-shadow",


### PR DESCRIPTION
## Summary

Adds a new **Plum Blossom** theme to KanaDojo's community themes collection.

### Theme Details
- **ID:** `plum-blossom`
- **Background:** `oklch(23.0% 0.042 340.0 / 1)` — deep plum tone
- **Main Color:** `oklch(78.0% 0.165 350.0 / 1)` — soft pink blossom
- **Secondary Color:** `oklch(88.0% 0.095 85.0 / 1)` — warm cream accent

> 💡 Vibe: Early spring ume flowers in soft pink

## Changes
- Added new theme entry to `community/content/community-themes.json`

## Verification
- Theme follows the exact format of existing community themes
- All color values use oklch color space (consistent with project conventions)
- JSON structure matches existing entries

Closes #13134