### PR TITLE
feat: Add Bamboo Forest and Neon Sakura color themes

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -418,5 +418,27 @@
     "backgroundColor": "oklch(22.0% 0.030 150.0 / 1)",
     "mainColor": "oklch(78.0% 0.135 145.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.090 110.0 / 1)"
+  },
+  {
+    "id": "bamboo-forest",
+    "name": "Bamboo Forest",
+    "description": "Arashiyama's towering green stalks",
+    "colors": {
+      "background": "oklch(21.0% 0.045 155.0 / 1)",
+      "main": "oklch(70.0% 0.145 150.0 / 1)",
+      "secondary": "oklch(78.0% 0.095 140.0 / 1)"
+    },
+    "author": "q404365631"
+  },
+  {
+    "id": "neon-sakura",
+    "name": "Neon Sakura",
+    "description": "Cherry blossoms meet cyberpunk neon",
+    "colors": {
+      "background": "oklch(18.5% 0.055 320.0 / 1)",
+      "main": "oklch(82.0% 0.210 340.0 / 1)",
+      "secondary": "oklch(72.0% 0.165 285.0 / 1)"
+    },
+    "author": "q404365631"
   }
 ]


### PR DESCRIPTION
## Summary

Added two new color themes to KanaDojo:

### 🎋 Bamboo Forest (`bamboo-forest`)
- **Vibe**: Arashiyama's towering green stalks
- Background: `oklch(21.0% 0.045 155.0 / 1)`
- Main: `oklch(70.0% 0.145 150.0 / 1)`
- Secondary: `oklch(78.0% 0.095 140.0 / 1)`

### 🦑 Neon Sakura (`neon-sakura`)
- **Vibe**: Cherry blossoms meet cyberpunk neon  
- Background: `oklch(18.5% 0.055 320.0 / 1)`
- Main: `oklch(82.0% 0.210 340.0 / 1)`
- Secondary: `oklch(72.0% 0.165 285.0 / 1)`

Closes #14459
Closes #14458