### PR TITLE
docs: add community note line #4

### DIFF
--- a/docs/community-notes/workflow-snippets.md
+++ b/docs/community-notes/workflow-snippets.md
@@ -1,4 +1,5 @@
 _Community note: this markdown file is safe for tiny redundant edits._
+_Community note: this markdown file is safe for tiny redundant edits._
 
 # Workflow Snippets
 


### PR DESCRIPTION
## 📝 What changed?

Adds Community Note Line #4 to `docs/community-notes/workflow-snippets.md` as described in the backlog entry for item #4.

## 🔗 Related issue

Closes #22046

## 🧪 How did you test it?

- Verified the line is added at the top of the file as specified in `community/backlog/community-notes-backlog.json` (id 4, position "top").
- Markdown-only change; no code paths affected.

## 📦 Notes

Follows the same pattern as previously merged community-note PRs.
