### PR TITLE
feat(theme): add Festival Yatai theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -377,4 +377,11 @@
   "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
   "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
 }, 
+,
+{
+  "id": "festival-yatai",
+  "backgroundColor": "oklch(19.0% 0.030 35.0 / 1)",
+  "mainColor": "oklch(78.0% 0.185 45.0 / 1)",
+  "secondaryColor": "oklch(88.0% 0.115 95.0 / 1)"
+}
 ]


### PR DESCRIPTION
## Summary

Adds a new **Festival Yatai** theme to KanaDojo's community themes collection.

### Theme Details
- **ID:** `festival-yatai`
- **Background:** `oklch(19.0% 0.030 35.0 / 1)` — dark warm tone
- **Main Color:** `oklch(78.0% 0.185 45.0 / 1)` — red lantern glow
- **Secondary Color:** `oklch(88.0% 0.115 95.0 / 1)` — gold sign accent

> 💡 Vibe: Street stalls: red lanterns and gold signs

## Changes
- Added new theme entry to `community/content/community-themes.json`

Closes #13123