### PR TITLE
Theme: add Tsuyu Drizzle theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -316,5 +316,12 @@
   "backgroundColor": "oklch(23.0% 0.030 85.0 / 1)",
   "mainColor": "oklch(86.0% 0.165 95.0 / 1)",
   "secondaryColor": "oklch(70.0% 0.115 75.0 / 1)"
-  }
+  },
+  {
+  "id": "tsuyu-drizzle",
+  "backgroundColor": "oklch(22.0% 0.015 250.0 / 1)",
+  "mainColor": "oklch(72.0% 0.105 230.0 / 1)",
+  "secondaryColor": "oklch(78.0% 0.025 260.0 / 1)"
+     }
+   ]
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -322,6 +322,5 @@
   "backgroundColor": "oklch(22.0% 0.015 250.0 / 1)",
   "mainColor": "oklch(72.0% 0.105 230.0 / 1)",
   "secondaryColor": "oklch(78.0% 0.025 260.0 / 1)"
-     }
-   ]
+  }
 ]


### PR DESCRIPTION
## 📝 Description
Adds a new color theme, "Tsuyu Drizzle," to the community themes list. Inspired by rainy season blues and soft gray clouds — dark blue-gray background with a muted cyan main color and soft gray-blue secondary.

## 🔗 Related Issue
Closes #21580

## ✅ Pre-Submission Checklist
- [✅] I have starred the repo ⭐
- [✅] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the Conventional Commits format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)

## 🧪 How Has This Been Tested?
**Test Steps:**
1. Validated the JSON syntax manually (jsonlint) to confirm the new theme object is well-formed and doesn't break the array.
2. Attempted to run the app locally to visually confirm the theme, but hit a pre-existing, unrelated build error (missing generated `shared/data/commitInfo.json`) that blocks `npm run dev` on a fresh clone — not caused by this change.

## 📸 Screenshots/Videos (if applicable)
N/A — could not get the local dev server running to capture one (see testing notes above).

## 📦 Additional Context
This is a single-entry JSON addition with no logic changes. Local environment setup hit an unrelated blocker (`commitInfo.json` not found) unconnected to this PR's diff. Happy to follow up if `npm run check`/screenshots are required before merge.