### PR TITLE
fix: add missing comma in japan-facts.json

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -82,7 +82,7 @@
   "There's a Japanese practice 'teineisa' (丁寧さ) meaning politeness shown through meticulous attention to detail.",
   "Japan has a 'Black Company' award given to employers with the worst working conditions - a form of public shaming for labor violations.",
   "Japan’s 'eki-ben' (駅弁) are region-specific boxed meals sold at train stations, often featuring local specialties.",
-  "There's a Japanese word 'tsujigiri' (辻斬り) that historically meant testing a new sword on a random passerby - thankfully outlawed centuries ago."
+  "There's a Japanese word 'tsujigiri' (辻斬り) that historically meant testing a new sword on a random passerby - thankfully outlawed centuries ago.",
   "The word 'ganban' (願番) describes taking turns at a task - cooperation without needing explicit coordination.",
   "Japan has the world's oldest population - one in three Japanese citizens is over 60 years old, and the ratio is increasing.",
   "In Japan, there is a famous highway in Osaka that passes directly through the 5th, 6th, and 7th floors of a 16-story office building (the Gate Tower Building).",


### PR DESCRIPTION
## 📝 Description

This PR fixes the syntax error (missing comma) identified in #18036

## 🔗 Related Issue

Closes #18036 

## ✅ Pre-Submission Checklist

- [X] I have starred the repo ⭐
- [X] My code follows the project's code style and uses `cn()` utility where needed
- [X] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [X] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] I have updated the documentation (if applicable) 📖
- [X] This PR is against the `main` branch 

## 🎯 Type of Change

- [X] `fix`: Bug fix (non-breaking change which fixes an issue)
- [X] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  Navigate to community/content/japan-facts.json.
2.  Verified that the JSON syntax is now valid (no errors).

<!--
**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

<img width="823" height="113" alt="image" src="https://github.com/user-attachments/assets/b1af2eb7-b50e-4ee6-95ac-35c009e04c25" />


**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

I identified the missing comma while working on my first contribution to the repository and decided to include it as a fix
