### PR TITLE
Content/add japanese proverb 95

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -238,5 +238,11 @@
   "romaji": "Mikka bouzu",
   "english": "A three-day monk",
   "meaning": "Someone who quits quickly"
+},
+{
+  "japanese": "負けるが勝ち",
+  "romaji": "Makeru ga kachi",
+  "english": "Sometimes losing is winning",
+  "meaning": "Conceding can be the best outcome"
 }
 ]

--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -244,5 +244,11 @@
   "romaji": "Makeru ga kachi",
   "english": "Sometimes losing is winning",
   "meaning": "Conceding can be the best outcome"
+},
+{
+  "japanese": "負けるが勝ち",
+  "romaji": "Makeru ga kachi",
+  "english": "Sometimes losing is winning",
+  "meaning": "Conceding can be the best outcome"
 }
 ]


### PR DESCRIPTION
## 📝 Description

Added the Japanese proverb "負けるが勝ち" (Makeru ga kachi) to `community/content/japanese-proverbs.json`.

- Japanese: 負けるが勝ち
- Romaji: Makeru ga kachi
- English: Sometimes losing is winning
- Meaning: Conceding can be the best outcome

## 🔗 Related Issue

Closes #22420

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [ ] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the Conventional Commits format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change

- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)

## 🧪 How Has This Been Tested?

1. Added the proverb object to `community/content/japanese-proverbs.json`.
2. Verified that the JSON syntax is valid.

## 📸 Screenshots/Videos (if applicable)

N/A

## 📦 Additional Context

This is a beginner-friendly content contribution adding a new Japanese proverb.