### PR TITLE
feat(theme): add Morning Dew theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -394,5 +394,13 @@
     "backgroundColor": "oklch(16.0% 0.025 280.0 / 1)",
     "mainColor": "oklch(85.0% 0.125 220.0 / 1)",
     "secondaryColor": "oklch(78.0% 0.165 45.0 / 1)"
+  },
+  {
+    "id": "morning-dew",
+    "backgroundColor": "oklch(93.0% 0.025 155.0 / 1)",
+    "mainColor": "oklch(50.0% 0.155 160.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.120 170.0 / 1)"
   }
+
+
 ]


### PR DESCRIPTION
## Summary of Changes

Added the **Morning Dew** color theme to the community themes collection. This light, fresh green-tinted theme evokes the feeling of morning dew on garden leaves.

## Root Cause / What Was Fixed

The community themes collection was missing a light green-themed color scheme. This PR adds the "morning-dew" theme with:
- Background: `oklch(93.0% 0.025 155.0 / 1)` — bright, fresh
- Main Color: `oklch(50.0% 0.155 160.0 / 1)` — vibrant green
- Secondary Color: `oklch(65.0% 0.120 170.0 / 1)` — subdued teal

## Testing Done

- ✅ JSON validated (valid JSON structure)
- ✅ Entry follows the same format as existing themes
- ✅ No duplicate IDs
- ✅ Closes #17152

## Screenshots

N/A — JSON-only change, no visual output.