### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -598,5 +598,11 @@
   "romaji": "I no naka no kawazu taikai wo shirazu",
   "english": "A frog in a well does not know the great sea",
   "meaning": "Limited experience limits perspective"
-}
+  },
+  {
+    "japanese": "七転び八起き",
+    "romaji": "Nanakorobi yaoki",
+    "english": "Fall seven times, get up eight",
+    "meaning": "Never give up"
+  }
 ]


### PR DESCRIPTION
## 📝 Description

Adds the Japanese proverb **七転び八起き** (*Nanakorobi yaoki* — "Fall seven times, get up eight") to the `community/content/japanese-proverbs.json` file, as requested in the good-first-issue #14308.

## 🔗 Related Issue

Closes #14308

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## ✅ Pre-Submission Checklist

- [ ] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [ ] I have starred the repo ⭐
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🧪 How Has This Been Tested?

This is a data-only change to a JSON file. JSON syntax was validated with `python3 -m json.tool`.

## 📸 Screenshots/Videos (if applicable)

N/A — content/data update only.

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

None.
