### PR TITLE
fix: correct 間柄 translation from 'relation(ship)' to 'relationship'

### DIFF
--- a/public/data-vocab/n1.json
+++ b/public/data-vocab/n1.json
@@ -33,7 +33,7 @@
     "jmdict_seq": "1215660",
     "kana": "あいだがら",
     "kanji": "間柄",
-    "waller_definition": "relation(ship)"
+    "waller_definition": "relationship"
   },
   {
     "jmdict_seq": "1575670",


### PR DESCRIPTION
## Description

Corrects the translation for 間柄 (あいだがら) from 'relation(ship)' to 'relationship'.

Fixes #23022

### Changes
- `public/data-vocab/n1.json`: Changed `waller_definition` from `"relation(ship)"` to `"relationship"`

### Before
```json
"kanji": "間柄",
"waller_definition": "relation(ship)"
```

### After
```json
"kanji": "間柄",
"waller_definition": "relationship"
```
