### PR TITLE
add new trivia question

### DIFF
--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -636,5 +636,16 @@
     "Yokohama"
   ],
   "correctIndex": 0
+},
+  {
+  "question": "Which Japanese city hosted the 1998 Winter Olympics?",
+  "difficulty": "hard",
+  "answers": [
+    "Nagano",
+    "Kobe",
+    "Hiroshima",
+    "Naha"
+  ],
+  "correctIndex": 0
 }
 ]


### PR DESCRIPTION
## 📝 Description

Closes # 16598

## Pull Request Change Details

- Branch: `japan-trivia-hard-ques`
- Commit: `57b2fff97`
- Commit message: `added a new japan hard trivia question`
- Changed file: `community/content/japan-trivia-hard.json`

### Change summary

- Added one new trivia entry:
  - Question: `Which Japanese city hosted the 1998 Winter Olympics?`
  - Difficulty: `hard`
  - Answers:
    - `Nagano`
    - `Kobe`
    - `Hiroshima`
    - `Naha`
  - Correct answer index: `0` (Nagano)
