### PR TITLE
feat(theme): add Tokyo Metro theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -377,4 +377,11 @@
   "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
   "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
 }, 
+,
+{
+  "id": "tokyo-metro",
+  "backgroundColor": "oklch(20.0% 0.025 260.0 / 1)",
+  "mainColor": "oklch(70.0% 0.180 145.0 / 1)",
+  "secondaryColor": "oklch(80.0% 0.120 50.0 / 1)"
+}
 ]


### PR DESCRIPTION
## Summary

Adds a new **Tokyo Metro** theme to KanaDojo's community themes collection.

### Theme Details
- **ID:** `tokyo-metro`
- **Background:** `oklch(20.0% 0.025 260.0 / 1)` — deep subway tone
- **Main Color:** `oklch(70.0% 0.180 145.0 / 1)` — metro line accent
- **Secondary Color:** `oklch(80.0% 0.120 50.0 / 1)` — warm station glow

> 💡 Vibe: Underground commute through the city's veins

## Changes
- Added new theme entry to `community/content/community-themes.json`

Closes #13115