### PR TITLE
content: add japanese haiku

### DIFF
--- a/community/content/japanese-haiku.json
+++ b/community/content/japanese-haiku.json
@@ -61,5 +61,14 @@
     "season": "Spring",
     "kigo": "Frog (kaeru)",
     "notes": "Humorous encouragement and compassion in Issa's voice."
+  },
+  {
+    "japanese": "五月雨を\n集めて早し\n最上川",
+    "romaji": "Samidare o / atsume te hayashi / Mogamigawa",
+    "english": "Gathering summer rains, the Mogami River rushes on.",
+    "poet": "Matsuo Basho",
+    "season": "Summer",
+    "kigo": "Summer rain (samidare)",
+    "notes": "A dynamic river image with strong seasonal presence."
   }
 ]


### PR DESCRIPTION
## Summary
- Adds the requested Japanese haiku to `community/content/japanese-haiku.json` for beginner-friendly content contribution issue #19822.

## Related issue
- Closes #19822

## Validation
- Ran `npm install` to provision dependencies.
- Ran `npm run check`.
- Check command failed with existing baseline lint violations unrelated to this content-only JSON change (12 errors, 513 warnings across many files).

## Notes
- Change is intentionally limited to a single JSON record append for low-risk community content contribution.
