### PR TITLE
Add Japan Fact #188 - Kochira Katsushika-ku Kameari Koen Mae Hashutsujo

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -82,5 +82,6 @@
   "There's a Japanese practice 'teineisa' (丁寧さ) meaning politeness shown through meticulous attention to detail.",
   "Japan has a 'Black Company' award given to employers with the worst working conditions - a form of public shaming for labor violations.",
   "Japan’s 'eki-ben' (駅弁) are region-specific boxed meals sold at train stations, often featuring local specialties.",
-  "The word 'ganban' (願番) describes taking turns at a task - cooperation without needing explicit coordination."
+  "The word 'ganban' (願番) describes taking turns at a task - cooperation without needing explicit coordination.",
+  "Japan has the world's longest-running comic book series - 'Kochira Katsushika-ku Kameari Kōen Mae Hashutsujo' ran for 40 years."
 ]


### PR DESCRIPTION
## Add Japan Fact #188

Issue: #18033

### New Fact Added

- Fact: Japan has the world's longest-running comic book series - 'Kochira Katsushika-ku Kameari Koen Mae Hashutsujo' ran for 40 years.

### Checklist

- [x] Added new fact to community/content/japan-facts.json
- [x] Valid JSON format
- [x] Follows existing structure
- [x] Only modified files in community/content/

Closes #18033