### PR TITLE
docs(community): fix nested double quotes in Japan Facts example and …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,15 +140,15 @@ If your change affects visuals (themes, fonts, UI), take a quick screenshot or G
 ### Editing JSON content safely
 
 Many community contributions update JSON files such as `community/content/japan-facts.json`.
-If the text itself contains quotation marks, escape inner double quotes so the JSON stays valid.
+If the text itself contains quotation marks, you can either use single quotes or escape inner double quotes so the JSON stays valid.
 
 ```json
 {
-  "fact": "The phrase 'yoroshiku onegaishimasu' (よろしくお願いします) is a versatile expression for \"please take care of me.\""
+  "fact": "The phrase 'yoroshiku onegaishimasu' (よろしくお願いします) is a versatile expression for 'please take care of me.'"
 }
 ```
 
-Quick rule: keep JSON keys and values wrapped in double quotes, and write embedded double quotes as `\"`.
+Quick rule: keep JSON keys and values wrapped in double quotes, and write embedded double quotes as `\"` (or use single quotes `'` to avoid escaping).
 
 ## 🌐 Translating the App
 

--- a/community/backlog/facts-backlog.json
+++ b/community/backlog/facts-backlog.json
@@ -1741,7 +1741,7 @@
   },
   {
     "id": 291,
-    "fact": "Japan’s name for the rainy season, 'tsuyu' (梅雨), literally means \"plum rain\" because it coincides with the ripening of ume plums.",
+    "fact": "Japan’s name for the rainy season, 'tsuyu' (梅雨), literally means 'plum rain' because it coincides with the ripening of ume plums.",
     "issued": false,
     "completed": false
   },
@@ -1855,7 +1855,7 @@
   },
   {
     "id": 310,
-    "fact": "The term 'okagesama' (おかげさまで) expresses humility, meaning \"thanks to you\" or \"thanks to circumstances.\"",
+    "fact": "The term 'okagesama' (おかげさまで) expresses humility, meaning 'thanks to you' or 'thanks to circumstances.'",
     "issued": false,
     "completed": false
   },
@@ -1873,7 +1873,7 @@
   },
   {
     "id": 313,
-    "fact": "The phrase 'yoroshiku onegaishimasu' (よろしくお願いします) is a versatile expression for \"please take care of me.\"",
+    "fact": "The phrase 'yoroshiku onegaishimasu' (よろしくお願いします) is a versatile expression for 'please take care of me.'",
     "issued": false,
     "completed": false
   },
@@ -1909,13 +1909,13 @@
   },
   {
     "id": 319,
-    "fact": "The Japanese term 'shinrin-yoku' (森林浴) translates to \"forest bathing\" and emphasizes mindful time in nature.",
+    "fact": "The Japanese term 'shinrin-yoku' (森林浴) translates to 'forest bathing' and emphasizes mindful time in nature.",
     "issued": false,
     "completed": false
   },
   {
     "id": 320,
-    "fact": "'Mame' (豆) can mean both \"bean\" and \"diligent\"—so bean-related gifts sometimes imply good health and hard work.",
+    "fact": "'Mame' (豆) can mean both 'bean' and 'diligent'—so bean-related gifts sometimes imply good health and hard work.",
     "issued": false,
     "completed": false
   }


### PR DESCRIPTION
## 📝 Description

This PR fixes JSON syntax issues that contributors may encounter when adding new Japan Facts.

### Changes Made

* Updated the Japan Facts example in `CONTRIBUTING.md` to use JSON-safe quoting.
* Updated affected entries in `community/backlog/facts-backlog.json` to replace internal double quotes with single quotes.
* Ensured future generated issues contain content that can be copied directly into `community/content/japan-facts.json` without causing JSON parsing errors.

## 🔗 Related Issue

Closes #18054

## ✅ Pre-Submission Checklist

* [x] I have starred the repo ⭐
* [x] My code follows the project's code style and uses `cn()` utility where needed
* [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
* [x] My commit messages follow the Conventional Commits format
* [x] I have updated the documentation (if applicable) 📖
* [x] This PR is against the `main` branch

## 🎯 Type of Change

* [x] `fix`: Bug fix (non-breaking change which fixes an issue)
* [x] `docs`: Documentation update (e.g., this file, README)
* [ ] `feat`
* [ ] `content`
* [ ] `style`
* [ ] `refactor`
* [ ] `test`
* [ ] `chore`

## 🧪 How Has This Been Tested?

### Test Steps

1. Updated the affected examples in `CONTRIBUTING.md` and `community/backlog/facts-backlog.json`.
2. Verified that the modified JSON files remain valid.
3. Confirmed that the example content can be copied directly into `community/content/japan-facts.json` without producing JSON syntax errors.
4. Ran project validation checks successfully.

## 📦 Additional Context

The issue occurred because generated GitHub issues displayed fact strings containing nested quotation marks. Contributors copying these strings directly into JSON files could unintentionally create invalid JSON. Replacing the internal quotes with single quotes ensures the examples remain copy-paste safe.
