### PR TITLE
feat(proverb): add Japanese proverb #132 — 急がば回れ (Isogaba maware)

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -481,5 +481,11 @@
     "romaji": "Gou ni itte wa gou ni shitagae",
     "english": "When you enter a village, follow the village",
     "meaning": "When in Rome, do as the Romans do; adapt to local customs."
+  },
+  {
+    "japanese": "急がば回れ",
+    "romaji": "Isogaba maware",
+    "english": "If in a hurry, go around",
+    "meaning": "The safer path can be faster"
   }
 ]


### PR DESCRIPTION
## Summary

Fixes #16800

Community members browsing the Japanese proverbs section can now learn 急がば回れ (Isogaba maware), a classic proverb teaching that taking the safer, more deliberate path often leads to faster results.

## Root Cause

The proverb dataset in `community/content/japanese-proverbs.json` was simply missing this entry — no bug, just content that hadn't been added yet.

## Fix

Added a new JSON object following the existing schema (japanese, romaji, english, meaning) matching the issue specification exactly.

## Changes

- `community/content/japanese-proverbs.json`: +6 lines (one new proverb entry)

## Testing

- **JSON validity**: file parses without errors after edit ✅
- **Schema consistency**: new entry follows the existing field structure ✅
- **No regressions**: all 130+ existing proverbs unchanged ✅