### PR TITLE
content: add Inari shrine trivia question

### DIFF
--- a/community/content/japan-trivia-easy.json
+++ b/community/content/japan-trivia-easy.json
@@ -256,5 +256,16 @@
     "Yatai"
   ],
   "correctIndex": 0
-}
+  },
+  {
+    "question": "Which animal is famously associated with Inari shrines in Japan? (Community variation 33)",
+    "difficulty": "easy",
+    "answers": [
+      "Fox",
+      "Crane",
+      "Turtle",
+      "Deer"
+    ],
+    "correctIndex": 0
+  }
 ]


### PR DESCRIPTION
## Summary

Adds a new easy Japan trivia question about the animal associated with Inari shrines.

Fixes #19307

## Tests/checks run

- JSON validation — passed
- Trivia entry verification — passed
- Git diff validation — passed

## Changed files

Only `community/content/japan-trivia-easy.json` was changed.
