### PR TITLE
content: add new Japanese proverbs

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -576,21 +576,33 @@
     "meaning": "Kindness comes back to you"
   },
   {
-  "japanese": "木を見て森を見ず",
-  "romaji": "Ki wo mite mori wo mizu",
-  "english": "See the trees but not the forest",
-  "meaning": "Missing the bigger picture"
-},
+    "japanese": "木を見て森を見ず",
+    "romaji": "Ki wo mite mori wo mizu",
+    "english": "See the trees but not the forest",
+    "meaning": "Missing the bigger picture"
+  },
   {
-  "japanese": "木を見て森を見ず",
-  "romaji": "Ki wo mite mori wo mizu",
-  "english": "See the trees but not the forest",
-  "meaning": "Missing the bigger picture"
-},
+    "japanese": "木を見て森を見ず",
+    "romaji": "Ki wo mite mori wo mizu",
+    "english": "See the trees but not the forest",
+    "meaning": "Missing the bigger picture"
+  },
   {
-  "japanese": "泣きっ面に蜂",
-  "romaji": "Nakittsura ni hachi",
-  "english": "A bee on a crying face",
-  "meaning": "Misfortune never comes alone"
-}
+    "japanese": "泣きっ面に蜂",
+    "romaji": "Nakittsura ni hachi",
+    "english": "A bee on a crying face",
+    "meaning": "Misfortune never comes alone"
+  },
+  {
+    "japanese": "蛙の子は蛙",
+    "romaji": "Kaeru no ko wa kaeru",
+    "english": "A frog's child is a frog",
+    "meaning": "Children resemble their parents"
+  },
+  {
+    "japanese": "口は災いの元",
+    "romaji": "Kuchi wa wazawai no moto",
+    "english": "The mouth is the source of disaster",
+    "meaning": "Careless words cause trouble"
+  }
 ]


### PR DESCRIPTION
Added two Japanese proverbs:
- #81: 蛙の子は蛙 (Kaeru no ko wa kaeru) - Children resemble their parents
- #93: 口は災いの元 (Kuchi wa wazawai no moto) - Careless words cause trouble

Closes #17706
Closes #17701