### PR TITLE
feat(theme): add Moss Temple theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -376,12 +376,12 @@
     "mainColor": "oklch(65.0% 0.195 40.0 / 1)",
     "secondaryColor": "oklch(75.0% 0.145 85.0 / 1)"
   },
-{
+  {
   "id": "torii-sunset",
   "backgroundColor": "oklch(22.0% 0.058 35.0 / 1)",
   "mainColor": "oklch(75.0% 0.195 40.0 / 1)",
   "secondaryColor": "oklch(85.0% 0.155 70.0 / 1)"
-},
+  },
   {
     "id": "cyber-kitsune",
     "backgroundColor": "oklch(13.0% 0.058 295.0 / 1)",
@@ -393,8 +393,8 @@
   "backgroundColor": "oklch(98.0% 0.004 90.0 / 1)",
   "mainColor": "oklch(55.0% 0.035 250.0 / 1)",
   "secondaryColor": "oklch(70.0% 0.015 90.0 / 1)"
-},
-   {
+  },
+  {
     "id": "tsukimi-night",
     "backgroundColor": "oklch(14.0% 0.030 260.0 / 1)",
     "mainColor": "oklch(88.0% 0.050 230.0 / 1)",
@@ -411,11 +411,17 @@
   "backgroundColor": "oklch(92.0% 0.012 90.0 / 1)",
   "mainColor": "oklch(35.0% 0.085 255.0 / 1)",
   "secondaryColor": "oklch(55.0% 0.055 65.0 / 1)"
-},
-{
+  },
+  {
     "id": "edo-vintage",
     "backgroundColor": "oklch(24.0% 0.028 65.0 / 1)",
     "mainColor": "oklch(72.0% 0.085 70.0 / 1)",
     "secondaryColor": "oklch(60.0% 0.065 55.0 / 1)"
+  },
+  {
+    "id": "moss-temple",
+    "backgroundColor": "oklch(22.0% 0.045 145.0 / 1)",
+    "mainColor": "oklch(65.0% 0.155 140.0 / 1)",
+    "secondaryColor": "oklch(55.0% 0.100 120.0 / 1)"
   }
 ]


### PR DESCRIPTION
## 📝 Description
Added new community theme: Moss Temple — a dark green theme inspired by ancient moss-covered temple grounds.

## 🔗 Related Issue
Closes #20557

## ✅ Pre-Submission Checklist
- [x] I have starred the repo ⭐
- [x] My commit messages follow the Conventional Commits format
- [x] This PR is against the `main` branch

## 🎯 Type of Change
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)

## 🧪 How Has This Been Tested?
Added JSON entry to community-themes.json with valid structure matching existing themes.