### PR TITLE
feat(theme): add Pixel Retro theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -502,5 +502,11 @@
   "backgroundColor": "oklch(20.0% 0.040 235.0 / 1)",
   "mainColor": "oklch(78.0% 0.205 35.0 / 1)']",
   "secondaryColor": "oklch(88.0% 0.065 210.0 / 1)"
-}
+},
+  {
+    "id": "pixel-retro",
+    "backgroundColor": "oklch(14.0% 0.025 280.0 / 1)",
+    "mainColor": "oklch(72.0% 0.200 145.0 / 1)",
+    "secondaryColor": "oklch(80.0% 0.185 55.0 / 1)"
+  }
 ]


### PR DESCRIPTION
## Summary

Adds the **Pixel Retro** community theme (8-bit arcade nostalgia) to `community/content/community-themes.json`, as specified in the issue:

| Property | Value |
|----------|-------|
| ID | `pixel-retro` |
| Background | `oklch(14.0% 0.025 280.0 / 1)` |
| Main Color | `oklch(72.0% 0.200 145.0 / 1)` |
| Secondary | `oklch(80.0% 0.185 55.0 / 1)` |

The file was validated as parseable JSON after the change, and `pixel-retro` is not a duplicate of any existing theme id.

Closes #22786