### PR TITLE
Add Japan Fact #27 - Japanese Address System

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -82,12 +82,13 @@
   "There's a Japanese practice 'teineisa' (丁寧さ) meaning politeness shown through meticulous attention to detail.",
   "Japan has a 'Black Company' award given to employers with the worst working conditions - a form of public shaming for labor violations.",
   "Japan’s 'eki-ben' (駅弁) are region-specific boxed meals sold at train stations, often featuring local specialties.",
-  "There's a Japanese word 'tsujigiri' (辻斬り) that historically meant testing a new sword on a random passerby - thankfully outlawed centuries ago."
+  "There's a Japanese word 'tsujigiri' (辻斬り) that historically meant testing a new sword on a random passerby - thankfully outlawed centuries ago.",
   "The word 'ganban' (願番) describes taking turns at a task - cooperation without needing explicit coordination.",
   "Japan has the world's oldest population - one in three Japanese citizens is over 60 years old, and the ratio is increasing.",
   "In Japan, there is a famous highway in Osaka that passes directly through the 5th, 6th, and 7th floors of a 16-story office building (the Gate Tower Building).",
   "Japan's crime rate is so low that police often spend time helping lost tourists and giving directions.",
   "The word 'kazaana' (風穴) refers to naturally cool caves used historically to store ice and preserve food in summer.",
   "The concept 'kokoro' (心) means heart-mind-spirit combined - emotions and thoughts are not separate in Japanese philosophy.",
-  "Japan has a tradition of exchanging seasonal gifts called 'oseibo' (お歳暮) in December to express thanks."
+  "Japan has a tradition of exchanging seasonal gifts called 'oseibo' (お歳暮) in December to express thanks.",
+  "Japan uses a unique area-based address system rather than street names, with buildings numbered by construction order within a block."
 ]


### PR DESCRIPTION
Adds a new Japan fact about the unique Japanese address numbering system.

Fact: Japanese addresses are based on blocks rather than streets - buildings are numbered by the order they were built, not their location.

Closes #18035