### PR TITLE
Add new fact about shimenawa to japan-facts.json

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -89,5 +89,6 @@
   "Japanese farmers grow cubic watermelons in glass boxes - not for taste but because they're easier to stack and refrigerate.",
   "There's a Japanese concept 'ningensei' (人間性) meaning humanity or human nature - the qualities that make us human.",
   "The word 'enryo' (遠慮) describes polite restraint - like declining seconds even when hungry, to not be a burden.",
-  "Japan has 'omikuji' (おみくじ) fortune slips at shrines; bad fortunes are often tied to a tree or rack to leave them behind."
+  "Japan has 'omikuji' (おみくじ) fortune slips at shrines; bad fortunes are often tied to a tree or rack to leave them behind.",
+  "Japan’s 'shimenawa' (注連縄) sacred ropes are hung at shrines and homes to mark purified, protected spaces."
 ]


### PR DESCRIPTION
## 📝 Description

Added "Japan’s 'shimenawa' (注連縄) sacred ropes are hung at shrines and homes to mark purified, protected spaces." to the file.

Closes #23699
