### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -5,13 +5,13 @@
     "english": "Not knowing is Buddha",
     "meaning": "Ignorance is bliss"
   },
- ,
-{
-  "japanese": "猿も木から落ちる",
-  "romaji": "Saru mo ki kara ochiru", 
-  "english": "Even monkeys fall from trees",
-  "meaning": "Even experts make mistakes"
-} {
+  {
+    "japanese": "猿も木から落ちる",
+    "romaji": "Saru mo ki kara ochiru",
+    "english": "Even monkeys fall from trees",
+    "meaning": "Even experts make mistakes"
+  },
+  {
     "japanese": "馬子にも衣装",
     "romaji": "Mago ni mo ishou",
     "english": "Even a packhorse driver looks good in fine clothes",
@@ -268,5 +268,11 @@
     "romaji": "Ishi no ue ni mo san nen",
     "english": "Three years on a stone",
     "meaning": "Perseverance brings success"
+  },
+  {
+    "japanese": "井の中の蛙大海を知らず",
+    "romaji": "I no naka no kawazu taikai wo shirazu",
+    "english": "A frog in a well does not know the great sea",
+    "meaning": "Limited experience limits perspective"
   }
 ]


### PR DESCRIPTION
Closes #22295

## Description

This PR adds the requested Japanese proverb to `community/content/japanese-proverbs.json`:

- Japanese: 井の中の蛙大海を知らず
- Romaji: I no naka no kawazu taikai wo shirazu
- English: A frog in a well does not know the great sea
- Meaning: Limited experience limits perspective

While making this change, I also corrected a pre-existing JSON syntax issue in the file so that it remains valid and parseable. No existing proverb content was changed.