### PR TITLE
content: add japanese haiku

### DIFF
--- a/community/content/japanese-haiku.json
+++ b/community/content/japanese-haiku.json
@@ -6,4 +6,13 @@
     "season": "Spring",
     "kigo": "Frog (kaeru)",
     "notes": "Humorous encouragement and compassion in Issa's voice."
+  },
+  {
+    "japanese": "夏草や\n兵どもが\n夢の跡",
+    "romaji": "Natsukusa ya / tsuwamono domo ga / yume no ato",
+    "english": "Summer grasses; all that remains of warriors' dreams.",
+    "poet": "Matsuo Basho",
+    "season": "Summer",
+    "kigo": "Summer grasses (natsukusa)",
+    "notes": "Reflects impermanence through a historical battlefield image."
   }

--- a/community/content/japanese-haiku.json
+++ b/community/content/japanese-haiku.json
@@ -1,3 +1,4 @@
+[
 {
     "japanese": "痩蛙 負けるな一茶 これにあり",
     "romaji": "Yasegaeru / makeru na Issa / kore ni ari",
@@ -16,3 +17,4 @@
     "kigo": "Summer grasses (natsukusa)",
     "notes": "Reflects impermanence through a historical battlefield image."
   }
+]


### PR DESCRIPTION
Closes #17178

## 📝 Description

Added a classic Japanese haiku by Matsuo Basho to the community haiku content.  
This haiku, "夏草や 兵どもが 夢の跡" (Natsukusa ya / tsuwamono domo ga / yume no ato), reflects on impermanence through the image of summer grasses growing over a historical battlefield.  
The entry includes Japanese text, romaji, English translation, poet, season, kigo, and cultural notes.

## 🔗 Related Issue

Closes #17178

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Verified the JSON file is valid and loads without errors.
2. Confirmed the new haiku appears in the haiku content array.

## 📸 Screenshots/Videos (if applicable)

N/A

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

No additional context.