### PR TITLE
fix(kanji): correct corrupted kana readings in N5 data

### DIFF
--- a/public/data-kanji/N5.json
+++ b/public/data-kanji/N5.json
@@ -53,7 +53,7 @@
     "kanjiChar": "人",
     "onyomi": [
       "jin ジン",
-      "nin るン"
+      "nin ニン"
     ],
     "kunyomi": [
       "hito ひと"
@@ -67,7 +67,7 @@
     "id": 5,
     "kanjiChar": "年",
     "onyomi": [
-      "nen れン"
+      "nen ネン"
     ],
     "kunyomi": [
       "toshi とし"
@@ -82,7 +82,7 @@
     "kanjiChar": "大",
     "onyomi": [
       "dai ダイ",
-      "tai テイ"
+      "tai タイ"
     ],
     "kunyomi": [
       "oo おお",
@@ -113,7 +113,7 @@
     "kanjiChar": "二",
     "onyomi": [
       "ni ニ",
-      "ji ビ"
+      "ji ジ"
     ],
     "kunyomi": [
       "futa ふた",
@@ -240,7 +240,7 @@
     "kunyomi": [
       "i い",
       "yu ゆ",
-      "okona わこな"
+      "okona おこな"
     ],
     "meanings": [
       "going",
@@ -318,8 +318,8 @@
       "kou コウ"
     ],
     "kunyomi": [
-      "nochi わち",
-      "ushi ゆし",
+      "nochi のち",
+      "ushi うし",
       "ato あと"
     ],
     "meanings": [
@@ -419,7 +419,7 @@
     "id": 25,
     "kanjiChar": "東",
     "onyomi": [
-      "tou ゆう"
+      "tou トウ"
     ],
     "kunyomi": [
       "higashi ひがし"
@@ -531,7 +531,7 @@
     "id": 32,
     "kanjiChar": "高",
     "onyomi": [
-      "kou ゴウ"
+      "kou コウ"
     ],
     "kunyomi": [
       "taka(i) たか(い)"
@@ -578,15 +578,14 @@
     "id": 35,
     "kanjiChar": "外",
     "onyomi": [
-      "gai ゴイ",
+      "gai ガイ",
       "ge ゲ"
     ],
     "kunyomi": [
       "soto そと",
       "hoka ほか",
-      "hazu- ず(す)",
-      "to- と-",
-      "hokan ほう(ん)"
+      "hazu- はず(す)",
+      "to- と-"
     ],
     "meanings": [
       "outside"
@@ -651,7 +650,7 @@
     "kanjiChar": "来",
     "onyomi": [
       "rai ライ",
-      "tai テイ"
+      "tai タイ"
     ],
     "kunyomi": [
       "kuru く.る",
@@ -757,7 +756,7 @@
       "jo ジョ"
     ],
     "kunyomi": [
-      "onnna わんな",
+      "onna おんな",
       "me め"
     ],
     "meanings": [
@@ -785,7 +784,7 @@
       "go ゴ"
     ],
     "kunyomi": [
-      "uma むー"
+      "uma うま"
     ],
     "meanings": [
       "noon",
@@ -888,10 +887,10 @@
     "id": 54,
     "kanjiChar": "水",
     "onyomi": [
-      "sui サイ"
+      "sui スイ"
     ],
     "kunyomi": [
-      "mizu むず"
+      "mizu みず"
     ],
     "meanings": [
       "water"
@@ -922,8 +921,8 @@
       "nan ナン"
     ],
     "kunyomi": [
-      "otoko わたく",
-      "o わ"
+      "otoko おとこ",
+      "o お"
     ],
     "meanings": [
       "male",
@@ -938,7 +937,7 @@
       "sai サイ"
     ],
     "kunyomi": [
-      "nishi わし"
+      "nishi にし"
     ],
     "meanings": [
       "west"
@@ -1062,8 +1061,7 @@
     "id": 65,
     "kanjiChar": "車",
     "onyomi": [
-      "sha シャ",
-      "kuruma カルマ"
+      "sha シャ"
     ],
     "kunyomi": [
       "kuruma くるま"


### PR DESCRIPTION
Fixes #23058

## What happened

The bug report was about 男 showing "otoko わたく" instead of "otoko おとこ" in the kanji lesson answer explanation. It turned out to be corrupted data in `public/data-kanji/N5.json`, and 男 was not the only one. In every affected entry the romaji is correct but the kana next to it is scrambled. The reporter mentioned finding more mismatches during N5 lessons, and this should cover all of them.

## Changes

Fixed the kana for 19 readings across 16 kanji (the romaji was already correct, except one typo on 女):

| Kanji | Reading | Before | After |
|-------|---------|--------|-------|
| 人 | nin | るン | ニン |
| 年 | nen | れン | ネン |
| 大 | tai | テイ | タイ |
| 二 | ji | ビ | ジ |
| 行 | okona | わこな | おこな |
| 後 | nochi | わち | のち |
| 後 | ushi | ゆし | うし |
| 東 | tou | ゆう | トウ |
| 高 | kou | ゴウ | コウ |
| 外 | gai | ゴイ | ガイ |
| 外 | hazu- | ず(す) | はず(す) |
| 来 | tai | テイ | タイ |
| 女 | onna | onnna わんな | onna おんな |
| 午 | uma | むー | うま |
| 水 | sui | サイ | スイ |
| 水 | mizu | むず | みず |
| 男 | otoko | わたく | おとこ |
| 男 | o | わ | お |
| 西 | nishi | わし | にし |

Also removed two entries that are not real readings:

- 車 listed "kuruma カルマ" as an onyomi. The onyomi is シャ, and kuruma くるま is already in the kunyomi list where it belongs.
- 外 had "hokan ほう(ん)", which is not a reading of 外. The actual kun readings (そと, ほか, はず(す)) are all still present.

## How I verified

I wrote a small script that converts the kana in each reading to romaji and compares it against the romaji in the same string. Before the fix it flagged all of the readings above. After the fix it reports no real mismatches, and the file still parses as valid JSON. Formatting is untouched, only the reading strings changed.

One note for later: N4.json has a handful of the same kind of corrupted entries (代, 主, 朝, 空), and a few files have typos on the romaji side. I kept this PR scoped to N5 since that is what the report covers, but I am happy to do a follow-up PR for those.
