### PR TITLE
feat(theme): add Golden Kintsugi theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -412,5 +412,11 @@
     "backgroundColor": "oklch(15.0% 0.048 25.0 / 1)",
     "mainColor": "oklch(65.0% 0.225 30.0 / 1)",
     "secondaryColor": "oklch(90.0% 0.055 95.0 / 1)"
+  },
+  {
+    "id": "golden-kintsugi",
+    "backgroundColor": "oklch(20.0% 0.020 70.0 / 1)",
+    "mainColor": "oklch(85.0% 0.155 85.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.085 25.0 / 1)"
   }
 ]


### PR DESCRIPTION
Closes #16202

Added Golden Kintsugi dark theme to community-themes.json.

Theme details:
- ID: golden-kintsugi
- Background: oklch(20.0% 0.020 70.0 / 1)
- Main Color: oklch(85.0% 0.155 85.0 / 1)
- Secondary: oklch(60.0% 0.085 25.0 / 1)