### PR TITLE
feat(theme): add Harajuku Pop theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -304,5 +304,11 @@
     "backgroundColor": "oklch(17.0% 0.072 305.0 / 1)",
     "mainColor": "oklch(75.0% 0.175 195.0 / 1)",
     "secondaryColor": "oklch(80.0% 0.195 330.0 / 1)"
+  },
+  {
+    "id": "harajuku-pop",
+    "backgroundColor": "oklch(96.0% 0.025 85.0 / 1)",
+    "mainColor": "oklch(72.0% 0.225 320.0 / 1)",
+    "secondaryColor": "oklch(80.0% 0.195 200.0 / 1)"
   }
 ]


### PR DESCRIPTION
## What

Added new community theme 'Harajuku Pop' with bright candy colors and street style.

## Theme Details

| Property | Value |
|----------|-------|
| ID |  |
| Background |  |
| Main Color |  |
| Secondary |  |

**Vibe:** Bright candy colors and street style

Closes #19000