### PR TITLE
feat(theme): add Tea Ceramic theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -346,5 +346,11 @@
   "backgroundColor": "oklch(24.0% 0.028 65.0 / 1)",
   "mainColor": "oklch(72.0% 0.085 70.0 / 1)",
   "secondaryColor": "oklch(60.0% 0.065 55.0 / 1)"
-}
+},
+  {
+    "id": "tea-ceramic",
+    "backgroundColor": "oklch(23.0% 0.020 60.0 / 1)",
+    "mainColor": "oklch(72.0% 0.085 50.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.060 35.0 / 1)"
+  }
 ]


### PR DESCRIPTION
## 📝 Description
Adds a new community color theme, **Tea Ceramic** (`tea-ceramic`), to `community/content/community-themes.json`, as requested in the good-first-issue. The palette evokes glazed cups and warm clay.

| Property | Value |
|----------|-------|
| ID | `tea-ceramic` |
| Background | `oklch(23.0% 0.020 60.0 / 1)` |
| Main | `oklch(72.0% 0.085 50.0 / 1)` |
| Secondary | `oklch(60.0% 0.060 35.0 / 1)` |

## 🔗 Related Issue
Closes #19666 

## ✅ Pre-Submission Checklist
- [x] I have starred the repo ⭐
- [ ] My code follows the project's code style and uses `cn()` utility where needed <!-- N/A — data-only JSON change, no code -->
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞 <!-- N/A — no code touched; verified JSON validity manually -->
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖 <!-- N/A -->
- [x] This PR is against the `main` branch

## 🎯 Type of Change
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?
**Test Steps:**
1. Added the new theme object to `community/content/community-themes.json`.
2. Confirmed the file is valid JSON — double-quoted keys/values, comma added after the previous entry, no trailing comma after the new final object.

## 📸 Screenshots/Videos (if applicable)
N/A — theme palette added via data file; no manual UI changes in this PR.

## 📦 Additional Context
N/A