### PR TITLE
fix: prevent hidden ReturnFromGame from handling Escape

### DIFF
--- a/features/Kana/components/Game/index.tsx
+++ b/features/Kana/components/Game/index.tsx
@@ -125,7 +125,11 @@ const Game = () => {
         )}
       >
         {showStats && <SessionStats />}
-        <Return isHidden={showStats} gameMode={gameMode} onQuit={handleQuit} />
+        <Return
+          isHidden={showStats || view === 'summary'}
+          gameMode={gameMode}
+          onQuit={handleQuit}
+        />
         {gameMode.toLowerCase() === 'pick' ? (
           <TilesMode isHidden={showStats || view !== 'playing'} />
         ) : gameMode.toLowerCase() === 'mcq' ? (

--- a/features/Kanji/components/Game/index.tsx
+++ b/features/Kanji/components/Game/index.tsx
@@ -132,7 +132,11 @@ const Game = () => {
         className='flex min-h-[100dvh] max-w-[100dvw] flex-col items-center gap-8 px-2 md:gap-12 md:px-0'
       >
         {showStats && <SessionStats />}
-        <Return isHidden={showStats} gameMode={gameMode} onQuit={handleQuit} />
+        <Return
+          isHidden={showStats || view === 'summary'}
+          gameMode={gameMode}
+          onQuit={handleQuit}
+        />
         {gameMode.toLowerCase() === 'pick' ? (
           <TilesMode
             selectedKanjiObjs={selectedKanjiObjs}

--- a/features/Vocabulary/components/Game/index.tsx
+++ b/features/Vocabulary/components/Game/index.tsx
@@ -133,7 +133,11 @@ const Game = () => {
         className='flex min-h-[100dvh] max-w-[100dvw] flex-col items-center gap-8 px-2 md:gap-12 md:px-0'
       >
         {showStats && <SessionStats />}
-        <Return isHidden={showStats} gameMode={gameMode} onQuit={handleQuit} />
+        <Return
+          isHidden={showStats || view === 'summary'}
+          gameMode={gameMode}
+          onQuit={handleQuit}
+        />
         {gameMode.toLowerCase() === 'pick' ? (
           <TilesMode
             key={`vocab-tiles-${sessionNonce}`}

--- a/shared/ui-composite/Game/ReturnFromGame.tsx
+++ b/shared/ui-composite/Game/ReturnFromGame.tsx
@@ -116,14 +116,16 @@ const Return = ({ isHidden, gameMode, onQuit }: ReturnProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isHidden]);
 
-  // Keyboard shortcuts
+  // Keyboard shortcut: Escape exits the game.
+  // Only register when visible to avoid duplicate handling when Session Summary is shown.
   useEffect(() => {
+    if (isHidden) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') buttonRef.current?.click();
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [isHidden]);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -206,7 +208,7 @@ const Return = ({ isHidden, gameMode, onQuit }: ReturnProps) => {
         {/* Stats button - visible only on small screens */}
         <ActionButton
           borderRadius='xl'
-          className='w-auto px-2 py-1 text-xl sm:hidden animate-float [--float-distance:-1px]'
+          className='animate-float w-auto px-2 py-1 text-xl [--float-distance:-1px] sm:hidden'
           onClick={handleShowStats}
         >
           <ChartSpline size={22} />
@@ -222,9 +224,7 @@ const Return = ({ isHidden, gameMode, onQuit }: ReturnProps) => {
               className={clsx('text-(--main-color)', modeConfig.className)}
             />
           )}
-          <span className='text-(--secondary-color)'>
-            {normalizedMode}
-          </span>
+          <span className='text-(--secondary-color)'>{normalizedMode}</span>
           <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
             <PopoverTrigger asChild>
               <button
@@ -243,7 +243,7 @@ const Return = ({ isHidden, gameMode, onQuit }: ReturnProps) => {
                 }}
                 className='rounded-full hover:cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--main-color)'
               >
-                <span className='flex h-6 w-6 items-center justify-center rounded-lg bg-(--main-color) border-b-3 border-(--main-color-accent) ml-0.5 sm:ml-1 mt-0.5'>
+                <span className='mt-0.5 ml-0.5 flex h-6 w-6 items-center justify-center rounded-lg border-b-3 border-(--main-color-accent) bg-(--main-color) sm:ml-1'>
                   <Check className='h-4 w-4 text-(--background-color)' />
                 </span>
               </button>
@@ -279,7 +279,7 @@ const Return = ({ isHidden, gameMode, onQuit }: ReturnProps) => {
           <ActionButton
             borderRadius='2xl'
             borderBottomThickness={8}
-            className='hidden w-auto py-2 text-xl sm:flex sm:px-6 animate-float [--float-distance:-3px]'
+            className='animate-float hidden w-auto py-2 text-xl [--float-distance:-3px] sm:flex sm:px-6'
             onClick={handleShowStats}
           >
             <ChartSpline size={24} />
@@ -291,4 +291,3 @@ const Return = ({ isHidden, gameMode, onQuit }: ReturnProps) => {
 };
 
 export default Return;
-


### PR DESCRIPTION
## Description

Fixes an issue where pressing the **Escape** key on the **Session Summary** screen triggered the hidden `ReturnFromGame` component's global keyboard listener.

Previously, both `SessionSummaryScreen` and `ReturnFromGame` responded to the same Escape key event. This caused `saveSession()` to be invoked multiple times, resulting in duplicated session statistics, incorrect achievement progress, and eventually leaving the **Menu** button unresponsive after repeated presses.

This change ensures that the `ReturnFromGame` Escape key listener is only registered while the component is active. Once the Session Summary is displayed, the listener is cleaned up, preventing hidden components from responding to keyboard events. This implementation follows the existing keyboard listener pattern used elsewhere in the project.

##   Related Issue

Closes #3128

##  Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated the documentation (if applicable) 📖 *(Not applicable)*
- [x] This PR is against the `main` branch

##  Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

##  How Has This Been Tested?

**Test Steps:**

1. Start a game in Kana, Kanji, or Vocabulary mode.
2. Complete the session until the **Session Summary** screen is displayed.
3. Press the **Escape** key repeatedly.
4. Verify that the Session Summary closes correctly.
5. Confirm that session statistics and achievement progress are updated only once.
6. Verify that the **Menu** button remains functional after repeated Escape key presses.
7. Verify normal game exit behavior before reaching the Session Summary is unaffected.

## 📸 Screenshots/Videos (if applicable)
<img width="1888" height="909" alt="image" src="https://github.com/user-attachments/assets/0f8383f4-c3e3-4cbe-870c-d5afc8fb1ac9" />

##  Additional Context

- Root cause: `ReturnFromGame` remained mounted and continued listening for global Escape key events while the Session Summary was active.
- Solution: Register the Escape key listener only while `ReturnFromGame` is active, matching the project's existing keyboard listener lifecycle pattern.
- This is a minimal, targeted fix with no changes to normal gameplay behavior.
