### PR TITLE
feat(theme): add Bamboo Mist theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -298,5 +298,11 @@
     "backgroundColor": "oklch(22.0% 0.045 40.0 / 1)",
     "mainColor": "oklch(82.0% 0.160 55.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.120 15.0 / 1)"
+  },
+  {
+    "id": "bamboo-mist",
+    "backgroundColor": "oklch(24.0% 0.032 150.0 / 1)",
+    "mainColor": "oklch(78.0% 0.145 145.0 / 1)",
+    "secondaryColor": "oklch(68.0% 0.085 130.0 / 1)"
   }
 ]


### PR DESCRIPTION
Adds the Bamboo Mist theme from issue #15255 to community/content/community-themes.json (id: bamboo-mist). Verified the id is not already present and JSON parses cleanly.

Note: the issue body shows the snippet in TypeScript syntax (unquoted keys); converted to proper JSON with double-quoted keys to match the rest of the file.

Closes #15255