### PR TITLE
content: add new grammar point #99 - なくてもいい

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -77,5 +77,6 @@
   "\"〜に違いない\" means \"must be\" or \"no doubt\". (practice variation 38)",
   "\"〜ところ\" can mean \"just did / about to do / in the middle of\".",
   "\"〜ことがある\" means \"sometimes\" when talking about habitual actions. (practice variation 42)",
-  "\"〜ていく/〜てくる\" shows direction or change over time, like \"will start\" or \"have been\"."
+  "\"〜ていく/〜てくる\" shows direction or change over time, like \"will start\" or \"have been\".",
+  "\"〜なくてもいい\" means \"don't have to\" and lifts an obligation. (practice variation 14)"
 ]


### PR DESCRIPTION
## Summary

Adds a new Japanese grammar point to the community collection.

### Grammar Point
> "〜なくてもいい" means "don't have to" and lifts an obligation. (practice variation 14)

## Changes
- Added new entry to `community/content/japanese-grammar.json`

Closes #13128