### PR TITLE
feat(theme): add Festival Gold theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -298,5 +298,11 @@
     "backgroundColor": "oklch(22.0% 0.045 40.0 / 1)",
     "mainColor": "oklch(82.0% 0.160 55.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.120 15.0 / 1)"
+  },
+  {
+    "id": "festival-gold",
+    "backgroundColor": "oklch(19.0% 0.035 45.0 / 1)",
+    "mainColor": "oklch(82.0% 0.155 85.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.145 20.0 / 1)"
   }
 ]


### PR DESCRIPTION
Adds the Festival Gold theme from issue #15265 to community/content/community-themes.json (id: festival-gold). Verified the id is not already present and JSON parses cleanly.

Note: the issue body shows the snippet in TypeScript syntax (unquoted keys); converted to proper JSON with double-quoted keys to match the rest of the file.

Closes #15265