### PR TITLE
content: add new Japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -55,5 +55,6 @@
   "The word 'enryo' (遠慮) describes polite restraint - like declining seconds even when hungry, to not be a burden.",
   "Japan is home to Kongō Gumi, the world's oldest company founded in 578 AD to build Buddhist temples, it operated independently until 2006.",
   "Japan has 'Peko-chan' - a cartoon mascot for Fujiya confectionery since 1950, whose tongue-sticking pose has become an iconic symbol recognized by nearly all Japanese people.",
-  "There's a Japanese concept called 'ikigai' (生き甲斐) - your reason for being - found at the intersection of what you love, need, and can be paid for."
+  "There's a Japanese concept called 'ikigai' (生き甲斐) - your reason for being - found at the intersection of what you love, need, and can be paid for.",
+  "Japan has an island where cats outnumber humans 6 to 1 - Tashirojima was once used to farm silkworms, and cats protected them from mice."
 ]


### PR DESCRIPTION
## Summary
This updates `community/content/japan-facts.json` by adding one new fact:

> "Japan has an island where cats outnumber humans 6 to 1 - Tashirojima was once used to farm silkworms, and cats protected them from mice."

Closes #19782.

## Validation
- Ran `npm run check` on this branch.
- Repository `npm run check` currently has existing baseline issues unrelated to this content-only change:
  - 12 ESLint errors
  - 513 ESLint warnings

The JSON change itself is minimal and confined to the requested data file.
