### PR TITLE
Fix/training action bar overlap

### DIFF
--- a/features/Kana/components/KanaCards/index.tsx
+++ b/features/Kana/components/KanaCards/index.tsx
@@ -121,12 +121,7 @@ interface KanaCardsProps {
   selectedSubset?: string;
 }
 
-const KanaCards = ({
-  filter = 'all',
-  viewMode,
-  selectedKanaType,
-  selectedSubset,
-}: KanaCardsProps) => {
+const KanaCards = ({ filter = 'all', viewMode, selectedKanaType, selectedSubset }: KanaCardsProps) => {
   const { playClick } = useClick();
 
   const effectiveFilter: KanaCardsFilter =
@@ -231,111 +226,109 @@ const KanaCards = ({
   }
 
   return (
-    <div className='flex w-full flex-col gap-4'>
-      <div className='flex w-full flex-col gap-2 sm:flex-row sm:items-start'>
-        {(() => {
-          const compactGroups = kanaGroups.filter(g => {
-            if (filter === 'hiragana')
-              return g.name.toLowerCase().startsWith('hiragana');
-            if (filter === 'katakana')
-              return g.name.toLowerCase().startsWith('katakana');
-            return true;
-          });
-          const isSingleCompact = compactGroups.length === 1;
-          return compactGroups.map(group => {
-            const groupHidden = isHidden(group.name);
-            const [mainTitle, japaneseTitle] = group.name.split(' ');
+    <div className='flex w-full flex-col gap-2 sm:flex-row sm:items-start'>
+      {(() => {
+        const compactGroups = kanaGroups.filter(g => {
+          if (filter === 'hiragana')
+            return g.name.toLowerCase().startsWith('hiragana');
+          if (filter === 'katakana')
+            return g.name.toLowerCase().startsWith('katakana');
+          return true;
+        });
+        const isSingleCompact = compactGroups.length === 1;
+        return compactGroups.map(group => {
+          const groupHidden = isHidden(group.name);
+          const [mainTitle, japaneseTitle] = group.name.split(' ');
 
-            return (
-              <Fragment key={group.name}>
-                <form
+          return (
+            <Fragment key={group.name}>
+              <form
+                className={clsx(
+                  'flex w-full flex-col gap-2 p-4',
+                  isSingleCompact ? 'sm:w-full' : 'sm:w-1/2',
+                  cardBorderStyles,
+                )}
+              >
+                {/* Group Header */}
+                <legend
                   className={clsx(
-                    'flex w-full flex-col gap-2 p-4',
-                    isSingleCompact ? 'sm:w-full' : 'sm:w-1/2',
-                    cardBorderStyles,
+                    'group flex flex-row items-center hover:cursor-pointer',
+                    USE_NEW_KANA_BADGE_DESIGN
+                      ? 'gap-2 text-[1.9rem]'
+                      : 'gap-1 text-2xl',
                   )}
+                  onClick={() => toggleVisibility(group.name)}
                 >
-                  {/* Group Header */}
-                  <legend
-                    className={clsx(
-                      'group flex flex-row items-center hover:cursor-pointer',
-                      USE_NEW_KANA_BADGE_DESIGN
-                        ? 'gap-2 text-[1.9rem]'
-                        : 'gap-1 text-2xl',
-                    )}
-                    onClick={() => toggleVisibility(group.name)}
-                  >
-                    <ChevronUp className={chevronClasses(groupHidden)} />
-                    {USE_NEW_KANA_BADGE_DESIGN && (
-                      <span className={headingBadgeClasses.group}>
-                        {groupKanaBadgeByName[group.name] ?? 'あ'}
-                      </span>
-                    )}
-                    <h3 className='flex items-center gap-2'>
-                      <span>{mainTitle}</span>
-                      <span className='hidden text-(--secondary-color) xl:inline'>
-                        {japaneseTitle}
-                      </span>
-                    </h3>
-                  </legend>
+                  <ChevronUp className={chevronClasses(groupHidden)} />
+                  {USE_NEW_KANA_BADGE_DESIGN && (
+                    <span className={headingBadgeClasses.group}>
+                      {groupKanaBadgeByName[group.name] ?? 'あ'}
+                    </span>
+                  )}
+                  <h3 className='flex items-center gap-2'>
+                    <span>{mainTitle}</span>
+                    <span className='hidden text-(--secondary-color) xl:inline'>
+                      {japaneseTitle}
+                    </span>
+                  </h3>
+                </legend>
 
-                  {/* Subsets */}
-                  {!groupHidden &&
-                    group.subsets.map((subset, index) => {
-                      const subsetHidden = isHidden(subset.name);
-                      const isLastSubset = index === group.subsets.length - 1;
+                {/* Subsets */}
+                {!groupHidden &&
+                  group.subsets.map((subset, index) => {
+                    const subsetHidden = isHidden(subset.name);
+                    const isLastSubset = index === group.subsets.length - 1;
 
-                      return (
-                        <div
-                          key={subset.name}
-                          className='flex w-full flex-col gap-2'
-                        >
-                          <div>
-                            {/* Subset Header */}
-                            <h4
-                              className={clsx(
-                                'group flex flex-row items-center hover:cursor-pointer',
-                                USE_NEW_KANA_BADGE_DESIGN
-                                  ? 'gap-2 text-[1.5rem]'
-                                  : 'gap-1 text-xl',
-                              )}
-                              onClick={() => toggleVisibility(subset.name)}
-                            >
-                              <ChevronUp
-                                className={chevronClasses(subsetHidden)}
-                                size={24}
-                              />
-                              {USE_NEW_KANA_BADGE_DESIGN && (
-                                <span className={headingBadgeClasses.subset}>
-                                  {subsetKanaBadgeByName[subset.name] ?? 'あ'}
-                                </span>
-                              )}
-                              <span>{subset.name.slice(1)}</span>
-                            </h4>
-
-                            {/* Subset Content */}
-                            {!subsetHidden && (
-                              <Subset
-                                sliceRange={subset.sliceRange}
-                                group={group.name}
-                                subgroup={subset.name}
-                              />
+                    return (
+                      <div
+                        key={subset.name}
+                        className='flex w-full flex-col gap-2'
+                      >
+                        <div>
+                          {/* Subset Header */}
+                          <h4
+                            className={clsx(
+                              'group flex flex-row items-center hover:cursor-pointer',
+                              USE_NEW_KANA_BADGE_DESIGN
+                                ? 'gap-2 text-[1.5rem]'
+                                : 'gap-1 text-xl',
                             )}
-                          </div>
+                            onClick={() => toggleVisibility(subset.name)}
+                          >
+                            <ChevronUp
+                              className={chevronClasses(subsetHidden)}
+                              size={24}
+                            />
+                            {USE_NEW_KANA_BADGE_DESIGN && (
+                              <span className={headingBadgeClasses.subset}>
+                                {subsetKanaBadgeByName[subset.name] ?? 'あ'}
+                              </span>
+                            )}
+                            <span>{subset.name.slice(1)}</span>
+                          </h4>
 
-                          {/* Divider (except after last subset) */}
-                          {!isLastSubset && (
-                            <hr className='w-full border-t border-(--border-color)' />
+                          {/* Subset Content */}
+                          {!subsetHidden && (
+                            <Subset
+                              sliceRange={subset.sliceRange}
+                              group={group.name}
+                              subgroup={subset.name}
+                            />
                           )}
                         </div>
-                      );
-                    })}
-                </form>
-              </Fragment>
-            );
-          });
-        })()}
-      </div>
+
+                        {/* Divider (except after last subset) */}
+                        {!isLastSubset && (
+                          <hr className='w-full border-t border-(--border-color)' />
+                        )}
+                      </div>
+                    );
+                  })}
+              </form>
+            </Fragment>
+          );
+        });
+      })()}
       <div aria-hidden className='py-4' />
     </div>
   );

--- a/features/Kana/components/KanaCards/index.tsx
+++ b/features/Kana/components/KanaCards/index.tsx
@@ -121,7 +121,12 @@ interface KanaCardsProps {
   selectedSubset?: string;
 }
 
-const KanaCards = ({ filter = 'all', viewMode, selectedKanaType, selectedSubset }: KanaCardsProps) => {
+const KanaCards = ({
+  filter = 'all',
+  viewMode,
+  selectedKanaType,
+  selectedSubset,
+}: KanaCardsProps) => {
   const { playClick } = useClick();
 
   const effectiveFilter: KanaCardsFilter =
@@ -219,115 +224,119 @@ const KanaCards = ({ filter = 'all', viewMode, selectedKanaType, selectedSubset 
               />
             ))}
           </div>
+          <div aria-hidden className='py-4' />
         </div>
       );
     }
   }
 
   return (
-    <div className='flex w-full flex-col gap-2 sm:flex-row sm:items-start'>
-      {(() => {
-        const compactGroups = kanaGroups.filter(g => {
-          if (filter === 'hiragana')
-            return g.name.toLowerCase().startsWith('hiragana');
-          if (filter === 'katakana')
-            return g.name.toLowerCase().startsWith('katakana');
-          return true;
-        });
-        const isSingleCompact = compactGroups.length === 1;
-        return compactGroups.map(group => {
-          const groupHidden = isHidden(group.name);
-          const [mainTitle, japaneseTitle] = group.name.split(' ');
+    <div className='flex w-full flex-col gap-4'>
+      <div className='flex w-full flex-col gap-2 sm:flex-row sm:items-start'>
+        {(() => {
+          const compactGroups = kanaGroups.filter(g => {
+            if (filter === 'hiragana')
+              return g.name.toLowerCase().startsWith('hiragana');
+            if (filter === 'katakana')
+              return g.name.toLowerCase().startsWith('katakana');
+            return true;
+          });
+          const isSingleCompact = compactGroups.length === 1;
+          return compactGroups.map(group => {
+            const groupHidden = isHidden(group.name);
+            const [mainTitle, japaneseTitle] = group.name.split(' ');
 
-          return (
-            <Fragment key={group.name}>
-              <form
-                className={clsx(
-                  'flex w-full flex-col gap-2 p-4',
-                  isSingleCompact ? 'sm:w-full' : 'sm:w-1/2',
-                  cardBorderStyles,
-                )}
-              >
-                {/* Group Header */}
-                <legend
+            return (
+              <Fragment key={group.name}>
+                <form
                   className={clsx(
-                    'group flex flex-row items-center hover:cursor-pointer',
-                    USE_NEW_KANA_BADGE_DESIGN
-                      ? 'gap-2 text-[1.9rem]'
-                      : 'gap-1 text-2xl',
+                    'flex w-full flex-col gap-2 p-4',
+                    isSingleCompact ? 'sm:w-full' : 'sm:w-1/2',
+                    cardBorderStyles,
                   )}
-                  onClick={() => toggleVisibility(group.name)}
                 >
-                  <ChevronUp className={chevronClasses(groupHidden)} />
-                  {USE_NEW_KANA_BADGE_DESIGN && (
-                    <span className={headingBadgeClasses.group}>
-                      {groupKanaBadgeByName[group.name] ?? 'あ'}
-                    </span>
-                  )}
-                  <h3 className='flex items-center gap-2'>
-                    <span>{mainTitle}</span>
-                    <span className='hidden text-(--secondary-color) xl:inline'>
-                      {japaneseTitle}
-                    </span>
-                  </h3>
-                </legend>
+                  {/* Group Header */}
+                  <legend
+                    className={clsx(
+                      'group flex flex-row items-center hover:cursor-pointer',
+                      USE_NEW_KANA_BADGE_DESIGN
+                        ? 'gap-2 text-[1.9rem]'
+                        : 'gap-1 text-2xl',
+                    )}
+                    onClick={() => toggleVisibility(group.name)}
+                  >
+                    <ChevronUp className={chevronClasses(groupHidden)} />
+                    {USE_NEW_KANA_BADGE_DESIGN && (
+                      <span className={headingBadgeClasses.group}>
+                        {groupKanaBadgeByName[group.name] ?? 'あ'}
+                      </span>
+                    )}
+                    <h3 className='flex items-center gap-2'>
+                      <span>{mainTitle}</span>
+                      <span className='hidden text-(--secondary-color) xl:inline'>
+                        {japaneseTitle}
+                      </span>
+                    </h3>
+                  </legend>
 
-                {/* Subsets */}
-                {!groupHidden &&
-                  group.subsets.map((subset, index) => {
-                    const subsetHidden = isHidden(subset.name);
-                    const isLastSubset = index === group.subsets.length - 1;
+                  {/* Subsets */}
+                  {!groupHidden &&
+                    group.subsets.map((subset, index) => {
+                      const subsetHidden = isHidden(subset.name);
+                      const isLastSubset = index === group.subsets.length - 1;
 
-                    return (
-                      <div
-                        key={subset.name}
-                        className='flex w-full flex-col gap-2'
-                      >
-                        <div>
-                          {/* Subset Header */}
-                          <h4
-                            className={clsx(
-                              'group flex flex-row items-center hover:cursor-pointer',
-                              USE_NEW_KANA_BADGE_DESIGN
-                                ? 'gap-2 text-[1.5rem]'
-                                : 'gap-1 text-xl',
+                      return (
+                        <div
+                          key={subset.name}
+                          className='flex w-full flex-col gap-2'
+                        >
+                          <div>
+                            {/* Subset Header */}
+                            <h4
+                              className={clsx(
+                                'group flex flex-row items-center hover:cursor-pointer',
+                                USE_NEW_KANA_BADGE_DESIGN
+                                  ? 'gap-2 text-[1.5rem]'
+                                  : 'gap-1 text-xl',
+                              )}
+                              onClick={() => toggleVisibility(subset.name)}
+                            >
+                              <ChevronUp
+                                className={chevronClasses(subsetHidden)}
+                                size={24}
+                              />
+                              {USE_NEW_KANA_BADGE_DESIGN && (
+                                <span className={headingBadgeClasses.subset}>
+                                  {subsetKanaBadgeByName[subset.name] ?? 'あ'}
+                                </span>
+                              )}
+                              <span>{subset.name.slice(1)}</span>
+                            </h4>
+
+                            {/* Subset Content */}
+                            {!subsetHidden && (
+                              <Subset
+                                sliceRange={subset.sliceRange}
+                                group={group.name}
+                                subgroup={subset.name}
+                              />
                             )}
-                            onClick={() => toggleVisibility(subset.name)}
-                          >
-                            <ChevronUp
-                              className={chevronClasses(subsetHidden)}
-                              size={24}
-                            />
-                            {USE_NEW_KANA_BADGE_DESIGN && (
-                              <span className={headingBadgeClasses.subset}>
-                                {subsetKanaBadgeByName[subset.name] ?? 'あ'}
-                              </span>
-                            )}
-                            <span>{subset.name.slice(1)}</span>
-                          </h4>
+                          </div>
 
-                          {/* Subset Content */}
-                          {!subsetHidden && (
-                            <Subset
-                              sliceRange={subset.sliceRange}
-                              group={group.name}
-                              subgroup={subset.name}
-                            />
+                          {/* Divider (except after last subset) */}
+                          {!isLastSubset && (
+                            <hr className='w-full border-t border-(--border-color)' />
                           )}
                         </div>
-
-                        {/* Divider (except after last subset) */}
-                        {!isLastSubset && (
-                          <hr className='w-full border-t border-(--border-color)' />
-                        )}
-                      </div>
-                    );
-                  })}
-              </form>
-            </Fragment>
-          );
-        });
-      })()}
+                      );
+                    })}
+                </form>
+              </Fragment>
+            );
+          });
+        })()}
+      </div>
+      <div aria-hidden className='py-4' />
     </div>
   );
 };


### PR DESCRIPTION
## 📝 Description

In Kana mode, the `TrainingActionBar` overlaps with the last row of Kana's grid.

<img width="1265" height="415" alt="image" src="https://github.com/user-attachments/assets/0a6bab1e-9f61-403e-9ae7-0e1fc7f76965" />

In Kanji and Vocabulary this problem does not happen because the `LevelSetCards` already leave room at the bottom with a `py-4`.

To solve this problem, same padding has been added to `index.tsx` file of `KanaCards`.

## 🔗 Related Issue

Closes #

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

<!--
**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

...

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

...
