### PR TITLE
fix: harden CSP, use env vars for Sentry, fix tsconfig typo, cleanup locale config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/next.config.js ./
+COPY --from=builder /app/next.config.ts ./
 COPY --from=builder /app/package.json ./
 
 USER nextjs

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import '../shared/styles/animations.css' layer(utilities);
-@tailwind utilities;
 
 @theme {
   --breakpoint-xs: 30rem;

--- a/core/i18n/config.ts
+++ b/core/i18n/config.ts
@@ -2,8 +2,8 @@
 export const allLocales = ['en', 'es', 'fr', 'zh'] as const;
 export type AllLocale = (typeof allLocales)[number];
 
-// Active locales (TEMP: Single locale for dev performance)
-export const locales = ['en'] as const; // Change to allLocales for full i18n
+// Active locales
+export const locales = ['en', 'es'] as const;
 export type Locale = (typeof locales)[number];
 
 export const defaultLocale: Locale = 'en';

--- a/core/i18n/locales/en.json
+++ b/core/i18n/locales/en.json
@@ -1,7 +1,0 @@
-{
-  "MenuInfo": {
-    "greeting": "Welcome to KanaDojo!",
-    "description": "KanaDojo is an aesthetic, minimalist platform for learning Japanese inspired by Monkeytype.",
-    "instructions": "To begin, select a dojo and start training now!"
-  }
-}

--- a/core/i18n/locales/es.json
+++ b/core/i18n/locales/es.json
@@ -1,7 +1,0 @@
-{
-  "MenuInfo": {
-    "greeting": "¡Bienvenido a KanaDojo!",
-    "description": "KanaDojo es una plataforma divertida, estética y minimalista para aprender y practicar el idioma Japonés en linea.",
-    "instructions": "Para empezar, coge un dojo. ¡Y comienza a entrenar ahora!"
-  }
-}

--- a/core/i18n/locales/zh.json
+++ b/core/i18n/locales/zh.json
@@ -1,7 +1,0 @@
-{
-  "MenuInfo": {
-    "greeting": "欢迎使用 KanaDojo！",
-    "description": "KanaDojo 是一个美观、社区驱动的日语学习平台，灵感来自 Duolingo 和 Monkeytype。",
-    "instructions": "开始之前，请在下方选择一个道场，立即开始训练！"
-  }
-}

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -2,13 +2,12 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: 'https://a6f82883d78e424ee7b578556b78743d@o4511608063197184.ingest.us.sentry.io/4511608067981312',
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || process.env.SENTRY_DSN,
   integrations: [Sentry.replayIntegration()],
-  tracesSampleRate: 1,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 0,
   enableLogs: true,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
-  sendDefaultPii: true,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
@@ -64,7 +63,7 @@ if (typeof window !== 'undefined' && !sessionStorage.getItem(RELOAD_FLAG)) {
   });
 }
 if (process.env.NODE_ENV === 'development') {
-  console.log('PostHog client instrumentation disabled in development mode.');
+  console.warn('PostHog client instrumentation disabled in development mode.');
 } else if (
   process.env.NODE_ENV === 'production' &&
   process.env.NEXT_PUBLIC_VERCEL_ENV === 'production'

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,14 +31,11 @@ if (posthogServerHost && posthogServerHost !== posthogHost) {
   cspConnectSrc.push(posthogServerHost);
 }
 
-const cspEnforced =
-  "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: blob: https: https://assets.kanadojo.com; font-src 'self' data: https:; connect-src 'self' https:; frame-src 'self' https:; object-src 'none'; base-uri 'self';";
-
-const cspReportOnly = [
+const cspEnforced = [
   "default-src 'self'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com https://www.clarity.ms https://challenges.cloudflare.com",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  "img-src 'self' data: blob: https: https://assets.kanadojo.com",
+  "img-src 'self' data: blob: https://assets.kanadojo.com",
   "font-src 'self' data: https://fonts.gstatic.com",
   `connect-src ${cspConnectSrc.join(' ')}`,
   "frame-src 'self' https://www.googletagmanager.com https://challenges.cloudflare.com",
@@ -53,7 +50,6 @@ const nextConfig: NextConfig = {
   poweredByHeader: false, // Remove X-Powered-By header for security
   generateEtags: true, // Generate ETags for better caching
 
-  // Disable instrumentation in development
   // instrumentationHook: !isDev,
 
   // Compiler optimizations
@@ -146,10 +142,6 @@ const nextConfig: NextConfig = {
             value: cspEnforced,
           },
           {
-            key: 'Content-Security-Policy-Report-Only',
-            value: cspReportOnly,
-          },
-          {
             key: 'Cross-Origin-Opener-Policy',
             value: 'same-origin-allow-popups',
           },
@@ -221,9 +213,9 @@ export default withSentryConfig(withBundleAnalyzer(withNextIntl(nextConfig)), {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
-  org: "zephyr-software",
+  org: 'zephyr-software',
 
-  project: "javascript-nextjs",
+  project: 'javascript-nextjs',
 
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
@@ -238,7 +230,7 @@ export default withSentryConfig(withBundleAnalyzer(withNextIntl(nextConfig)), {
   // This can increase your server load as well as your hosting bill.
   // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
   // side errors will fail.
-  tunnelRoute: "/monitoring",
+  tunnelRoute: '/monitoring',
 
   webpack: {
     // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@sentry/nextjs": "^10.59.0",
         "@supabase/supabase-js": "^2.108.2",
+        "@swc/helpers": "^0.5.23",
         "@tailwindcss/postcss": "^4.1.18",
         "@tailwindcss/typography": "^0.5.19",
         "@vercel/analytics": "^1.5.0",
@@ -5453,9 +5454,10 @@
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -13592,6 +13594,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -3,18 +3,14 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: "https://a6f82883d78e424ee7b578556b78743d@o4511608063197184.ingest.us.sentry.io/4511608067981312",
+  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 0,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,18 +2,14 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  dsn: "https://a6f82883d78e424ee7b578556b78743d@o4511608063197184.ingest.us.sentry.io/4511608067981312",
+  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.2 : 0,
 
   // Enable logs to be sent to Sentry
   enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,24 +19,12 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ],
-      "@/entities/*": [
-        "./entities/*"
-      ],
-      "@/features/*": [
-        "./features/*"
-      ],
-      "@/widgets/*": [
-        "./widgets/*"
-      ],
-      "@/shared/*": [
-        "./shared/*"
-      ],
-      "@/core/*": [
-        "./core/*"
-      ]
+      "@/*": ["./*"],
+      "@/entities/*": ["./entities/*"],
+      "@/features/*": ["./features/*"],
+      "@/widgets/*": ["./widgets/*"],
+      "@/shared/*": ["./shared/*"],
+      "@/core/*": ["./core/*"]
     },
     // Performance optimizations
     "assumeChangesOnlyAffectDirectDependencies": true,
@@ -53,7 +37,7 @@
     ".next/types/**/*.ts",
     "tailwind.config.js",
     ".next/dev/types/**/*.ts",
-    ".next/dev/dev/types/**/*.ts"
+    ".next/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary

- **CSP**: Replaced `https:` wildcards with specific allowed domains. Removed contradictory double CSP headers (enforced + report-only).
- **Sentry**: DSN now reads from `SENTRY_DSN`/`NEXT_PUBLIC_SENTRY_DSN` env vars. Reduced `tracesSampleRate` from 1.0 to 0.2 in production. Removed `sendDefaultPii: true`.
- **tsconfig.json**: Fixed double `dev/dev` path typo in include.
- **Dockerfile**: Fixed `COPY` of `next.config.js` → `next.config.ts`.
- **Locale**: Synced `config.ts` locales with `routing.ts` (`['en']` → `['en', 'es']`).
- **Cleanup**: Removed stale single-file locale JSONs (superseded by namespace directories). Removed `@tailwind utilities` v3 directive conflicting with Tailwind v4.
- **Logging**: Changed `console.log` to `console.warn` for ESLint compliance.