### PR TITLE
content: add video game quote

### DIFF
--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -1,5 +1,12 @@
 [
   {
+  "japanese": "ここからが本番だ",
+  "romaji": "Koko kara ga honban da",
+  "english": "The real challenge starts now.",
+  "game": "Monster Hunter series",
+  "character": "Guild Handler lines"
+},
+  {
     "japanese": "勝つと思うな、思えば負けよ",
     "romaji": "Katsu to omou na, omoeba makeyo",
     "english": "If you only think of winning, you lose.",


### PR DESCRIPTION
## 📝 Description
Added a Japanese video game quote from the Monster Hunter series (Guild Handler lines) to community/content/japanese-videogame-quotes.json

## 🔗 Related Issue
Closes #20918

## ✅ Pre-Submission Checklist
- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the Conventional Commits format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?
**Test Steps:**
1. Validated the JSON file with `node -e "JSON.parse(...)"` to confirm syntax is valid.
2. Confirmed the new entry follows the same structure and fields as existing entries in the file.

## 📸 Screenshots/Videos (if applicable)
N/A — content-only JSON change, no UI impact.

## 📦 Additional Context
Ran `npm run check` — found a pre-existing unrelated TypeScript error in `features/PatchNotes/components/PatchNotesModal.tsx` (missing `commitInfo.json`, likely generated at build time). Not related to this content-only change.