### PR TITLE
docs: add community note line #1

### DIFF
--- a/docs/community-notes/contribution-notes-1.md
+++ b/docs/community-notes/contribution-notes-1.md
@@ -3,3 +3,4 @@
 This page collects low-priority notes about community workflow experiments.
 
 Minor redundant edits here are acceptable because nothing in the app depends on this file.
+- Community note: this file is used for lightweight contribution practice.


### PR DESCRIPTION
This PR adds a community note line as described in #14513.

- Added: `Community note: this file is used for lightweight contribution practice.`

Closes #14513