### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -184,5 +184,11 @@
   "romaji": "En no shita no chikaramochi",
   "english": "A strong person under the veranda",
   "meaning": "An unsung hero who supports behind the scenes"
+},
+{
+  "japanese": "藪をつついて蛇を出す",
+  "romaji": "Yabu wo tsutsuite hebi wo dasu",
+  "english": "Poke the bush and bring out a snake",
+  "meaning": "Stir up trouble unnecessarily"
 }
 ]


### PR DESCRIPTION
## 📝 Description

Added a new Japanese proverb to `community/content/japanese-proverbs.json`:

* Japanese: 藪をつついて蛇を出す
* Romaji: Yabu wo tsutsuite hebi wo dasu
* English: Poke the bush and bring out a snake
* Meaning: Stir up trouble unnecessarily

## 🔗 Related Issue

Closes #84

## ✅ Pre-Submission Checklist

* [x] I have starred the repo ⭐
* [x] My commit messages follow the Conventional Commits format
* [x] This PR is against the `main` branch

## 🎯 Type of Change

* [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)

## 🧪 How Has This Been Tested?

Verified that the JSON format remains valid after adding the new proverb.

## 📦 Additional Context

This is a content-only change that adds a traditional Japanese proverb for learners.
