### PR TITLE
fix(theme): remove duplicate theme entries and add id uniqueness test

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -496,11 +496,5 @@
   "backgroundColor": "oklch(96.0% 0.018 340.0 / 1)",
   "mainColor": "oklch(62.0% 0.195 10.0 / 1)",
   "secondaryColor": "oklch(78.0% 0.095 350.0 / 1)"
-},
-  {
-  "id": "coastal-shrine",
-  "backgroundColor": "oklch(20.0% 0.040 235.0 / 1)",
-  "mainColor": "oklch(78.0% 0.205 35.0 / 1)']",
-  "secondaryColor": "oklch(88.0% 0.065 210.0 / 1)"
 }
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -228,12 +228,6 @@
     "secondaryColor": "oklch(65.0% 0.145 20.0 / 1)"
   },
   {
-    "id": "ocean-tofu",
-    "backgroundColor": "oklch(21.0% 0.042 235.0 / 1)",
-    "mainColor": "oklch(92.0% 0.025 240.0 / 1)",
-    "secondaryColor": "oklch(70.0% 0.135 225.0 / 1)"
-  },
-  {
     "id": "plum-wood",
     "backgroundColor": "oklch(24.0% 0.030 20.0 / 1)",
     "mainColor": "oklch(72.0% 0.145 5.0 / 1)",
@@ -264,40 +258,10 @@
     "secondaryColor": "oklch(88.0% 0.095 85.0 / 1)"
   },
   {
-    "id": "tanuki-mischief",
-    "backgroundColor": "oklch(22.0% 0.042 55.0 / 1)",
-    "mainColor": "oklch(68.0% 0.125 65.0 / 1)",
-    "secondaryColor": "oklch(72.0% 0.155 145.0 / 1)"
-  },
-  {
-    "id": "plaza-snow",
-    "backgroundColor": "oklch(97.0% 0.006 240.0 / 1)",
-    "mainColor": "oklch(40.0% 0.035 260.0 / 1)",
-    "secondaryColor": "oklch(65.0% 0.120 220.0 / 1)"
-  },
-  {
-    "id": "harbor-lights",
-    "backgroundColor": "oklch(14.0% 0.045 250.0 / 1)",
-    "mainColor": "oklch(80.0% 0.140 210.0 / 1)",
-    "secondaryColor": "oklch(70.0% 0.120 310.0 / 1)"
-  },
-  {
-    "id": "coastal-shrine",
-    "backgroundColor": "oklch(20.0% 0.040 235.0 / 1)",
-    "mainColor": "oklch(78.0% 0.205 35.0 / 1)",
-    "secondaryColor": "oklch(88.0% 0.065 210.0 / 1)"
-  },
-  {
     "id": "misty-shrine",
     "backgroundColor": "oklch(21.0% 0.025 190.0 / 1)",
     "mainColor": "oklch(76.0% 0.085 180.0 / 1)",
     "secondaryColor": "oklch(62.0% 0.065 210.0 / 1)"
-  },
-  {
-    "id": "firefly-field",
-    "backgroundColor": "oklch(16.0% 0.038 150.0 / 1)",
-    "mainColor": "oklch(88.0% 0.175 110.0 / 1)",
-    "secondaryColor": "oklch(65.0% 0.125 145.0 / 1)"
   },
   {
     "id": "firefly-field",
@@ -396,12 +360,6 @@
     "secondaryColor": "oklch(80.0% 0.125 60.0 / 1)"
   },
   {
-    "id": "kimono-silk",
-    "backgroundColor": "oklch(19.0% 0.048 320.0 / 1)",
-    "mainColor": "oklch(72.0% 0.155 330.0 / 1)",
-    "secondaryColor": "oklch(80.0% 0.125 60.0 / 1)"
-  },
-  {
     "id": "sakura-ink",
     "backgroundColor": "oklch(88.0% 0.030 340.0 / 1)",
     "mainColor": "oklch(55.0% 0.170 350.0 / 1)",
@@ -426,12 +384,6 @@
     "secondaryColor": "oklch(62.0% 0.085 55.0 / 1)"
   },
   {
-    "id": "pagoda-twilight",
-    "backgroundColor": "oklch(20.0% 0.045 290.0 / 1)",
-    "mainColor": "oklch(68.0% 0.155 315.0 / 1)",
-    "secondaryColor": "oklch(75.0% 0.125 280.0 / 1)"
-  },
-  {
     "id": "bento-sage",
     "backgroundColor": "oklch(20.0% 0.030 145.0 / 1)",
     "mainColor": "oklch(70.0% 0.115 135.0 / 1)",
@@ -444,28 +396,10 @@
     "secondaryColor": "oklch(60.0% 0.155 25.0 / 1)"
   },
   {
-    "id": "festival-red",
-    "backgroundColor": "oklch(17.0% 0.055 25.0 / 1)",
-    "mainColor": "oklch(78.0% 0.205 25.0 / 1)",
-    "secondaryColor": "oklch(85.0% 0.085 85.0 / 1)"
-  },
-  {
     "id": "sake-glass",
     "backgroundColor": "oklch(98.0% 0.004 90.0 / 1)",
     "mainColor": "oklch(55.0% 0.035 250.0 / 1)",
     "secondaryColor": "oklch(70.0% 0.015 90.0 / 1)"
-  },
-  {
-    "id": "ramen-shop",
-    "backgroundColor": "oklch(94.0% 0.025 85.0 / 1)",
-    "mainColor": "oklch(60.0% 0.195 25.0 / 1)",
-    "secondaryColor": "oklch(88.0% 0.145 90.0 / 1)"
-  },
-  {
-    "id": "shinkansen-speed",
-    "backgroundColor": "oklch(22.0% 0.035 240.0 / 1)",
-    "mainColor": "oklch(90.0% 0.085 220.0 / 1)",
-    "secondaryColor": "oklch(65.0% 0.185 25.0 / 1)"
   },
   {
     "id": "street-lantern",
@@ -490,11 +424,5 @@
   "backgroundColor": "oklch(23.0% 0.045 150.0 / 1)",
   "mainColor": "oklch(60.0% 0.205 25.0 / 1)",
   "secondaryColor": "oklch(72.0% 0.145 145.0 / 1)"
-},
-  {
-  "id": "strawberry-daifuku",
-  "backgroundColor": "oklch(96.0% 0.018 340.0 / 1)",
-  "mainColor": "oklch(62.0% 0.195 10.0 / 1)",
-  "secondaryColor": "oklch(78.0% 0.095 350.0 / 1)"
 }
 ]

--- a/community/content/community-themes.test.ts
+++ b/community/content/community-themes.test.ts
@@ -43,4 +43,10 @@ describe('community-themes.json', () => {
   it('sea-glass should have a unique id among themes', () => {
     expect(themes.filter(t => t.id === 'sea-glass').length).toBe(1);
   });
+
+  it('all theme ids should be unique', () => {
+    const ids = themes.map(t => t.id);
+    const duplicates = [...new Set(ids.filter((id, i) => ids.indexOf(id) !== i))];
+    expect(duplicates).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

`community/content/community-themes.json` had accumulated **12 duplicate theme ids** (likely from multiple community contributions adding the same theme). This PR:

1. **Removes the 12 duplicate entries**, keeping the first occurrence of each id: `plaza-snow`, `tanuki-mischief`, `pagoda-twilight`, `ocean-tofu`, `festival-red`, `harbor-lights`, `coastal-shrine`, `firefly-field`, `shinkansen-speed`, `ramen-shop`, `kimono-silk`, `strawberry-daifuku`. The JSON diff is pure deletions — no reformatting of kept entries. 71 unique themes remain.
2. **Adds a test** to `community-themes.test.ts` asserting all theme ids are unique, so future duplicate submissions are caught in CI.

### Notes for review

- **`tanuki-mischief` is the only duplicate whose two copies had *different* colors** (first: green/yellow palette at the top of the file; second: brown/orange). I kept the first occurrence, consistent with the rest of the dedupe — happy to swap if the later palette was the intended one.
- All other 11 duplicate pairs were byte-identical in values.
- Builds on #22845 (removal of the corrupted third `coastal-shrine` copy); merging that first will shrink this diff.

### Pre-existing test failures (not addressed here)

`community-themes.test.ts` currently fails on `main`: it expects `tsukiji-morning` and `sea-glass` themes that are not present in the JSON. The expected color values are fully specified in the test file, so either adding those two themes or removing the stale tests would fix it — flagging for a separate change. The new uniqueness test added here passes.

### Verification

- `npx vitest run community/content/community-themes.test.ts` — the new `all theme ids should be unique` test passes (remaining failures are the pre-existing `tsukiji-morning`/`sea-glass` ones described above).
- File validated as parseable JSON with 71 entries and zero duplicate ids.