### PR TITLE
feat(theme): add City Rain theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -496,5 +496,11 @@
   "backgroundColor": "oklch(15.0% 0.018 260.0 / 1)",
   "mainColor": "oklch(78.0% 0.040 230.0 / 1)",
   "secondaryColor": "oklch(50.0% 0.030 255.0 / 1)"  
-  }  
+  },
+  {
+    "id": "city-rain",
+    "backgroundColor": "oklch(16.0% 0.030 260.0 / 1)",
+    "mainColor": "oklch(82.0% 0.085 220.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.145 330.0 / 1)"
+  }
 ]


### PR DESCRIPTION
Implements the "City Rain" theme as requested in issue #14233.

This PR adds a new theme entry to the community themes configuration with the following details:

- id: city-rain
- backgroundColor: oklch(16.0% 0.030 260.0 / 1)
- mainColor: oklch(82.0% 0.085 220.0 / 1)
- secondaryColor: oklch(70.0% 0.145 330.0 / 1)

The theme follows the existing structure in `community/content/community-themes.json` and is formatted consistently with the other entries.

Closes #14233