### PR TITLE
content: add japan fact 113

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -97,5 +97,6 @@
   "Japan has a museum dedicated to instant ramen in Osaka where visitors can create their own custom Cup Noodles flavor combinations.",
   "Japanese rail stations often have melodic 'departure jingles' tailored to the neighborhood, making each station instantly recognizable.",
   "The Japanese word 'mijikai' (短い) means short, but 'mijikai hanashi' can refer to a concise story — valued in polite conversation",
-  "Japan’s rail system is so punctual that many train companies issue delay certificates ('chien shoumeisho') for commuters."
+  "Japan’s rail system is so punctual that many train companies issue delay certificates ('chien shoumeisho') for commuters.",
+  "The word 'jibun' (自分) means 'self' but is also used to mean 'I' in many dialects - showing how identity is tied to selfhood."
 ]


### PR DESCRIPTION
## Description

Adds a Japan fact to `community/content/japan-facts.json`:


> The word 'jibun' (自分) means 'self' but is also used to mean 'I' in many dialects - showing how identity is tied to selfhood.



Closes #18714