### PR TITLE
feat(theme): add River Stone theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -1,225 +1,224 @@
 [
-    {
-        "id":  "morning-fog",
-        "backgroundColor":  "oklch(22.0% 0.010 240.0 / 1)",
-        "mainColor":  "oklch(78.0% 0.030 220.0 / 1)",
-        "secondaryColor":  "oklch(65.0% 0.040 260.0 / 1)"
-    },
-    {
-        "id":  "soba-slate",
-        "backgroundColor":  "oklch(18.0% 0.015 250.0 / 1)",
-        "mainColor":  "oklch(68.0% 0.085 60.0 / 1)",
-        "secondaryColor":  "oklch(58.0% 0.045 70.0 / 1)"
-    },
-    {
-        "id":  "konbini-light",
-        "backgroundColor":  "oklch(96.0% 0.015 210.0 / 1)",
-        "mainColor":  "oklch(55.0% 0.185 200.0 / 1)",
-        "secondaryColor":  "oklch(60.0% 0.155 25.0 / 1)"
-    },
-    {
-        "id":  "sakura-soda",
-        "backgroundColor":  "oklch(94.0% 0.025 345.0 / 1)",
-        "mainColor":  "oklch(68.0% 0.160 350.0 / 1)",
-        "secondaryColor":  "oklch(72.0% 0.110 210.0 / 1)"
-    },
-    {
-        "id":  "fuji-shadow",
-        "backgroundColor":  "oklch(15.0% 0.015 250.0 / 1)",
-        "mainColor":  "oklch(78.0% 0.035 230.0 / 1)",
-        "secondaryColor":  "oklch(65.0% 0.105 300.0 / 1)"
-    },
-    {
-        "id":  "taisho-cafe",
-        "backgroundColor":  "oklch(18.0% 0.028 65.0 / 1)",
-        "mainColor":  "oklch(72.0% 0.115 65.0 / 1)",
-        "secondaryColor":  "oklch(60.0% 0.085 25.0 / 1)"
-    },
-    {
-        "id":  "anime-pop",
-        "backgroundColor":  "oklch(95.0% 0.015 85.0 / 1)",
-        "mainColor":  "oklch(65.0% 0.235 345.0 / 1)",
-        "secondaryColor":  "oklch(70.0% 0.200 260.0 / 1)"
-    },
-    {
-        "id":  "coastal-breeze",
-        "backgroundColor":  "oklch(20.0% 0.035 225.0 / 1)",
-        "mainColor":  "oklch(80.0% 0.120 210.0 / 1)",
-        "secondaryColor":  "oklch(70.0% 0.085 195.0 / 1)"
-    },
-    {
-        "id":  "umbrella-rain",
-        "backgroundColor":  "oklch(22.0% 0.018 250.0 / 1)",
-        "mainColor":  "oklch(70.0% 0.175 225.0 / 1)",
-        "secondaryColor":  "oklch(75.0% 0.145 350.0 / 1)"
-    },
-    {
-        "id":  "citrus-shrine",
-        "backgroundColor":  "oklch(20.0% 0.030 70.0 / 1)",
-        "mainColor":  "oklch(86.0% 0.155 85.0 / 1)",
-        "secondaryColor":  "oklch(75.0% 0.095 60.0 / 1)"
-    },
-    {
-        "id":  "kendo-strike",
-        "backgroundColor":  "oklch(16.0% 0.028 265.0 / 1)",
-        "mainColor":  "oklch(65.0% 0.025 270.0 / 1)",
-        "secondaryColor":  "oklch(72.0% 0.165 25.0 / 1)"
-    },
-    {
-        "id":  "shibuya-haze",
-        "backgroundColor":  "oklch(17.0% 0.055 290.0 / 1)",
-        "mainColor":  "oklch(82.0% 0.195 310.0 / 1)",
-        "secondaryColor":  "oklch(74.0% 0.140 20.0 / 1)"
-    },
-    {
-        "id":  "shaved-ice",
-        "backgroundColor":  "oklch(95.0% 0.025 215.0 / 1)",
-        "mainColor":  "oklch(60.0% 0.195 25.0 / 1)",
-        "secondaryColor":  "oklch(65.0% 0.175 215.0 / 1)"
-    },
-    {
-        "id":  "peach-glow",
-        "backgroundColor":  "oklch(96.0% 0.035 40.0 / 1)",
-        "mainColor":  "oklch(62.0% 0.20 20.0 / 1)",
-        "secondaryColor":  "oklch(68.0% 0.16 200.0 / 1)"
-    },
-    {
-        "id":  "wavecrest-blue",
-        "backgroundColor":  "oklch(17.0% 0.030 245.0 / 1)",
-        "mainColor":  "oklch(88.0% 0.055 230.0 / 1)",
-        "secondaryColor":  "oklch(70.0% 0.145 210.0 / 1)"
-    },
-    {
-        "id":  "riverstone-gray",
-        "backgroundColor":  "oklch(20.0% 0.010 260.0 / 1)",
-        "mainColor":  "oklch(78.0% 0.020 90.0 / 1)",
-        "secondaryColor":  "oklch(55.0% 0.035 240.0 / 1)"
-    },
-    {
-        "id":  "garden-bridge",
-        "backgroundColor":  "oklch(23.0% 0.045 150.0 / 1)",
-        "mainColor":  "oklch(60.0% 0.205 25.0 / 1)",
-        "secondaryColor":  "oklch(72.0% 0.145 145.0 / 1)"
-    },
-    {
-        "id":  "sunset-train",
-        "backgroundColor":  "oklch(22.0% 0.052 45.0 / 1)",
-        "mainColor":  "oklch(88.0% 0.165 65.0 / 1)",
-        "secondaryColor":  "oklch(72.0% 0.185 35.0 / 1)"
-    },
-    {
-        "id":  "ginkgo-gold",
-        "backgroundColor":  "oklch(23.0% 0.045 85.0 / 1)",
-        "mainColor":  "oklch(88.0% 0.170 95.0 / 1)",
-        "secondaryColor":  "oklch(72.0% 0.135 75.0 / 1)"
-    },
-    {
-        "id":  "calligraphy-ink",
-        "backgroundColor":  "oklch(96.0% 0.008 85.0 / 1)",
-        "mainColor":  "oklch(20.0% 0.015 270.0 / 1)",
-        "secondaryColor":  "oklch(45.0% 0.025 260.0 / 1)"
-    },
-    {
-        "id":  "ruby-kabuki",
-        "backgroundColor":  "oklch(16.0% 0.040 20.0 / 1)",
-        "mainColor":  "oklch(70.0% 0.215 25.0 / 1)",
-        "secondaryColor":  "oklch(85.0% 0.055 95.0 / 1)"
-    },
-    {
-        "id":  "okinawa-sea",
-        "backgroundColor":  "oklch(23.0% 0.055 215.0 / 1)",
-        "mainColor":  "oklch(82.0% 0.165 195.0 / 1)",
-        "secondaryColor":  "oklch(90.0% 0.125 180.0 / 1)"
-    },
-    {
-        "id":  "kintsugi-gold",
-        "backgroundColor":  "oklch(22.0% 0.025 95.0 / 1)",
-        "mainColor":  "oklch(84.0% 0.120 95.0 / 1)",
-        "secondaryColor":  "oklch(68.0% 0.090 60.0 / 1)"
-    },
-    {
-        "id":  "indigo-shibori",
-        "backgroundColor":  "oklch(19.0% 0.055 255.0 / 1)",
-        "mainColor":  "oklch(55.0% 0.165 250.0 / 1)",
-        "secondaryColor":  "oklch(85.0% 0.065 90.0 / 1)"
-    },
-    {
-        "id":  "sakura-storm",
-        "backgroundColor":  "oklch(90.0% 0.032 340.0 / 1)",
-        "mainColor":  "oklch(70.0% 0.185 345.0 / 1)",
-        "secondaryColor":  "oklch(55.0% 0.145 350.0 / 1)"
-    },
-    {
-        "id":  "ninja-shadow",
-        "backgroundColor":  "oklch(12.0% 0.015 280.0 / 1)",
-        "mainColor":  "oklch(65.0% 0.025 270.0 / 1)",
-        "secondaryColor":  "oklch(55.0% 0.175 15.0 / 1)"
-    },
-    {
-        "id":  "sakura-latte",
-        "backgroundColor":  "oklch(95.0% 0.020 15.0 / 1)",
-        "mainColor":  "oklch(70.0% 0.155 350.0 / 1)",
-        "secondaryColor":  "oklch(82.0% 0.090 95.0 / 1)"
-    },
-    {
-        "id":  "umami-miso",
-        "backgroundColor":  "oklch(22.0% 0.028 55.0 / 1)",
-        "mainColor":  "oklch(72.0% 0.095 65.0 / 1)",
-        "secondaryColor":  "oklch(82.0% 0.145 130.0 / 1)"
-    },
-    {
-        "id":  "coastal-breeze",
-        "backgroundColor":  "oklch(20.0% 0.035 225.0 / 1)",
-        "mainColor":  "oklch(80.0% 0.120 210.0 / 1)",
-        "secondaryColor":  "oklch(70.0% 0.085 195.0 / 1)"
-    },
-    {
-        "id":  "sundown-shrine",
-        "backgroundColor":  "oklch(18.0% 0.055 330.0 / 1)",
-        "mainColor":  "oklch(72.0% 0.195 35.0 / 1)",
-        "secondaryColor":  "oklch(85.0% 0.095 275.0 / 1)"
-    },
-    {
-        "id":  "mountain-cedar",
-        "backgroundColor":  "oklch(20.0% 0.020 150.0 / 1)",
-        "mainColor":  "oklch(70.0% 0.105 145.0 / 1)",
-        "secondaryColor":  "oklch(60.0% 0.055 110.0 / 1)"
-    },
-    {
-        "id":  "yakuza-tattoo",
-        "backgroundColor":  "oklch(17.0% 0.045 255.0 / 1)",
-        "mainColor":  "oklch(62.0% 0.185 220.0 / 1)",
-        "secondaryColor":  "oklch(70.0% 0.175 15.0 / 1)"
-    },
-    {
-        "id":  "inkstone-blue",
-        "backgroundColor":  "oklch(17.0% 0.020 255.0 / 1)",
-        "mainColor":  "oklch(74.0% 0.060 230.0 / 1)",
-        "secondaryColor":  "oklch(60.0% 0.085 280.0 / 1)"
-    },
-    {
-        "id":  "volcanic-ash",
-        "backgroundColor":  "oklch(20.0% 0.018 270.0 / 1)",
-        "mainColor":  "oklch(70.0% 0.155 25.0 / 1)",
-        "secondaryColor":  "oklch(55.0% 0.045 260.0 / 1)"
-    },
-    {
-        "id":  "hanami-pink",
-        "backgroundColor":  "oklch(92.0% 0.028 345.0 / 1)",
-        "mainColor":  "oklch(70.0% 0.165 350.0 / 1)",
-        "secondaryColor":  "oklch(78.0% 0.110 25.0 / 1)"
-    },
-    {
-        "id":  "sushi-counter",
-        "backgroundColor":  "oklch(23.0% 0.028 70.0 / 1)",
-        "mainColor":  "oklch(70.0% 0.145 20.0 / 1)",
-        "secondaryColor":  "oklch(68.0% 0.095 75.0 / 1)"
-    }
-  ,
-{
-  "id": "yakuza-tattoo",
-  "backgroundColor": "oklch(15% 0.02 250 / 1)",
-  "mainColor": "oklch(60% 0.2 20 / 1)",
-  "secondaryColor": "oklch(50% 0.15 10 / 1)"
-}
+ {
+ "id": "morning-fog",
+ "backgroundColor": "oklch(22.0% 0.010 240.0 / 1)",
+ "mainColor": "oklch(78.0% 0.030 220.0 / 1)",
+ "secondaryColor": "oklch(65.0% 0.040 260.0 / 1)"
+ },
+ {
+ "id": "soba-slate",
+ "backgroundColor": "oklch(18.0% 0.015 250.0 / 1)",
+ "mainColor": "oklch(68.0% 0.085 60.0 / 1)",
+ "secondaryColor": "oklch(58.0% 0.045 70.0 / 1)"
+ },
+ {
+ "id": "konbini-light",
+ "backgroundColor": "oklch(96.0% 0.015 210.0 / 1)",
+ "mainColor": "oklch(55.0% 0.185 200.0 / 1)",
+ "secondaryColor": "oklch(60.0% 0.155 25.0 / 1)"
+ },
+ {
+ "id": "sakura-soda",
+ "backgroundColor": "oklch(94.0% 0.025 345.0 / 1)",
+ "mainColor": "oklch(68.0% 0.160 350.0 / 1)",
+ "secondaryColor": "oklch(72.0% 0.110 210.0 / 1)"
+ },
+ {
+ "id": "fuji-shadow",
+ "backgroundColor": "oklch(15.0% 0.015 250.0 / 1)",
+ "mainColor": "oklch(78.0% 0.035 230.0 / 1)",
+ "secondaryColor": "oklch(65.0% 0.105 300.0 / 1)"
+ },
+ {
+ "id": "taisho-cafe",
+ "backgroundColor": "oklch(18.0% 0.028 65.0 / 1)",
+ "mainColor": "oklch(72.0% 0.115 65.0 / 1)",
+ "secondaryColor": "oklch(60.0% 0.085 25.0 / 1)"
+ },
+ {
+ "id": "anime-pop",
+ "backgroundColor": "oklch(95.0% 0.015 85.0 / 1)",
+ "mainColor": "oklch(65.0% 0.235 345.0 / 1)",
+ "secondaryColor": "oklch(70.0% 0.200 260.0 / 1)"
+ },
+ {
+ "id": "coastal-breeze",
+ "backgroundColor": "oklch(20.0% 0.035 225.0 / 1)",
+ "mainColor": "oklch(80.0% 0.120 210.0 / 1)",
+ "secondaryColor": "oklch(70.0% 0.085 195.0 / 1)"
+ },
+ {
+ "id": "umbrella-rain",
+ "backgroundColor": "oklch(22.0% 0.018 250.0 / 1)",
+ "mainColor": "oklch(70.0% 0.175 225.0 / 1)",
+ "secondaryColor": "oklch(75.0% 0.145 350.0 / 1)"
+ },
+ {
+ "id": "citrus-shrine",
+ "backgroundColor": "oklch(20.0% 0.030 70.0 / 1)",
+ "mainColor": "oklch(86.0% 0.155 85.0 / 1)",
+ "secondaryColor": "oklch(75.0% 0.095 60.0 / 1)"
+ },
+ {
+ "id": "kendo-strike",
+ "backgroundColor": "oklch(16.0% 0.028 265.0 / 1)",
+ "mainColor": "oklch(65.0% 0.025 270.0 / 1)",
+ "secondaryColor": "oklch(72.0% 0.165 25.0 / 1)"
+ },
+ {
+ "id": "shibuya-haze",
+ "backgroundColor": "oklch(17.0% 0.055 290.0 / 1)",
+ "mainColor": "oklch(82.0% 0.195 310.0 / 1)",
+ "secondaryColor": "oklch(74.0% 0.140 20.0 / 1)"
+ },
+ {
+ "id": "shaved-ice",
+ "backgroundColor": "oklch(95.0% 0.025 215.0 / 1)",
+ "mainColor": "oklch(60.0% 0.195 25.0 / 1)",
+ "secondaryColor": "oklch(65.0% 0.175 215.0 / 1)"
+ },
+ {
+ "id": "peach-glow",
+ "backgroundColor": "oklch(96.0% 0.035 40.0 / 1)",
+ "mainColor": "oklch(62.0% 0.20 20.0 / 1)",
+ "secondaryColor": "oklch(68.0% 0.16 200.0 / 1)"
+ },
+ {
+ "id": "wavecrest-blue",
+ "backgroundColor": "oklch(17.0% 0.030 245.0 / 1)",
+ "mainColor": "oklch(88.0% 0.055 230.0 / 1)",
+ "secondaryColor": "oklch(70.0% 0.145 210.0 / 1)"
+ },
+ {
+ "id": "riverstone-gray",
+ "backgroundColor": "oklch(20.0% 0.010 260.0 / 1)",
+ "mainColor": "oklch(78.0% 0.020 90.0 / 1)",
+ "secondaryColor": "oklch(55.0% 0.035 240.0 / 1)"
+ },
+ {
+ "id": "garden-bridge",
+ "backgroundColor": "oklch(23.0% 0.045 150.0 / 1)",
+ "mainColor": "oklch(60.0% 0.205 25.0 / 1)",
+ "secondaryColor": "oklch(72.0% 0.145 145.0 / 1)"
+ },
+ {
+ "id": "sunset-train",
+ "backgroundColor": "oklch(22.0% 0.052 45.0 / 1)",
+ "mainColor": "oklch(88.0% 0.165 65.0 / 1)",
+ "secondaryColor": "oklch(72.0% 0.185 35.0 / 1)"
+ },
+ {
+ "id": "ginkgo-gold",
+ "backgroundColor": "oklch(23.0% 0.045 85.0 / 1)",
+ "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
+ "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
+ },
+ {
+ "id": "calligraphy-ink",
+ "backgroundColor": "oklch(96.0% 0.008 85.0 / 1)",
+ "mainColor": "oklch(20.0% 0.015 270.0 / 1)",
+ "secondaryColor": "oklch(45.0% 0.025 260.0 / 1)"
+ },
+ {
+ "id": "ruby-kabuki",
+ "backgroundColor": "oklch(16.0% 0.040 20.0 / 1)",
+ "mainColor": "oklch(70.0% 0.215 25.0 / 1)",
+ "secondaryColor": "oklch(85.0% 0.055 95.0 / 1)"
+ },
+ {
+ "id": "okinawa-sea",
+ "backgroundColor": "oklch(23.0% 0.055 215.0 / 1)",
+ "mainColor": "oklch(82.0% 0.165 195.0 / 1)",
+ "secondaryColor": "oklch(90.0% 0.125 180.0 / 1)"
+ },
+ {
+ "id": "kintsugi-gold",
+ "backgroundColor": "oklch(22.0% 0.025 95.0 / 1)",
+ "mainColor": "oklch(84.0% 0.120 95.0 / 1)",
+ "secondaryColor": "oklch(68.0% 0.090 60.0 / 1)"
+ },
+ {
+ "id": "indigo-shibori",
+ "backgroundColor": "oklch(19.0% 0.055 255.0 / 1)",
+ "mainColor": "oklch(55.0% 0.165 250.0 / 1)",
+ "secondaryColor": "oklch(85.0% 0.065 90.0 / 1)"
+ },
+ {
+ "id": "sakura-storm",
+ "backgroundColor": "oklch(90.0% 0.032 340.0 / 1)",
+ "mainColor": "oklch(70.0% 0.185 345.0 / 1)",
+ "secondaryColor": "oklch(55.0% 0.145 350.0 / 1)"
+ },
+ {
+ "id": "ninja-shadow",
+ "backgroundColor": "oklch(12.0% 0.015 280.0 / 1)",
+ "mainColor": "oklch(65.0% 0.025 270.0 / 1)",
+ "secondaryColor": "oklch(55.0% 0.175 15.0 / 1)"
+ },
+ {
+ "id": "sakura-latte",
+ "backgroundColor": "oklch(95.0% 0.020 15.0 / 1)",
+ "mainColor": "oklch(70.0% 0.155 350.0 / 1)",
+ "secondaryColor": "oklch(82.0% 0.090 95.0 / 1)"
+ },
+ {
+ "id": "umami-miso",
+ "backgroundColor": "oklch(22.0% 0.028 55.0 / 1)",
+ "mainColor": "oklch(72.0% 0.095 65.0 / 1)",
+ "secondaryColor": "oklch(82.0% 0.145 130.0 / 1)"
+ },
+ {
+ "id": "coastal-breeze",
+ "backgroundColor": "oklch(20.0% 0.035 225.0 / 1)",
+ "mainColor": "oklch(80.0% 0.120 210.0 / 1)",
+ "secondaryColor": "oklch(70.0% 0.085 195.0 / 1)"
+ },
+ {
+ "id": "sundown-shrine",
+ "backgroundColor": "oklch(18.0% 0.055 330.0 / 1)",
+ "mainColor": "oklch(72.0% 0.195 35.0 / 1)",
+ "secondaryColor": "oklch(85.0% 0.095 275.0 / 1)"
+ },
+ {
+ "id": "mountain-cedar",
+ "backgroundColor": "oklch(20.0% 0.020 150.0 / 1)",
+ "mainColor": "oklch(70.0% 0.105 145.0 / 1)",
+ "secondaryColor": "oklch(60.0% 0.055 110.0 / 1)"
+ },
+ {
+ "id": "yakuza-tattoo",
+ "backgroundColor": "oklch(17.0% 0.045 255.0 / 1)",
+ "mainColor": "oklch(62.0% 0.185 220.0 / 1)",
+ "secondaryColor": "oklch(70.0% 0.175 15.0 / 1)"
+ },
+ {
+ "id": "inkstone-blue",
+ "backgroundColor": "oklch(17.0% 0.020 255.0 / 1)",
+ "mainColor": "oklch(74.0% 0.060 230.0 / 1)",
+ "secondaryColor": "oklch(60.0% 0.085 280.0 / 1)"
+ },
+ {
+ "id": "volcanic-ash",
+ "backgroundColor": "oklch(20.0% 0.018 270.0 / 1)",
+ "mainColor": "oklch(70.0% 0.155 25.0 / 1)",
+ "secondaryColor": "oklch(55.0% 0.045 260.0 / 1)"
+ },
+ {
+ "id": "hanami-pink",
+ "backgroundColor": "oklch(92.0% 0.028 345.0 / 1)",
+ "mainColor": "oklch(70.0% 0.165 350.0 / 1)",
+ "secondaryColor": "oklch(78.0% 0.110 25.0 / 1)"
+ },
+ {
+ "id": "sushi-counter",
+ "backgroundColor": "oklch(23.0% 0.028 70.0 / 1)",
+ "mainColor": "oklch(70.0% 0.145 20.0 / 1)",
+ "secondaryColor": "oklch(68.0% 0.095 75.0 / 1)"
+ },
+ {
+ "id": "river-stone",
+ "backgroundColor": "oklch(19.0% 0.020 250.0 / 1)",
+ "mainColor": "oklch(72.0% 0.050 215.0 / 1)",
+ "secondaryColor": "oklch(60.0% 0.040 230.0 / 1)"
+ }
 ]


### PR DESCRIPTION
## Description

This PR adds a new community theme called **River Stone** to the community themes collection.

### Theme: River Stone

**Description:** Smooth stones under clear water - a serene, nature-inspired theme with soft blue-green tones reminiscent of river stones.

**Color Palette:**
- **Background:** `oklch(19.0% 0.020 250.0 / 1)` - Deep river-water blue
- **Main Color:** `oklch(72.0% 0.050 215.0 / 1)` - Stone-blue primary accent
- **Secondary Color:** `oklch(60.0% 0.040 230.0 / 1)` - Softer blue-green secondary

### Changes Made
- Added `river-stone` theme object to `community/content/community-themes.json`

### Verification Steps
1. Check out this branch
2. Open the kana-dojo app
3. Navigate to Settings > Theme
4. Select "River Stone" from the community themes dropdown
5. Verify the theme renders correctly with the specified colors
6. Test in both light and dark mode contexts

Closes #14482