### PR TITLE
Fix/rapid enter correct tab flicker

### DIFF
--- a/features/Achievements/hooks/useAchievementPrompts.ts
+++ b/features/Achievements/hooks/useAchievementPrompts.ts
@@ -2,6 +2,8 @@ import { useStatsStore } from '@/features/Progress';
 import { useCallback, useState } from 'react';
 import useAchievementStore, { type Achievement } from '../store/useAchievementStore';
 
+type StatsState = ReturnType<typeof useStatsStore.getState>;
+
 export interface AchievementPrompt {
   achievement: Achievement;
   progress: number;
@@ -42,7 +44,7 @@ export const useAchievementPrompts = (): UseAchievementPromptsReturn => {
   }, [achievementStore]);
 
   // Calculate progress for a specific achievement
-  const calculateProgress = useCallback((achievement: Achievement, stats: any): number => {
+  const calculateProgress = useCallback((achievement: Achievement, stats: StatsState): number => {
     const { type, value, additional } = achievement.requirements;
 
     switch (type) {
@@ -58,7 +60,7 @@ export const useAchievementPrompts = (): UseAchievementPromptsReturn => {
         } else if (additional?.contentType === 'katakana') {
           return Math.min((stats.allTimeStats.katakanaCorrect / value) * 100, 100);
         } else if (additional?.contentType === 'kanji') {
-          return Math.min((stats.allTimeStats.kanjiCorrect / value) * 100, 100);
+          return Math.min((Object.values(stats.allTimeStats.kanjiCorrectByLevel).reduce((a, b) => a + b, 0) / value) * 100, 100);
         } else if (additional?.contentType === 'vocabulary') {
           return Math.min((stats.allTimeStats.vocabularyCorrect / value) * 100, 100);
         }
@@ -73,7 +75,7 @@ export const useAchievementPrompts = (): UseAchievementPromptsReturn => {
         return Math.min((accuracy / value) * 100, 100);
 
       case 'sessions':
-        return Math.min((stats.allTimeStats.sessionsCompleted / value) * 100, 100);
+        return Math.min((stats.allTimeStats.totalSessions / value) * 100, 100);
 
       default:
         return 0;

--- a/features/Experiments/components/FlashRush.tsx
+++ b/features/Experiments/components/FlashRush.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useClick, useCorrect, useError } from '@/shared/hooks/generic/useAudio';
-import { allKana } from '../data/kanaData';
+import { allKana, type KanaEntry } from '../data/kanaData';
 import clsx from 'clsx';
 import { Timer, Zap, Trophy, RefreshCcw } from 'lucide-react';
 import confetti from 'canvas-confetti';
@@ -13,8 +13,8 @@ export default function FlashRush() {
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'result'>(
     'idle',
   );
-  const [currentKana, setCurrentKana] = useState<any>(null);
-  const [options, setOptions] = useState<any[]>([]);
+  const [currentKana, setCurrentKana] = useState<KanaEntry | null>(null);
+  const [options, setOptions] = useState<KanaEntry[]>([]);
   const [score, setScore] = useState(0);
   const [timeLeft, setTimeLeft] = useState(GAME_DURATION);
   const [lastResult, setLastResult] = useState<'correct' | 'wrong' | null>(
@@ -56,10 +56,10 @@ export default function FlashRush() {
     return () => clearInterval(timer);
   }, [gameState, timeLeft, score]);
 
-  const handleAnswer = (option: any) => {
+  const handleAnswer = (option: KanaEntry) => {
     if (gameState !== 'playing') return;
 
-    if (option.kana === currentKana.kana) {
+    if (currentKana && option.kana === currentKana.kana) {
       playCorrect();
       setScore(s => s + 1);
       setLastResult('correct');

--- a/features/Experiments/components/KanaSearch.tsx
+++ b/features/Experiments/components/KanaSearch.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useClick, useCorrect, useError } from '@/shared/hooks/generic/useAudio';
-import { allKana } from '../data/kanaData';
+import { allKana, type KanaEntry } from '../data/kanaData';
 import clsx from 'clsx';
 import { Search, Timer, Trophy, AlertCircle } from 'lucide-react';
 
@@ -12,7 +12,7 @@ const ROUND_TIME = 10;
 export default function KanaSearch() {
   const [level, setLevel] = useState(1);
   const [target, setTarget] = useState(allKana[0]);
-  const [grid, setGrid] = useState<any[]>([]);
+  const [grid, setGrid] = useState<KanaEntry[]>([]);
   const [timeLeft, setTimeLeft] = useState(ROUND_TIME);
   const [score, setScore] = useState(0);
   const [gameState, setGameState] = useState<'playing' | 'gameover' | 'idle'>(
@@ -66,7 +66,7 @@ export default function KanaSearch() {
     return () => clearInterval(timer);
   }, [gameState, timeLeft, playError]);
 
-  const handleSelect = (kana: any) => {
+  const handleSelect = (kana: KanaEntry) => {
     if (gameState !== 'playing') return;
 
     if (kana.kana === target.kana) {

--- a/features/Experiments/data/kanaData.ts
+++ b/features/Experiments/data/kanaData.ts
@@ -1,5 +1,10 @@
 // Flattened kana data for experiments
-export const allKana = [
+export interface KanaEntry {
+  kana: string;
+  romanji: string;
+}
+
+export const allKana: KanaEntry[] = [
   { kana: 'あ', romanji: 'a' },
   { kana: 'い', romanji: 'i' },
   { kana: 'う', romanji: 'u' },

--- a/features/Kana/components/Game/Input.tsx
+++ b/features/Kana/components/Game/Input.tsx
@@ -94,6 +94,14 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
     recordCorrect: recordTargetLengthCorrect,
     recordWrong: recordTargetLengthWrong,
   } = useAdaptiveTargetLength();
+  // Ref so buildTargetPair's identity is stable even when targetLength changes.
+  // Without this, a level-up mid-question re-creates buildTargetPair → triggers
+  // useEffect([buildTargetPair]) → sets new pairData while still in 'correct'
+  // state → GameBottomBar freezes the *next* question's answer in the completed tab.
+  const targetLengthRef = useRef(targetLength);
+  useEffect(() => {
+    targetLengthRef.current = targetLength;
+  }, [targetLength]);
 
   const [inputValue, setInputValue] = useState('');
   const [bottomBarState, setBottomBarState] = useState<BottomBarState>('check');
@@ -148,7 +156,7 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
     const promptParts: string[] = [];
     const answerParts: string[] = [];
 
-    for (let i = 0; i < targetLength; i++) {
+    for (let i = 0; i < targetLengthRef.current; i++) {
       const available = sourceArray.filter(char => !used.has(char));
       if (available.length === 0) break;
       const selected = adaptiveSelector.selectWeightedCharacter(available);
@@ -164,8 +172,10 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
       promptParts,
       answerParts,
     };
-  }, [isReverse, selectedRomaji, selectedKana, targetLength, selectedPairs]);
+  }, [isReverse, selectedRomaji, selectedKana, selectedPairs]);
 
+  // Safe: targetLengthRef.current === targetLength at this point (ref initialised above on same render).
+  // eslint-disable-next-line react-hooks/refs
   const [pairData, setPairData] = useState(() => buildTargetPair());
   const correctChar = pairData.correctChar;
   const targetChar = pairData.targetChar;
@@ -431,7 +441,7 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
         onKeyDown={e => {
           if (e.key === 'Enter') {
             e.preventDefault();
-            if (inputValue.trim().length > 0 && bottomBarState !== 'correct') {
+            if (inputValue.trim().length > 0 && bottomBarState !== 'correct' && !justAnsweredRef.current) {
               handleCheck();
             }
           }
@@ -457,4 +467,3 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
 };
 
 export default InputGame;
-

--- a/features/Kanji/components/Game/Input.tsx
+++ b/features/Kanji/components/Game/Input.tsx
@@ -204,7 +204,8 @@ const KanjiInputGame = ({
     if (
       e.key === 'Enter' &&
       inputValue.trim().length &&
-      bottomBarState !== 'correct'
+      bottomBarState !== 'correct' &&
+      !justAnsweredRef.current
     ) {
       handleCheck();
     }
@@ -485,4 +486,3 @@ const KanjiInputGame = ({
 };
 
 export default KanjiInputGame;
-

--- a/features/Vocabulary/components/Game/Input.tsx
+++ b/features/Vocabulary/components/Game/Input.tsx
@@ -341,7 +341,8 @@ const VocabInputGame = ({
     if (
       e.key === 'Enter' &&
       inputValue.trim().length &&
-      bottomBarState !== 'correct'
+      bottomBarState !== 'correct' &&
+      !justAnsweredRef.current
     ) {
       handleCheck();
     }
@@ -484,4 +485,3 @@ const VocabInputGame = ({
 };
 
 export default VocabInputGame;
-


### PR DESCRIPTION
## 📝 Description

When a user answers correctly and presses Enter rapidly (or holds it down), the bottom bar briefly flashes the next question's answer instead of the one just answered. No question is incorrectly marked complete, but the visual feedback is wrong.
The root cause is in Kana mode: buildTargetPair had targetLength in its useCallback dependencies. Every 5th correct answer increments targetLength, giving buildTargetPair a new reference, which triggers a useEffect that calls setPairData with the next question's data while the bottom bar is still in the correct state. This also fixes two real bugs caught by enforcing TypeScript types: sessionsCompleted and kanjiCorrect do not exist on AllTimeStats and were silently wrong.

## 🔗 Related Issue

Closes #15588 

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [x] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Ran npm run dev and reproduced the original bug (rapid Enter showing next answer in completed tab)
2. Confirmed the bug no longer occurs after the fix
3. Verified TypeScript and ESLint pass with no errors
4. Confirmed no regressions in existing passing tests

<!--
**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

...

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

...
