### PR TITLE
feat(theme): add Festival Red and Sake Glass themes

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -442,6 +442,11 @@
   "backgroundColor": "oklch(96.0% 0.015 210.0 / 1)",
   "mainColor": "oklch(55.0% 0.185 200.0 / 1)",
   "secondaryColor": "oklch(60.0% 0.155 25.0 / 1)"
+},
+  {
+  "id": "festival-red",
+  "backgroundColor": "oklch(17.0% 0.055 25.0 / 1)",
+  "mainColor": "oklch(78.0% 0.205 25.0 / 1)",
+  "secondaryColor": "oklch(85.0% 0.085 85.0 / 1)"
 }
-  
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -443,10 +443,16 @@
   "mainColor": "oklch(55.0% 0.185 200.0 / 1)",
   "secondaryColor": "oklch(60.0% 0.155 25.0 / 1)"
 },
-  {
+{
   "id": "festival-red",
   "backgroundColor": "oklch(17.0% 0.055 25.0 / 1)",
   "mainColor": "oklch(78.0% 0.205 25.0 / 1)",
   "secondaryColor": "oklch(85.0% 0.085 85.0 / 1)"
+},
+{
+  "id": "sake-glass",
+  "backgroundColor": "oklch(98.0% 0.004 90.0 / 1)",
+  "mainColor": "oklch(55.0% 0.035 250.0 / 1)",
+  "secondaryColor": "oklch(70.0% 0.015 90.0 / 1)"
 }
 ]


### PR DESCRIPTION
## 📝 Description
Adds two community themes:
- **Festival Red**: deep crimson tones inspired by matsuri banners and taiko drums.
- **Sake Glass**: light crystal background with subtle blue-grey tones inspired by clear crystal with a rice-white sheen.

## 🔗 Related Issue
Closes #22480
Closes #22472

## ✅ Pre-Submission Checklist
- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?
**Test Steps:**
1. Added theme entry to `community/content/community-themes.json`
2. Verified JSON remains valid after the addition

## 📸 Screenshots/Videos (if applicable)
N/A — JSON-only change, no visual output to capture locally.

## 📦 Additional Context
Simple JSON entry following the existing theme format. No code changes, no dependencies affected.