### PR TITLE
Add Trivia Question #29: Which Japanese city is known for Gion district?

### DIFF
--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -572,168 +572,179 @@
     "correctIndex": 0
   },
   {
-  "question": "Which Japanese city is famous for its street food district, Dotonbori? (Community variation 22)",
-  "difficulty": "hard",
-  "answers": [
-    "Osaka",
-    "Niigata",
-    "Kagoshima",
-    "Takayama"
-  ],
-  "correctIndex": 0
-},
-  {
-  "question": "Which Japanese city is known for the floating garden observatory?",
-  "difficulty": "hard",
-  "answers": [
-    "Osaka",
-    "Nagoya",
-    "Kobe",
-    "Yokohama"
-  ],
-  "correctIndex": 0
-},
-  {
-  "question": "Which Japanese city is known for the floating garden observatory?",
-  "difficulty": "hard",
-  "answers": [
-    "Osaka",
-    "Nagoya",
-    "Kobe",
-    "Yokohama"
-  ],
-  "correctIndex": 0
-},
-{
-  "question": "Which Japanese island is known for its active volcano, Sakurajima?",
-  "difficulty": "hard",
-  "answers": [
-    "Kyushu",
-    "Honshu",
-    "Shikoku",
-    "Hokkaido"
-  ],
-  "correctIndex": 0
-},  
-{
-  "question": "Which Japanese castle is known for its black exterior and nickname Crow Castle?",
-  "difficulty": "hard",
-  "answers": [
-    "Matsumoto Castle",
-    "Osaka Castle",
-    "Nijo Castle",
-    "Himeji Castle"
-  ],
-  "correctIndex": 0
-},
-  {
-  "question": "Which Japanese city is known for the floating garden observatory?",
-  "difficulty": "hard",
-  "answers": [
-    "Osaka",
-    "Nagoya",
-    "Kobe",
-    "Yokohama"
-  ],
-  "correctIndex": 0
-},
-  {
-  "question": "Which Japanese city hosted the 1998 Winter Olympics?",
-  "difficulty": "hard",
-  "answers": [
-    "Nagano",
-    "Kobe",
-    "Hiroshima",
-    "Naha"
-  ],
-  "correctIndex": 0
-},
-  {
-  "question": "Which Japanese island chain is known for tropical beaches and coral reefs?",
-  "difficulty": "hard",
-  "answers": [
-    "Okinawa",
-    "Sado",
-    "Awaji",
-    "Oki"
-  ],
-  "correctIndex": 0
-},
-  {
-  "question": "Which Japanese food is a grilled eel dish often eaten in summer? (Community variation 26)",
-  "difficulty": "hard",
-  "answers": [
-    "Tempura",
-    "Unagi",
-    "Sukiyaki",
-    "Okonomiyaki"
-  ],
-  "correctIndex": 1
-},
-  {
-  "question": "Which Japanese city is famous for its street food district, Dotonbori? (Community variation 22)",
-  "difficulty": "hard",
-  "answers": [
-    "Osaka",
-    "Niigata",
-    "Kagoshima",
-    "Takayama"
-  ],
-  "correctIndex": 0
+    "question": "Which Japanese city is famous for its street food district, Dotonbori? (Community variation 22)",
+    "difficulty": "hard",
+    "answers": [
+      "Osaka",
+      "Niigata",
+      "Kagoshima",
+      "Takayama"
+    ],
+    "correctIndex": 0
   },
   {
-  "question": "What is the name of the traditional Japanese theater featuring puppets?",
-  "difficulty": "hard",
-  "answers": [
-    "Bunraku",
-    "Noh",
-    "Kabuki",
-    "Kyogen"
-  ],
-  "correctIndex": 0
+    "question": "Which Japanese city is known for the floating garden observatory?",
+    "difficulty": "hard",
+    "answers": [
+      "Osaka",
+      "Nagoya",
+      "Kobe",
+      "Yokohama"
+    ],
+    "correctIndex": 0
   },
   {
-  "question": "Which Japanese city hosted the 1998 Winter Olympics? (Community variation 24)",
-  "difficulty": "hard",
-  "answers": [
-    "Nagano",
-    "Kobe",
-    "Hiroshima",
-    "Naha"
-  ],
-  "correctIndex": 0
-},
-{
-  "question": "Which Japanese castle is known for its black exterior and nickname \"Crow Castle\"? (Community variation 50)",
-  "difficulty": "hard",
-  "answers": [
-    "Matsumoto Castle",
-    "Osaka Castle",
-    "Nijo Castle",
-    "Himeji Castle"
-  ],
-  "correctIndex": 0
-},
-{
-  "question": "Which sea separates Japan from the Korean Peninsula? (Community variation 47)",
-  "difficulty": "hard",
-  "answers": [
-    "Sea of Japan",
-    "East China Sea",
-    "Philippine Sea",
-    "Bering Sea"
-  ],
-  "correctIndex": 0
-},
-{
-  "question": "What is the name of the traditional Japanese board game similar to chess?",
-  "difficulty": "hard",
-  "answers": [
-    "Shogi",
-    "Go",
-    "Mahjong",
-    "Reversi"
-  ],
-  "correctIndex": 0
-}
+    "question": "Which Japanese city is known for the floating garden observatory?",
+    "difficulty": "hard",
+    "answers": [
+      "Osaka",
+      "Nagoya",
+      "Kobe",
+      "Yokohama"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese island is known for its active volcano, Sakurajima?",
+    "difficulty": "hard",
+    "answers": [
+      "Kyushu",
+      "Honshu",
+      "Shikoku",
+      "Hokkaido"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese castle is known for its black exterior and nickname Crow Castle?",
+    "difficulty": "hard",
+    "answers": [
+      "Matsumoto Castle",
+      "Osaka Castle",
+      "Nijo Castle",
+      "Himeji Castle"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese city is known for the floating garden observatory?",
+    "difficulty": "hard",
+    "answers": [
+      "Osaka",
+      "Nagoya",
+      "Kobe",
+      "Yokohama"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese city hosted the 1998 Winter Olympics?",
+    "difficulty": "hard",
+    "answers": [
+      "Nagano",
+      "Kobe",
+      "Hiroshima",
+      "Naha"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese island chain is known for tropical beaches and coral reefs?",
+    "difficulty": "hard",
+    "answers": [
+      "Okinawa",
+      "Sado",
+      "Awaji",
+      "Oki"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese food is a grilled eel dish often eaten in summer? (Community variation 26)",
+    "difficulty": "hard",
+    "answers": [
+      "Tempura",
+      "Unagi",
+      "Sukiyaki",
+      "Okonomiyaki"
+    ],
+    "correctIndex": 1
+  },
+  {
+    "question": "Which Japanese city is famous for its street food district, Dotonbori? (Community variation 22)",
+    "difficulty": "hard",
+    "answers": [
+      "Osaka",
+      "Niigata",
+      "Kagoshima",
+      "Takayama"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the name of the traditional Japanese theater featuring puppets?",
+    "difficulty": "hard",
+    "answers": [
+      "Bunraku",
+      "Noh",
+      "Kabuki",
+      "Kyogen"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese city hosted the 1998 Winter Olympics? (Community variation 24)",
+    "difficulty": "hard",
+    "answers": [
+      "Nagano",
+      "Kobe",
+      "Hiroshima",
+      "Naha"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese castle is known for its black exterior and nickname \"Crow Castle\"? (Community variation 50)",
+    "difficulty": "hard",
+    "answers": [
+      "Matsumoto Castle",
+      "Osaka Castle",
+      "Nijo Castle",
+      "Himeji Castle"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which sea separates Japan from the Korean Peninsula? (Community variation 47)",
+    "difficulty": "hard",
+    "answers": [
+      "Sea of Japan",
+      "East China Sea",
+      "Philippine Sea",
+      "Bering Sea"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "What is the name of the traditional Japanese board game similar to chess?",
+    "difficulty": "hard",
+    "answers": [
+      "Shogi",
+      "Go",
+      "Mahjong",
+      "Reversi"
+    ],
+    "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese city is known for its historic wooden district, Gion?",
+    "difficulty": "medium",
+    "answers": [
+      "Kyoto",
+      "Yokohama",
+      "Nagoya",
+      "Sendai"
+    ],
+    "correct": 0
+  }
 ]

--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -745,6 +745,6 @@
       "Nagoya",
       "Sendai"
     ],
-    "correct": 0
+    "correctIndex": 0
   }
 ]


### PR DESCRIPTION
Closes #19203

Adds the trivia question about Kyoto's Gion district to japan-trivia-hard.json as specified in the issue.