### PR TITLE
content: add new trivia question

### DIFF
--- a/community/content/japan-trivia-easy.json
+++ b/community/content/japan-trivia-easy.json
@@ -273,4 +273,15 @@
     "answers": ["Sumo", "Kendo", "Judo", "Aikido"],
     "correctIndex": 0
   }
+  ,{
+  "question": "What is the Japanese term for a hot spring? (Community variation 42)",
+  "difficulty": "easy",
+  "answers": [
+    "Onsen",
+    "Sentou",
+    "Ryokan",
+    "Izakaya"
+  ],
+  "correctIndex": 0
+}
 ]


### PR DESCRIPTION
## Summary

* Added a new easy Japan trivia question about the Japanese term for a hot spring ("Onsen").
* Included four answer choices with the correct answer set to "Onsen".
* Updated the `community/content/japan-trivia-easy.json` dataset.

Closes #22839
