### PR TITLE
feat(theme): add Saffron Dusk theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -724,5 +724,11 @@
     "backgroundColor": "oklch(22.0% 0.035 240.0 / 1)",
     "mainColor": "oklch(90.0% 0.085 220.0 / 1)",
     "secondaryColor": "oklch(65.0% 0.185 25.0 / 1)"
+  },
+    {
+    "id": "saffron-dusk",
+    "backgroundColor": "oklch(21.0% 0.040 55.0 / 1)",
+    "mainColor": "oklch(78.0% 0.160 60.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.095 40.0 / 1)"
   }
 ]


### PR DESCRIPTION
## 📝 Description
Adds a new community color theme, **Saffron Dusk** (`saffron-dusk`), to `community/content/community-themes.json`, as requested in the good-first-issue. The palette evokes late sunlight over temple roofs.

| Property | Value |
|----------|-------|
| ID | `saffron-dusk` |
| Background | `oklch(21.0% 0.040 55.0 / 1)` |
| Main | `oklch(78.0% 0.160 60.0 / 1)` |
| Secondary | `oklch(70.0% 0.095 40.0 / 1)` |

## 🔗 Related Issue
Closes #19668

## ✅ Pre-Submission Checklist
- [x] I have starred the repo ⭐
- [ ] My code follows the project's code style and uses `cn()` utility where needed <!-- N/A — data-only JSON change, no code -->
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞 <!-- N/A — no code touched; verified JSON validity manually -->
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖 <!-- N/A -->
- [x] This PR is against the `main` branch

## 🎯 Type of Change
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?
**Test Steps:**
1. Added the new theme object to `community/content/community-themes.json`.
2. Confirmed the file is valid JSON — double-quoted keys/values, comma added after the previous entry, and no trailing comma after the new final object.

## 📸 Screenshots/Videos (if applicable)
N/A — theme palette added via data file; no manual UI changes in this PR.

## 📦 Additional Context
N/A