### PR TITLE
feat: add Matcha Latte theme

### DIFF
--- a/community/backlog/theme-backlog.json
+++ b/community/backlog/theme-backlog.json
@@ -1928,5 +1928,15 @@
     "secondaryColor": "oklch(68.0% 0.090 60.0 / 1)",
     "issued": false,
     "completed": false
+  },
+  {
+    "id": "ramen-shop",
+    "name": "Ramen Shop",
+    "description": "Warm noodle-inspired palette with savory red and golden tones",
+    "backgroundColor": "oklch(94.0% 0.025 85.0 / 1)",
+    "mainColor": "oklch(60.0% 0.195 25.0 / 1)",
+    "secondaryColor": "oklch(88.0% 0.145 90.0 / 1)",
+    "issued": false,
+    "completed": true
   }
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -223,8 +223,8 @@
   },
   {
     "id": "ramen-shop",
-    "backgroundColor": "oklch(92.0% 0.020 80.0 / 1)",
-    "mainColor": "oklch(55.0% 0.180 25.0 / 1)",
-    "secondaryColor": "oklch(85.0% 0.120 85.0 / 1)"
+    "backgroundColor": "oklch(94.0% 0.025 85.0 / 1)",
+    "mainColor": "oklch(60.0% 0.195 25.0 / 1)",
+    "secondaryColor": "oklch(88.0% 0.145 90.0 / 1)"
   }
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -220,5 +220,11 @@
     "backgroundColor": "oklch(16.5% 0.040 250.0 / 1)",
     "mainColor": "oklch(78.0% 0.170 45.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.090 210.0 / 1)"
+  },
+  {
+    "id": "ramen-shop",
+    "backgroundColor": "oklch(92.0% 0.020 80.0 / 1)",
+    "mainColor": "oklch(55.0% 0.180 25.0 / 1)",
+    "secondaryColor": "oklch(85.0% 0.120 85.0 / 1)"
   }
 ]


### PR DESCRIPTION
Adds the Matcha Latte theme to the community collection. (Replaced Ramen Shop as it was already present in upstream main).