### PR TITLE
Revert Japanese field values to original text

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -324,67 +324,67 @@
     "meaning": "Many little things add up to something big; small daily efforts lead to great success."
   },
   {
-    "japanese": "Seeing is believing",
+    "japanese": "百聞は一見に如かず",
     "romaji": "Hyakubun wa ikken ni shikazu",
     "english": "A hundred hearings are not equal to one seeing",
     "meaning": "Seeing is believing; a single look provides a much better understanding than hearing about something a hundred times."
   },
   {
-    "japanese": "Kill two birds with one stone",
+    "japanese": "一石二鳥",
     "romaji": "Isseki nichou",
     "english": "One stone, two birds",
     "meaning": "To kill two birds with one stone; achieving two goals with a single action."
   },
   {
-    "japanese": "Continuation is power",
+    "japanese": "継続は力なり",
     "romaji": "Keizoku wa chikara nari",
     "english": "Continuity is strength",
     "meaning": "Perseverance pays off; consistency and staying with a task builds power and leads to success."
   },
   {
-    "japanese": "A talented hawk hides its claws",
+    "japanese": "能ある鷹は爪を隠す",
     "romaji": "Nou aru taka wa tsume wo kakusu",
     "english": "A skilled hawk hides its talons",
     "meaning": "A truly talented or wise person doesn't feel the need to show off or brag about their abilities."
   },
   {
-    "japanese": "Darkness under the lighthouse",
+    "japanese": "灯台下暗し",
     "romaji": "Toudai moto kurashi",
     "english": "It's darkest under the lighthouse",
     "meaning": "The obvious is often overlooked"
   },
   {
-    "japanese": "Don't regret it first",
+    "japanese": "後悔先に立たず",
     "romaji": "Koukai saki ni tatazu",
     "english": "Regret does not stand before",
     "meaning": "It's too late for regrets"
   },
     {
-        "japanese": "I want to borrow a cat's hand.",
+        "japanese": "猫の手も借りたい",
         "romaji": "Neko no te mo karitai",
         "english": "I'd even borrow a cat's paw",
         "meaning": "Extremely busy"
   },
    {
-  "japanese": "It rains and the ground hardens.",
+  "japanese": "雨降って地固まる",
   "romaji": "Ame futte ji katamaru",
   "english": "After rain, the ground hardens",
   "meaning": "Adversity builds strength"
   },
   {
-  "japanese": "Three years on the stone",
+  "japanese": "石の上にも三年",
   "romaji": "Ishi no ue ni mo san nen",
   "english": "Three years on a stone",
   "meaning": "Perseverance will be rewarded"
   },
   {
-  "japanese": "Looking into the sky through the eye of a needle",
+  "japanese": "針の穴から天を覗く",
   "romaji": "Hari no ana kara ten wo nozoku",
   "english": "Peek at the sky through a needle's eye",
   "meaning": "A narrow viewpoint leads to poor judgment"
   },
   {
-    "japanese": "Nenbutsu in the horse's ears",
+    "japanese": "馬の耳に念仏",
     "romaji": "Uma no mimi ni nenbutsu",
     "english": "Preaching Buddha to a horse's ear",
     "meaning": "Advice is wasted on the unwilling"


### PR DESCRIPTION
Undo auto-translation of Japanese text values caused by browser extension. Restored original Japanese characters in the "japanese" field across all affected entries.

## 📝 Description

...

## 🔗 Related Issue

Closes #18996

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [ ] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [ ] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

<!--
**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

...

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

...
