### PR TITLE
feat(theme): add Calligraphy Ink theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -456,3 +456,9 @@
   "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
 }
 ]
+,{
+  "id": "calligraphy-ink",
+  "backgroundColor": "oklch(96.0% 0.008 85.0 / 1)",
+  "mainColor": "oklch(20.0% 0.015 270.0 / 1)",
+  "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
+}]


### PR DESCRIPTION
## Summary

Adds the new Calligraphy Ink theme as requested in #13393.

## Changes

- Added theme object to `community/content/community-themes.json` with the specified color values:
  - ID: `calligraphy-ink`
  - Background: `oklch(96.0% 0.008 85.0 / 1)`
  - Main Color: `oklch(20.0% 0.015 270.0 / 1)`
  - Secondary: `oklch(45.0% 0.025 260.0 / 1)`

## Testing

JSON format is valid, follows existing theme structure.

Fixes #13393