### PR TITLE
feat(theme): add Kabuki Drama theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -406,5 +406,11 @@
     "backgroundColor": "oklch(23.0% 0.018 75.0 / 1)",
     "mainColor": "oklch(70.0% 0.055 80.0 / 1)",
     "secondaryColor": "oklch(60.0% 0.145 25.0 / 1)"
+  },
+  {
+    "id": "kabuki-drama",
+    "backgroundColor": "oklch(15.0% 0.048 25.0 / 1)",
+    "mainColor": "oklch(65.0% 0.225 30.0 / 1)",
+    "secondaryColor": "oklch(90.0% 0.055 95.0 / 1)"
   }
 ]


### PR DESCRIPTION
Closes #16222

Added the Kabuki Drama dark theme to community-themes.json.

Theme details:
- ID: kabuki-drama
- Background: oklch(15.0% 0.048 25.0 / 1)
- Main Color: oklch(65.0% 0.225 30.0 / 1)
- Secondary: oklch(90.0% 0.055 95.0 / 1)