### PR TITLE
fix(kanji): correct corrupted kana readings in N4 data

### DIFF
--- a/public/data-kanji/N4.json
+++ b/public/data-kanji/N4.json
@@ -282,7 +282,7 @@
     "id": 19,
     "kanjiChar": "代",
     "onyomi": [
-      "dai ドイ"
+      "dai ダイ"
     ],
     "kunyomi": [
       "ka(wari) か(わり)"
@@ -450,8 +450,8 @@
       "shu シュ"
     ],
     "kunyomi": [
-      "nushi わし",
-      "omo も"
+      "nushi ぬし",
+      "omo おも"
     ],
     "meanings": [
       "lord",
@@ -1124,7 +1124,7 @@
     "id": 71,
     "kanjiChar": "朝",
     "onyomi": [
-      "chou ショウ"
+      "chou チョウ"
     ],
     "kunyomi": [
       "asa あさ"
@@ -1376,7 +1376,7 @@
       "kara から",
       "a(ku) あ(く)",
       "su(ku) す(く)",
-      "muna(shii) (な(しい)"
+      "muna(shii) むな(しい)"
     ],
     "meanings": [
       "empty",
@@ -1956,7 +1956,7 @@
       "ka カ"
     ],
     "kunyomi": [
-      "uta うた ",
+      "uta うた",
       "uta(u) うた(う)"
     ],
     "meanings": [
@@ -2392,7 +2392,7 @@
     ],
     "kunyomi": [
       "ka(su) か(す)",
-      "kashi か(す)"
+      "kashi かし"
     ],
     "meanings": [
       "lend",


### PR DESCRIPTION
Follow-up to #23132, as requested. Same class of bug in `public/data-kanji/N4.json`: the romaji in each affected reading is correct but the kana next to it got scrambled.

## Changes

| Kanji | Reading | Before | After |
|-------|---------|--------|-------|
| 代 | dai | ドイ | ダイ |
| 主 | nushi | わし | ぬし |
| 主 | omo | も | おも |
| 朝 | chou | ショウ | チョウ |
| 空 | muna(shii) | (な(しい) | むな(しい) |

Two smaller cleanups in the same file:

- 歌 had a trailing space in "uta うた " which made the string inconsistent with every other reading.
- 貸 listed "kashi か(す)" right after "ka(su) か(す)". The kashi reading is the prefix form (as in 貸し出し), so its kana should be かし rather than a duplicate of か(す).

## How I verified

Same script as the last PR: it converts the kana in each reading to romaji and compares it against the romaji half of the string. N4.json now comes back with zero mismatches, and the file still parses as valid JSON. Formatting is untouched.

With this, N5 and N4 are both clean. The remaining files (N3, N2, N1) have a handful of typos on the romaji side instead (for example 治 has "nasa(meru)" where it should be "osa(meru)", and 幸 pairs "sara" with さち). Happy to do one more PR for those if useful.
