### PR TITLE
content: add new japan fact #276 - kirei

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -82,5 +82,6 @@
   "Japan pioneered the concept of 'mukbang' content but calls it 'tabehoudai' (food challenge) which predates Korean streaming.",
   "Japan has 'sento' public bathhouses that predate modern plumbing and still serve as neighborhood gathering spots.",
   "Japan’s 'tanabata' festival celebrates star-crossed lovers with colorful paper wishes tied to bamboo branches.",
-  "Japan has 'yukidaruma' (雪だるま) snowman festivals where entire parks fill with glowing snow lanterns."
+  "Japan has 'yukidaruma' (雪だるま) snowman festivals where entire parks fill with glowing snow lanterns.",
+  "The term 'kirei' (綺麗) means both 'beautiful' and 'clean', linking aesthetics with neatness."
 ]


### PR DESCRIPTION
## Summary

Adds a new Japan fact about the word 'kirei' (綺麗).

### Fact
> The term 'kirei' (綺麗) means both 'beautiful' and 'clean', linking aesthetics with neatness.

## Changes
- Added new entry to `community/content/japan-facts.json`

Closes #13141