### PR TITLE
feat(theme): add Digital Oni and Ryokan Evening themes

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -474,5 +474,17 @@
   "backgroundColor": "oklch(23.0% 0.045 85.0 / 1)",
   "mainColor": "oklch(88.0% 0.170 95.0 / 1)",
   "secondaryColor": "oklch(72.0% 0.135 75.0 / 1)"
+},
+{
+  "id": "digital-oni",
+  "backgroundColor": "oklch(14.0% 0.075 355.0 / 1)",
+  "mainColor": "oklch(68.0% 0.240 10.0 / 1)",
+  "secondaryColor": "oklch(78.0% 0.195 150.0 / 1)"
+},
+{
+  "id": "ryokan-evening",
+  "backgroundColor": "oklch(23.0% 0.038 280.0 / 1)",
+  "mainColor": "oklch(78.0% 0.130 55.0 / 1)",
+  "secondaryColor": "oklch(68.0% 0.095 30.0 / 1)"
 }
 ]


### PR DESCRIPTION
Add two new community color themes:

- **Digital Oni**: Demon masks rendered in glitch art
- **Ryokan Evening**: Warm twilight of a traditional inn

Closes #16604
Closes #16574