### PR TITLE
feat(theme): add Calligraphy Ink theme #13396

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -400,5 +400,11 @@
     "backgroundColor": "oklch(92.0% 0.015 210.0 / 1)",
     "mainColor": "oklch(60.0% 0.130 215.0 / 1)",
     "secondaryColor": "oklch(85.0% 0.155 95.0 / 1)"
+  },
+  {
+    "id": "calligraphy-ink",
+    "backgroundColor": "oklch(96.0% 0.008 85.0 / 1)",
+    "mainColor": "oklch(20.0% 0.015 270.0 / 1)",
+    "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
   }
 ]


### PR DESCRIPTION
Summary
Adds the new Calligraphy Ink theme as requested in https://github.com/lingdojo/kana-dojo/issues/13393.

Changes
Added theme object to community/content/community-themes.json with the specified color values:
ID: calligraphy-ink
Background: oklch(96.0% 0.008 85.0 / 1)
Main Color: oklch(20.0% 0.015 270.0 / 1)
Secondary: oklch(45.0% 0.025 260.0 / 1)
Testing
JSON format is valid, follows existing theme structure.

Fixes https://github.com/lingdojo/kana-dojo/issues/13393

---
🤖 **Auto-linked:** Closes #13393