### PR TITLE
feat(theme): add Sumo Strength theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -388,5 +388,11 @@
     "backgroundColor": "oklch(22.0% 0.020 235.0 / 1)",
     "mainColor": "oklch(78.0% 0.135 215.0 / 1)",
     "secondaryColor": "oklch(85.0% 0.155 90.0 / 1)"
+  },
+  {
+    "id": "sumo-strength",
+    "backgroundColor": "oklch(20.0% 0.022 35.0 / 1)",
+    "mainColor": "oklch(72.0% 0.065 75.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.185 20.0 / 1)"
   }
 ]


### PR DESCRIPTION
## What
Adds the "Sumo Strength" community color theme.

| Property | Value |
|---|---|
| ID | `sumo-strength` |
| Background | `oklch(20.0% 0.022 35.0 / 1)` |
| Main | `oklch(72.0% 0.065 75.0 / 1)` |
| Secondary | `oklch(60.0% 0.185 20.0 / 1)` |

Closes #16146