### PR TITLE
content: add new trivia question

### DIFF
--- a/community/content/japan-trivia-medium.json
+++ b/community/content/japan-trivia-medium.json
@@ -615,5 +615,16 @@
     "Winter"
   ],
   "correctIndex": 2
-}
+},
+  {
+    "question": "Which Japanese city hosted the 1998 Winter Olympics? (Community variation 57)",
+    "difficulty": "medium",
+    "answers": [
+      "Nagano",
+      "Sapporo",
+      "Niigata",
+      "Sendai"
+    ],
+    "correctIndex": 0
+  }
 ]


### PR DESCRIPTION
## Summary

Added a new trivia question to `community/content/japan-trivia-medium.json`.

### Added Question
Which Japanese city hosted the 1998 Winter Olympics? (Community variation 57)

### Answers
- Nagano ✅
- Sapporo
- Niigata
- Sendai

Closes #21986