### PR TITLE
feat(proverbs): add "知らぬが仏" to community proverbs

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -376,5 +376,11 @@
   "romaji": "Nido aru koto wa sando aru",
   "english": "What happens twice will happen a third time",
   "meaning": "Patterns tend to repeat"
-}
+},
+  {
+    "japanese": "知らぬが仏",
+    "romaji": "Shiranu ga hotoke",
+    "english": "Not knowing is Buddha",
+    "meaning": "Ignorance is bliss"
+  }
 ]


### PR DESCRIPTION
## Summary
Adds one new entry to the community proverbs dataset for issue #16481, which asks for a new Japanese proverb to be appended to the collection. The entry is 知らぬが仏 ("Shiranu ga hotoke"), a common saying along the lines of "ignorance is bliss."

## Changes
- Append a new proverb object (`japanese`, `romaji`, `english`, `meaning`) for 知らぬが仏 to the end of the array in `community/content/japanese-proverbs.json`.

## Testing
Validated the file is still parseable JSON with:
`node -e "JSON.parse(require('fs').readFileSync('community/content/japanese-proverbs.json','utf8'))"`
No runtime or component code changed, so no other tests were exercised.

## Notes
The new object uses 2-space indentation to match the surrounding entries. The preceding entry's closing brace picked up a comma as required; indentation of that line was left as-is to keep the diff minimal.

Closes #16481