### PR TITLE
Add new haiku by Matsuo Basho

### DIFF
--- a/community/content/japanese-haiku.json
+++ b/community/content/japanese-haiku.json
@@ -144,4 +144,14 @@
   "kigo": "Spring sea (haru no umi)",
   "notes": "Known for musical phrasing and calm motion."
 }
+  ,
+{
+  "japanese": "閑さや\n岩にしみ入る\n蝉の声",
+  "romaji": "Shizukasa ya / iwa ni shimiiru / semi no koe",
+  "english": "Such stillness — the cries of the cicadas sink into the rocks.",
+  "poet": "Matsuo Basho",
+  "season": "Summer",
+  "kigo": "Cicada (semi)",
+  "notes": "Written at Yamadera temple; one of Basho's most celebrated haiku, evoking profound silence pierced by sound."
+}
 ]


### PR DESCRIPTION
Added a new haiku by Matsuo Basho, including its Japanese text, romaji, English translation, season, kigo, and notes.

## 📝 Description
This PR adds one new classic Japanese haiku to `community/content/japanese-haiku.json`:

- **Poet:** Matsuo Basho
- **Haiku:** 閑さや / 岩にしみ入る / 蝉の声 ("Shizukasa ya / iwa ni shimiiru / semi no koe")
- **Translation:** "Such stillness — the cries of the cicadas sink into the rocks."
- **Season:** Summer
- **Kigo:** Cicada (semi)

Written at Yamadera temple, this is one of Basho's most celebrated haiku, contrasting profound silence with the sound of cicadas. It was added in place of a duplicate entry from the original issue, since that haiku already existed in the file (twice).

## 🔗 Related Issue
Closes #10

## ✅ Pre-Submission Checklist
- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)

## 🧪 How Has This Been Tested?
**Test Steps:**
1. Validated the updated `japanese-haiku.json` is well-formed JSON (no trailing/missing commas).
2. Confirmed the new entry matches the existing object schema (japanese, romaji, english, poet, season, kigo, notes).
3. Visually confirmed the haiku renders correctly wherever community haiku content is displayed in the app.
