### PR TITLE
fix(theme): remove corrupted duplicate coastal-shrine entry

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -496,11 +496,5 @@
   "backgroundColor": "oklch(96.0% 0.018 340.0 / 1)",
   "mainColor": "oklch(62.0% 0.195 10.0 / 1)",
   "secondaryColor": "oklch(78.0% 0.095 350.0 / 1)"
-},
-  {
-  "id": "coastal-shrine",
-  "backgroundColor": "oklch(20.0% 0.040 235.0 / 1)",
-  "mainColor": "oklch(78.0% 0.205 35.0 / 1)']",
-  "secondaryColor": "oklch(88.0% 0.065 210.0 / 1)"
 }
 ]


### PR DESCRIPTION
## Summary

The last entry in `community/content/community-themes.json` was a third copy of the `coastal-shrine` theme with a corrupted `mainColor` value containing stray characters:

```json
"mainColor": "oklch(78.0% 0.205 35.0 / 1)']",
```

The stray `']` makes the value an invalid CSS color. Since the file already contains two identical, uncorrupted `coastal-shrine` entries, this PR removes the broken duplicate rather than repairing it (which would just leave a third identical copy).

Validated that the file parses as JSON after the change and that no remaining value contains stray characters.

## Note for maintainers

While fixing this I noticed the file has 12 theme ids with duplicate entries (`coastal-shrine` still appears twice after this fix, plus `plaza-snow`, `tanuki-mischief`, `pagoda-twilight`, `ocean-tofu`, `festival-red`, `harbor-lights`, `firefly-field`, `shinkansen-speed`, `ramen-shop`, `kimono-silk`, `strawberry-daifuku`). Happy to open a separate dedupe PR if that's welcome — kept this one minimal on purpose.