### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -238,5 +238,11 @@
   "romaji": "Mikka bouzu",
   "english": "A three-day monk",
   "meaning": "Someone who quits quickly"
+},
+{
+  "japanese": "負けるが勝ち",
+  "romaji": "Makeru ga kachi",
+  "english": "Sometimes losing is winning",
+  "meaning": "Conceding can be the best outcome"
 }
 ]


### PR DESCRIPTION
## 📝 Description

Added Japanese proverb #95 to `community/content/japanese-proverbs.json`.

* Japanese: 負けるが勝ち
* Romaji: Makeru ga kachi
* English: Sometimes losing is winning
* Meaning: Conceding can be the best outcome

## 🔗 Related Issue

Closes #22420

## ✅ Pre-Submission Checklist

* [x] I have starred the repo ⭐
* [ ] My code follows the project's code style and uses `cn()` utility where needed (Not applicable)
* [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞 (Not applicable for this content-only change)
* [x] My commit messages follow the Conventional Commits format
* [ ] I have updated the documentation (if applicable) 📖
* [x] This PR is against the `main` branch

## 🎯 Type of Change

* [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Added the proverb object to `community/content/japanese-proverbs.json`.
2. Verified the JSON syntax remains valid and the array structure is correct.

## 📸 Screenshots/Videos (if applicable)

Not applicable.

## 📦 Additional Context

This PR adds a new traditional Japanese proverb to expand the learning content available in the project.
