### PR TITLE
content: add Japan fact — tsundoku

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -55,5 +55,6 @@
   "The word 'enryo' (遠慮) describes polite restraint - like declining seconds even when hungry, to not be a burden.",
   "Japan is home to Kongō Gumi, the world's oldest company founded in 578 AD to build Buddhist temples, it operated independently until 2006.",
   "Japan has 'Peko-chan' - a cartoon mascot for Fujiya confectionery since 1950, whose tongue-sticking pose has become an iconic symbol recognized by nearly all Japanese people.",
-  "There's a Japanese concept called 'ikigai' (生き甲斐) - your reason for being - found at the intersection of what you love, need, and can be paid for."
+  "There's a Japanese concept called 'ikigai' (生き甲斐) - your reason for being - found at the intersection of what you love, need, and can be paid for.",
+  "Japan has a word 'tsundoku' (積ん読) for buying books and letting them pile up unread."
 ]


### PR DESCRIPTION
Adds a new Japan fact as requested in #19100.

> Japan has a word 'tsundoku' (積ん読) for buying books and letting them pile up unread.

Closes #19100