### PR TITLE
content: add japanese haiku

### DIFF
--- a/community/content/japanese-haiku.json
+++ b/community/content/japanese-haiku.json
@@ -106,5 +106,14 @@
   "season": "Autumn",
   "kigo": "Harvest moon (meigetsu)",
   "notes": "Captures Basho's admiration for the autumn moon and the quiet beauty of nighttime reflection."
+},
+{
+  "japanese": "春の海\nひねもすのたり\nのたりかな",
+  "romaji": "Haru no umi / hinemosu notari / notari kana",
+  "english": "The spring sea stretches lazily all day, rising and falling.",
+  "poet": "Yosa Buson",
+  "season": "Spring",
+  "kigo": "Spring sea (haru no umi)",
+  "notes": "Known for musical phrasing and calm motion."
 }
 ]


### PR DESCRIPTION
Adds Yosa Buson's classic spring haiku *Haru no umi* (春の海) to `community/content/japanese-haiku.json`, expanding the poetic and cultural learning content.

The new entry follows the existing schema exactly (`japanese`, `romaji`, `english`, `poet`, `season`, `kigo`, `notes`), and the file remains valid JSON after the change.

Closes #21444