### PR TITLE
content: add new trivia question

### DIFF
--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -669,5 +669,16 @@
     "Okonomiyaki"
   ],
   "correctIndex": 1
-}
+},
+  {
+    "question": "Which Japanese castle is known for its black exterior and nickname \"Crow Castle\"? (Community variation 50)",
+    "difficulty": "hard",
+    "answers": [
+      "Matsumoto Castle",
+      "Osaka Castle",
+      "Nijo Castle",
+      "Himeji Castle"
+    ],
+    "correctIndex": 0
+  }
 ]


### PR DESCRIPTION
## Summary

Fixes #16826

Adds a new Japan trivia question to the hard difficulty trivia bank about the Japanese castle known as the "Crow Castle" for its black exterior.

## Root Cause

The trivia bank at `community/content/japan-trivia-hard.json` was missing this community-contributed question (#130).

## Fix

Added the trivia question object to the JSON array following the exact schema used by all existing entries — `question`, `difficulty`, `answers` array, and `correctIndex`.

## Changes

- `community/content/japan-trivia-hard.json`: add 1 trivia question entry (`+12 -1` lines)

## Testing

- JSON file remains valid after insertion ✅
- New question follows same schema as existing entries ✅
- Existing trivia questions unaffected ✅