### PR TITLE
content: add new japan fact #11 - future self letter

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -82,5 +82,6 @@
   "Japan pioneered the concept of 'mukbang' content but calls it 'tabehoudai' (food challenge) which predates Korean streaming.",
   "Japan has 'sento' public bathhouses that predate modern plumbing and still serve as neighborhood gathering spots.",
   "Japan’s 'tanabata' festival celebrates star-crossed lovers with colorful paper wishes tied to bamboo branches.",
-  "Japan has 'yukidaruma' (雪だるま) snowman festivals where entire parks fill with glowing snow lanterns."
+  "Japan has 'yukidaruma' (雪だるま) snowman festivals where entire parks fill with glowing snow lanterns.",
+  "Japan's postal system has a special service where you can mail a letter to your future self, and they'll deliver it years later on the date you specify."
 ]


### PR DESCRIPTION
## Summary

Adds a new Japan fact about the postal system's future-self letter service.

### Fact
> Japan's postal system has a special service where you can mail a letter to your future self, and they'll deliver it years later on the date you specify.

## Changes
- Added new entry to `community/content/japan-facts.json`

Closes #13116