### PR TITLE
feat(theme): add Coastal Shrine theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -360,21 +360,27 @@
     "secondaryColor": "oklch(45.0% 0.125 140.0 / 1)"
   },
   {
-  id: 'coastal-breeze',
-  backgroundColor: 'oklch(20.0% 0.035 225.0 / 1)',
-  mainColor: 'oklch(80.0% 0.120 210.0 / 1)',
-  secondaryColor: 'oklch(70.0% 0.085 195.0 / 1)'
-},
-{
-  "id": "fuji-shadow",
-  "backgroundColor": "oklch(15.0% 0.015 250.0 / 1)",
-  "mainColor": "oklch(78.0% 0.035 230.0 / 1)",
-  "secondaryColor": "oklch(65.0% 0.105 300.0 / 1)"
-},
-{
-  "id": "ginkgo-gold",
-  "backgroundColor": "oklch(23.0% 0.045 85.0 / 1)",
-  "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
-  "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
-}, 
+    "id": "coastal-breeze",
+    "backgroundColor": "oklch(20.0% 0.035 225.0 / 1)",
+    "mainColor": "oklch(80.0% 0.120 210.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.085 195.0 / 1)"
+  },
+  {
+    "id": "fuji-shadow",
+    "backgroundColor": "oklch(15.0% 0.015 250.0 / 1)",
+    "mainColor": "oklch(78.0% 0.035 230.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.105 300.0 / 1)"
+  },
+  {
+    "id": "ginkgo-gold",
+    "backgroundColor": "oklch(23.0% 0.045 85.0 / 1)",
+    "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
+    "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
+  },
+  {
+    "id": "coastal-shrine",
+    "backgroundColor": "oklch(20.0% 0.040 235.0 / 1)",
+    "mainColor": "oklch(78.0% 0.205 35.0 / 1)",
+    "secondaryColor": "oklch(88.0% 0.065 210.0 / 1)"
+  }
 ]


### PR DESCRIPTION
## 📝 Description
Add new color theme: Coastal Shrine (海辺の神社) - sea spray and vermilion gates vibe.

Also fixed JSON formatting issue in community-themes.json (unquoted keys and single quotes in coastal-breeze entry).

## ✅ Checklist
- [x] Added theme to the correct JSON file
- [x] Followed the data structure from existing entries
- [x] Fixed pre-existing JSON formatting issue

Closes #13158