### PR TITLE
fix: remove duplicate entries in japanese-videogame-quotes.json

### DIFF
--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -119,53 +119,11 @@
     "character": "Sora"
   },
   {
-    "japanese": "俺たちの物語は、ここからだ",
-    "romaji": "Oretachi no monogatari wa, koko kara da",
-    "english": "Our story starts here.",
-    "game": "Tales series",
-    "character": "Various endings"
-  },
-  {
-    "japanese": "負ける気がしない",
-    "romaji": "Makeru ki ga shinai",
-    "english": "I don't feel like I can lose.",
-    "game": "Street Fighter series",
-    "character": "Ryu"
-  },
-  {
     "japanese": "一人で行くのは危険だ！これを持っていけ！",
     "romaji": "Hitori de iku no wa kiken da! Kore o motte ike!",
     "english": "It's dangerous to go alone! Take this.",
     "game": "The Legend of Zelda",
     "character": "Old Man"
-  },
-  {
-    "japanese": "風が、来る！",
-    "romaji": "Kaze ga, kuru!",
-    "english": "The wind is coming!",
-    "game": "The Legend of Zelda: Breath of the Wild (JP)",
-    "character": "Revali"
-  },
-  {
-    "japanese": "まだまだだね",
-    "romaji": "Mada mada da ne",
-    "english": "You still have lots more to work on.",
-    "game": "The Prince of Tennis: Sweat & Tears 2",
-    "character": "Ryoma Echizen"
-  },
-  {
-    "japanese": "俺たちの物語は、ここからだ",
-    "romaji": "Oretachi no monogatari wa, koko kara da",
-    "english": "Our story starts here.",
-    "game": "Tales series",
-    "character": "Various endings"
-  },
-  {
-    "japanese": "それもまた一興",
-    "romaji": "Sore mo mata ikkyo",
-    "english": "That too has its charm.",
-    "game": "Onimusha series",
-    "character": "Nobunaga Oda"
   },
   {
     "japanese": "それでも、守りたい世界があるんだ！",
@@ -175,48 +133,6 @@
     "character": "Garnet Til Alexandros XVII"
   },
   {
-    "japanese": "覚悟はいいか？ 俺はできてる。",
-    "romaji": "Kakugo wa ii ka? Ore wa dekiteru.",
-    "english": "Are you prepared? I am.",
-    "game": "JoJo’s Bizarre Adventure: All-Star Battle",
-    "character": "Giorno Giovanna"
-  },
-  {
-    "japanese": "行くぞ、みんな！",
-    "romaji": "Iku zo, minna!",
-    "english": "Let's go, everyone!",
-    "game": "Kingdom Hearts series (JP dub)",
-    "character": "Sora"
-  },
-  {
-    "japanese": "それもまた一興",
-    "romaji": "Sore mo mata ikkyo",
-    "english": "That too has its charm.",
-    "game": "Onimusha series",
-    "character": "Nobunaga Oda"
-  },
-  {
-    "japanese": "運命なんて、変えてみせる！",
-    "romaji": "Unmei nante, kaete miseru!",
-    "english": "I'll change destiny!",
-    "game": "Final Fantasy Type-0",
-    "character": "Class Zero"
-  },
-  {
-    "japanese": "世界を救うって、そういうことだろ？",
-    "romaji": "Sekai o sukuu tte, sou iu koto daro?",
-    "english": "Saving the world means doing this, right?",
-    "game": "Persona 5 Strikers",
-    "character": "Joker"
-  },
-  {
-    "japanese": "俺は悪くねぇ！",
-    "romaji": "Ore wa warukunee!",
-    "english": "It's not my fault!",
-    "game": "Tales of the Abyss",
-    "character": "Luke fon Fabre"
-  },
-  {
     "japanese": "未来を変えるんだ！",
     "romaji": "Mirai o kaerun da!",
     "english": "We're going to change the future!",
@@ -224,24 +140,10 @@
     "character": "Rintaro Okabe"
   },
   {
-    "japanese": "生きるってのは、戦うってことだ",
-    "romaji": "Ikiru tte no wa, tatakau tte koto da",
-    "english": "To live is to fight.",
-    "game": "Yakuza: Like a Dragon",
-    "character": "Ichiban Kasuga"
-  },
-  {
-  "japanese": "次はもっと強くなる",
-  "romaji": "Tsugi wa motto tsuyoku naru",
-  "english": "Next time, I'll be stronger.",
-  "game": "Pokemon series",
-  "character": "Rival characters"
-},
-{
-  "japanese": "行くぞ、みんな！",
-  "romaji": "Iku zo, minna!",
-  "english": "Let's go, everyone!",
-  "game": "Kingdom Hearts series (JP dub)",
-  "character": "Sora"
-}
+    "japanese": "次はもっと強くなる",
+    "romaji": "Tsugi wa motto tsuyoku naru",
+    "english": "Next time, I'll be stronger.",
+    "game": "Pokemon series",
+    "character": "Rival characters"
+  }
 ]


### PR DESCRIPTION
**PRs are always welcome.**

## Is your feature request related to a problem?

The japanese-videogame-quotes.json file contains duplicate entries — the same Japanese phrase appears multiple times with identical romaji, english, game, and character fields.

## Describe the solution you'd like

Deduplicate the file by keeping only the first occurrence of each unique japanese phrase. The file has 35 entries with 11 duplicates, meaning ~22 unique quotes after deduplication.

Affected phrases with duplicate counts:
- 俺たちの物語は、ここからだ (3x)
- それもまた一興 (3x)
- 行くぞ、みんな！ (3x)
- 世界を救うって、そういうことだろ？ (2x)
- 負ける気がしない (2x)
- まだまだだね (2x)
- 俺は悪くねぇ！ (2x)
- 風が、来る！ (2x)
- 生きるってのは、戦うってことだ (2x)
- 運命なんて、変えてみせる！ (2x)
- 覚悟はいいか？俺はできてる。 (2x)

## Describe alternatives you have considered

Alternatively, keep all entries and let a pre-commit hook or CI check prevent future duplicates.

## Additional context

Found while reviewing the file for a good-first-issue PR.
