### PR TITLE
content: add trivia question #120 (Tokugawa shogunate castle)

### DIFF
--- a/community/content/japan-trivia-medium.json
+++ b/community/content/japan-trivia-medium.json
@@ -582,4 +582,16 @@
   ],
   "correctIndex": 1 
  }
+,
+{
+  "question": "Which Japanese castle was the seat of the Tokugawa shogunate? (Community variation 40)",
+  "difficulty": "medium",
+  "answers": [
+    "Edo Castle",
+    "Himeji Castle",
+    "Matsumoto Castle",
+    "Osaka Castle"
+  ],
+  "correctIndex": 0
+}
 ]


### PR DESCRIPTION
## 📝 Description

Added Trivia Question #120 about Edo Castle to `community/content/japan-trivia-medium.json`.

## 🔗 Related Issue

Closes #21603

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style
- [x] JSON is valid and properly formatted
- [x] Entry added at the end of the array before closing ]

## 📋 What was added

```json
{
  "question": "Which Japanese castle was the seat of the Tokugawa shogunate? (Community variation 40)",
  "difficulty": "medium",
  "answers": [
    "Edo Castle",
    "Himeji Castle",
    "Matsumoto Castle",
    "Osaka Castle"
  ],
  "correctIndex": 0
}
```