### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -478,6 +478,11 @@
   "romaji": "Yakeishi ni mizu",
   "english": "Water on a hot stone",
   "meaning": "A futile effort with little effect"
-  }
-  
+  },
+  {
+  "japanese": "口は禍の元",
+  "romaji": "Kuchi wa wazawai no moto",
+  "english": "The mouth is the source of misfortune",
+  "meaning": "Careless words cause trouble"
+  }  
 ]


### PR DESCRIPTION
## 📝 Description

Added a new Japanese proverb to `community/content/japanese-proverbs.json`.

## 🔗 Related Issue

Closes #20066

## ✅ Pre-Submission Checklist

* [✅] I have starred the repo ⭐
* [✅] My commit messages follow the Conventional Commits format
* [✅] This PR is against the `main` branch

## 🎯 Type of Change

* [✅] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Added the proverb entry to `community/content/japanese-proverbs.json`
2. Verified the JSON structure remains valid

## 📦 Additional Context

Added the proverb:

口は禍の元 (Kuchi wa wazawai no moto) — "The mouth is the source of misfortune"
