### PR TITLE
feat(theme): add Sea Glass theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -461,10 +461,16 @@
     "mainColor": "oklch(80.0% 0.085 200.0 / 1)",
     "secondaryColor": "oklch(68.0% 0.105 160.0 / 1)"
   },
-   {
-  "id": "wasanbon",
-  "backgroundColor": "oklch(96.0% 0.012 95.0 / 1)",
-  "mainColor": "oklch(62.0% 0.110 75.0 / 1)",
-  "secondaryColor": "oklch(70.0% 0.060 85.0 / 1)"
-}
+  {
+    "id": "wasanbon",
+    "backgroundColor": "oklch(96.0% 0.012 95.0 / 1)",
+    "mainColor": "oklch(62.0% 0.110 75.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.060 85.0 / 1)"
+  },
+  {
+    "id": "sea-glass",
+    "backgroundColor": "oklch(96.0% 0.015 210.0 / 1)",
+    "mainColor": "oklch(60.0% 0.135 200.0 / 1)",
+    "secondaryColor": "oklch(78.0% 0.065 100.0 / 1)"
+  }
 ]

--- a/community/content/community-themes.test.ts
+++ b/community/content/community-themes.test.ts
@@ -31,4 +31,16 @@ describe('community-themes.json', () => {
     const tsukijiCount = themes.filter(t => t.id === 'tsukiji-morning').length;
     expect(tsukijiCount).toBe(1);
   });
+
+  it('should contain the sea-glass theme with correct colors', () => {
+    const theme = themes.find(t => t.id === 'sea-glass');
+    expect(theme).toBeDefined();
+    expect(theme).toHaveProperty('backgroundColor', 'oklch(96.0% 0.015 210.0 / 1)');
+    expect(theme).toHaveProperty('mainColor', 'oklch(60.0% 0.135 200.0 / 1)');
+    expect(theme).toHaveProperty('secondaryColor', 'oklch(78.0% 0.065 100.0 / 1)');
+  });
+
+  it('sea-glass should have a unique id among themes', () => {
+    expect(themes.filter(t => t.id === 'sea-glass').length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

Adds the Sea Glass community color theme to `community/content/community-themes.json` per issue #17586.

## Test plan

- [x] JSON validates
- [ ] CI passes community PR checks

Closes #17586

Made with [Cursor](https://cursor.com)