### PR TITLE
feat(crazy-mode): add streak tracking with persistent best streak

### DIFF
--- a/features/Achievements/store/useAchievementStore.ts
+++ b/features/Achievements/store/useAchievementStore.ts
@@ -21,7 +21,8 @@ export type AchievementCategory =
   | 'gauntlet'
   | 'blitz'
   | 'speed'
-  | 'fun';
+  | 'fun'
+  | 'crazy';
 
 // Extended requirement types for the expanded achievement system
 export type AchievementRequirementType =
@@ -54,7 +55,9 @@ export type AchievementRequirementType =
   | 'wrong_streak'
   | 'exact_count'
   | 'achievement_count'
-  | 'total_points';
+  | 'total_points'
+  // CrazyMode-specific types
+  | 'crazy_streak';
 
 // Additional requirement parameters for complex achievement conditions
 export interface AchievementRequirementAdditional {
@@ -1315,6 +1318,40 @@ export const ACHIEVEMENTS: Achievement[] = [
     requirements: { type: 'achievement_count', value: -1 }, // -1 means all
     hidden: true,
   },
+
+  // ============================================
+  // CRAZY MODE STREAK ACHIEVEMENTS
+  // ============================================
+  {
+    id: 'crazy_streak_10',
+    title: 'Crazy Streak Initiate',
+    description: 'Achieve a 10-answer streak in Crazy Mode',
+    icon: '🎪',
+    rarity: 'uncommon',
+    points: 75,
+    category: 'crazy',
+    requirements: { type: 'crazy_streak', value: 10 },
+  },
+  {
+    id: 'crazy_streak_25',
+    title: 'Crazy Streak Master',
+    description: 'Achieve a 25-answer streak in Crazy Mode',
+    icon: '🤹',
+    rarity: 'rare',
+    points: 200,
+    category: 'crazy',
+    requirements: { type: 'crazy_streak', value: 25 },
+  },
+  {
+    id: 'crazy_streak_50',
+    title: 'Crazy Streak Legend',
+    description: 'Achieve a 50-answer streak in Crazy Mode',
+    icon: '🤡',
+    rarity: 'epic',
+    points: 500,
+    category: 'crazy',
+    requirements: { type: 'crazy_streak', value: 50 },
+  },
 ];
 
 // ============================================
@@ -1969,6 +2006,24 @@ function checkRequirement(
     // Total points type (6.12)
     case 'total_points':
       return checkTotalPointsRequirement(achievement, state);
+
+    // CrazyMode streak type
+    case 'crazy_streak': {
+      // Import from CrazyMode streak store
+      const crazyStreakState = (() => {
+        try {
+          // Access the persisted localStorage data
+          if (typeof window === 'undefined') return 0;
+          const stored = window.localStorage.getItem('kanadojo-crazy-streak');
+          if (!stored) return 0;
+          const parsed = JSON.parse(stored);
+          return parsed?.state?.bestStreak ?? 0;
+        } catch {
+          return 0;
+        }
+      })();
+      return crazyStreakState >= value;
+    }
 
     default:
       return false;

--- a/features/CrazyMode/components/CrazyModeStreakBadge.tsx
+++ b/features/CrazyMode/components/CrazyModeStreakBadge.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useMemo } from 'react';
+import useCrazyModeStreakStore from '../store/useCrazyModeStreakStore';
+
+export interface CrazyModeStreakBadgeProps {
+  /** Minimum streak to show the badge */
+  threshold?: number;
+}
+
+export function CrazyModeStreakBadge({ threshold = 3 }: CrazyModeStreakBadgeProps) {
+  const currentStreak = useCrazyModeStreakStore(s => s.currentStreak);
+  const bestStreak = useCrazyModeStreakStore(s => s.bestStreak);
+
+  const display = useMemo(() => {
+    if (currentStreak < threshold) return null;
+
+    const fireIntensity =
+      currentStreak >= 50
+        ? 'text-orange-500 scale-125 animate-pulse'
+        : currentStreak >= 25
+          ? 'text-orange-400 scale-110'
+          : currentStreak >= 10
+            ? 'text-yellow-500 scale-105'
+            : 'text-yellow-400';
+
+    return { fireIntensity };
+  }, [currentStreak, threshold]);
+
+  if (!display) return null;
+
+  return (
+    <div className='flex items-center gap-1.5 rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-1 text-sm font-semibold'>
+      <span className={display.fireIntensity}>🔥</span>
+      <span className='text-yellow-400'>{currentStreak}</span>
+      {bestStreak > 0 && currentStreak < bestStreak && (
+        <span className='ml-1 text-xs text-yellow-600/60'>
+          (best: {bestStreak})
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default CrazyModeStreakBadge;

--- a/features/CrazyMode/facade/index.ts
+++ b/features/CrazyMode/facade/index.ts
@@ -1,2 +1,11 @@
-export { useCrazyMode, KYOKI_THEME_ID } from './useCrazyMode';
-export type { CrazyModeState, CrazyModeActions } from './useCrazyMode';
+export {
+  useCrazyMode,
+  useCrazyModeStreak,
+  KYOKI_THEME_ID,
+} from './useCrazyMode';
+export type {
+  CrazyModeState,
+  CrazyModeActions,
+  CrazyModeStreakState,
+  CrazyModeStreakActions,
+} from './useCrazyMode';

--- a/features/CrazyMode/facade/useCrazyMode.ts
+++ b/features/CrazyMode/facade/useCrazyMode.ts
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import useCrazyModeStore, { KYOKI_THEME_ID } from '../store/useCrazyModeStore';
+import useCrazyModeStreakStore from '../store/useCrazyModeStreakStore';
 import usePreferencesStore from '@/features/Preferences/store/usePreferencesStore';
 
 export { KYOKI_THEME_ID };
@@ -16,8 +17,18 @@ export interface CrazyModeActions {
   randomize: () => void;
 }
 
+export interface CrazyModeStreakState {
+  currentStreak: number;
+  bestStreak: number;
+}
+
+export interface CrazyModeStreakActions {
+  recordCorrect: () => void;
+  recordWrong: () => void;
+  reset: () => void;
+}
+
 export function useCrazyMode(): CrazyModeState & CrazyModeActions {
-  // Crazy mode is now derived from whether the kyoki theme is selected
   const selectedTheme = usePreferencesStore(state => state.theme);
   const isCrazyMode = selectedTheme === KYOKI_THEME_ID;
 
@@ -30,8 +41,28 @@ export function useCrazyMode(): CrazyModeState & CrazyModeActions {
       isCrazyMode,
       activeThemeId,
       activeFontName,
-      randomize
+      randomize,
     }),
-    [isCrazyMode, activeThemeId, activeFontName, randomize]
+    [isCrazyMode, activeThemeId, activeFontName, randomize],
+  );
+}
+
+export function useCrazyModeStreak(): CrazyModeStreakState &
+  CrazyModeStreakActions {
+  const currentStreak = useCrazyModeStreakStore(s => s.currentStreak);
+  const bestStreak = useCrazyModeStreakStore(s => s.bestStreak);
+  const recordCorrect = useCrazyModeStreakStore(s => s.recordCorrect);
+  const recordWrong = useCrazyModeStreakStore(s => s.recordWrong);
+  const reset = useCrazyModeStreakStore(s => s.reset);
+
+  return useMemo(
+    () => ({
+      currentStreak,
+      bestStreak,
+      recordCorrect,
+      recordWrong,
+      reset,
+    }),
+    [currentStreak, bestStreak, recordCorrect, recordWrong, reset],
   );
 }

--- a/features/CrazyMode/index.ts
+++ b/features/CrazyMode/index.ts
@@ -1,2 +1,13 @@
-export { useCrazyMode, KYOKI_THEME_ID } from './facade';
-export type { CrazyModeState, CrazyModeActions } from './facade';
+export {
+  useCrazyMode,
+  useCrazyModeStreak,
+  KYOKI_THEME_ID,
+} from './facade';
+export type {
+  CrazyModeState,
+  CrazyModeActions,
+  CrazyModeStreakState,
+  CrazyModeStreakActions,
+} from './facade';
+export { default as useCrazyModeStreakStore } from './store/useCrazyModeStreakStore';
+export { CrazyModeStreakBadge } from './components/CrazyModeStreakBadge';

--- a/features/CrazyMode/store/useCrazyModeStreakStore.ts
+++ b/features/CrazyMode/store/useCrazyModeStreakStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export interface CrazyModeStreakState {
+  currentStreak: number;
+  bestStreak: number;
+}
+
+export interface CrazyModeStreakActions {
+  recordCorrect: () => void;
+  recordWrong: () => void;
+  reset: () => void;
+}
+
+const useCrazyModeStreakStore = create<
+  CrazyModeStreakState & CrazyModeStreakActions
+>()(
+  persist(
+    set => ({
+      currentStreak: 0,
+      bestStreak: 0,
+
+      recordCorrect: () =>
+        set(s => {
+          const newStreak = s.currentStreak + 1;
+          return {
+            currentStreak: newStreak,
+            bestStreak: Math.max(s.bestStreak, newStreak),
+          };
+        }),
+
+      recordWrong: () => set({ currentStreak: 0 }),
+
+      reset: () => set({ currentStreak: 0, bestStreak: 0 }),
+    }),
+    {
+      name: 'kanadojo-crazy-streak',
+    },
+  ),
+);
+
+export default useCrazyModeStreakStore;

--- a/features/Kana/components/Game/Input.tsx
+++ b/features/Kana/components/Game/Input.tsx
@@ -10,6 +10,11 @@ import { useStatsStore } from '@/features/Progress';
 import { useShallow } from 'zustand/react/shallow';
 import Stars from '@/shared/ui-composite/Game/Stars';
 import { useCrazyModeTrigger } from '@/features/CrazyMode/hooks/useCrazyModeTrigger';
+import {
+  useCrazyMode,
+  useCrazyModeStreak,
+} from '@/features/CrazyMode/facade';
+import { CrazyModeStreakBadge } from '@/features/CrazyMode/components/CrazyModeStreakBadge';
 import { getGlobalAdaptiveSelector } from '@/shared/utils/adaptiveSelection';
 import { GameBottomBar } from '@/shared/ui-composite/Game/GameBottomBar';
 import { isKanaInputAnswerCorrect } from '@/features/Kana/lib/isKanaInputAnswerCorrect';
@@ -85,6 +90,9 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
   const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
+  const { isCrazyMode } = useCrazyMode();
+  const { recordCorrect: recordCrazyStreakCorrect, recordWrong: recordCrazyStreakWrong } =
+    useCrazyModeStreak();
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -313,6 +321,10 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
     });
     // Reset wrong streak on correct answer (Requirement 10.2)
     resetWrongStreak();
+    // Track CrazyMode streak
+    if (isCrazyMode) {
+      recordCrazyStreakCorrect();
+    }
     recordTargetLengthCorrect();
     setBottomBarState('correct');
     justAnsweredRef.current = true;
@@ -358,6 +370,10 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
       adaptiveSelector.updateCharacterWeight(char, positionResults[index]);
     });
     incrementWrongStreak();
+    // Reset CrazyMode streak on wrong answer
+    if (isCrazyMode) {
+      recordCrazyStreakWrong();
+    }
     recordTargetLengthWrong();
     setBottomBarState('wrong');
     logAttempt({
@@ -454,7 +470,10 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
           }
         }}
       />
-      <Stars />
+      <div className='flex items-center gap-3'>
+        {isCrazyMode && <CrazyModeStreakBadge threshold={3} />}
+        <Stars />
+      </div>
 
       <GameBottomBar
         state={bottomBarState}

--- a/features/Kana/components/Game/MCQ.tsx
+++ b/features/Kana/components/Game/MCQ.tsx
@@ -12,6 +12,11 @@ import { useStatsStore } from '@/features/Progress';
 import { useShallow } from 'zustand/react/shallow';
 import Stars from '@/shared/ui-composite/Game/Stars';
 import { useCrazyModeTrigger } from '@/features/CrazyMode/hooks/useCrazyModeTrigger';
+import {
+  useCrazyMode,
+  useCrazyModeStreak,
+} from '@/features/CrazyMode/facade';
+import { CrazyModeStreakBadge } from '@/features/CrazyMode/components/CrazyModeStreakBadge';
 import { getGlobalAdaptiveSelector } from '@/shared/utils/adaptiveSelection';
 import { useSmartReverseMode } from '@/shared/hooks/game/useSmartReverseMode';
 import { useAdaptiveOptionCount } from '@/shared/hooks/game/useAdaptiveOptionCount';
@@ -127,6 +132,9 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
   const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
+  const { isCrazyMode } = useCrazyMode();
+  const { recordCorrect: recordCrazyStreakCorrect, recordWrong: recordCrazyStreakWrong } =
+    useCrazyModeStreak();
 
   const kanaGroupIndices = useKanaStore(state => state.kanaGroupIndices);
 
@@ -314,6 +322,10 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
       }
       // Reset wrong streak on correct answer (Requirement 10.2)
       resetWrongStreak();
+      // Track CrazyMode streak
+      if (isCrazyMode) {
+        recordCrazyStreakCorrect();
+      }
       logAttempt({
         questionId: correctChar,
         questionPrompt: isReverse
@@ -347,6 +359,8 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
       correctRomajiCharReverse,
       shuffledVariants,
       isReverse,
+      isCrazyMode,
+      recordCrazyStreakCorrect,
     ],
   );
 
@@ -373,6 +387,10 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
       recordDifficultyWrong();
       // Track wrong streak for achievements (Requirement 10.2)
       incrementWrongStreak();
+      // Reset CrazyMode streak on wrong answer
+      if (isCrazyMode) {
+        recordCrazyStreakWrong();
+      }
       logAttempt({
         questionId: isReverse ? correctRomajiCharReverse : correctKanaChar,
         questionPrompt: isReverse ? correctRomajiCharReverse : correctKanaChar,
@@ -400,8 +418,10 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
       incrementWrongStreak,
       logAttempt,
       correctKanaCharReverse,
-      correctRomajiChar,
+      correctRomaji,
       shuffledVariants,
+      isCrazyMode,
+      recordCrazyStreakWrong,
     ],
   );
 
@@ -502,7 +522,10 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
           ))}
         </div>
       )}
-      <Stars />
+      <div className='flex items-center gap-3'>
+        {isCrazyMode && <CrazyModeStreakBadge threshold={3} />}
+        <Stars />
+      </div>
     </div>
   );
 };

--- a/features/Kanji/components/Game/MCQ.tsx
+++ b/features/Kanji/components/Game/MCQ.tsx
@@ -15,6 +15,11 @@ import AnswerSummary from '@/shared/ui-composite/Game/AnswerSummary';
 import SSRAudioButton from '@/shared/ui-composite/audio/SSRAudioButton';
 import FuriganaText from '@/shared/ui-composite/text/FuriganaText';
 import { useCrazyModeTrigger } from '@/features/CrazyMode/hooks/useCrazyModeTrigger';
+import {
+  useCrazyMode,
+  useCrazyModeStreak,
+} from '@/features/CrazyMode/facade';
+import { CrazyModeStreakBadge } from '@/features/CrazyMode/components/CrazyModeStreakBadge';
 import { getGlobalAdaptiveSelector } from '@/shared/utils/adaptiveSelection';
 import { useSmartReverseMode } from '@/shared/hooks/game/useSmartReverseMode';
 import useClassicSessionStore from '@/shared/store/useClassicSessionStore';
@@ -139,6 +144,9 @@ const KanjiMCQ = ({ selectedKanjiObjs, isHidden }: KanjiMCQProps) => {
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
   const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
+  const { isCrazyMode } = useCrazyMode();
+  const { recordCorrect: recordCrazyStreakCorrect, recordWrong: recordCrazyStreakWrong } =
+    useCrazyModeStreak();
 
   // State management - correctChar always stores the kanji character
   // This ensures consistency when isReverse changes dynamically
@@ -281,6 +289,10 @@ const KanjiMCQ = ({ selectedKanjiObjs, isHidden }: KanjiMCQProps) => {
     incrementKanjiCorrect(selectedKanjiCollection.toUpperCase());
     // Reset wrong streak on correct answer (Requirement 10.2)
     resetWrongStreak();
+    // Track CrazyMode streak
+    if (isCrazyMode) {
+      recordCrazyStreakCorrect();
+    }
     logAttempt({
       questionId: correctChar,
       questionPrompt: String(displayChar),
@@ -314,6 +326,10 @@ const KanjiMCQ = ({ selectedKanjiObjs, isHidden }: KanjiMCQProps) => {
     recordWrongAnswer();
     // Track wrong streak for achievements (Requirement 10.2)
     incrementWrongStreak();
+    // Reset CrazyMode streak on wrong answer
+    if (isCrazyMode) {
+      recordCrazyStreakWrong();
+    }
     logAttempt({
       questionId: correctChar,
       questionPrompt: String(displayChar),
@@ -411,7 +427,10 @@ const KanjiMCQ = ({ selectedKanjiObjs, isHidden }: KanjiMCQProps) => {
             ))}
           </div>
 
-          <Stars />
+          <div className='flex items-center gap-3'>
+            {isCrazyMode && <CrazyModeStreakBadge threshold={3} />}
+            <Stars />
+          </div>
         </>
       )}
     </div>

--- a/features/Vocabulary/components/Game/MCQ.tsx
+++ b/features/Vocabulary/components/Game/MCQ.tsx
@@ -15,6 +15,11 @@ import AnswerSummary from '@/shared/ui-composite/Game/AnswerSummary';
 import SSRAudioButton from '@/shared/ui-composite/audio/SSRAudioButton';
 import FuriganaText from '@/shared/ui-composite/text/FuriganaText';
 import { useCrazyModeTrigger } from '@/features/CrazyMode/hooks/useCrazyModeTrigger';
+import {
+  useCrazyMode,
+  useCrazyModeStreak,
+} from '@/features/CrazyMode/facade';
+import { CrazyModeStreakBadge } from '@/features/CrazyMode/components/CrazyModeStreakBadge';
 import { getGlobalAdaptiveSelector } from '@/shared/utils/adaptiveSelection';
 import { useSmartReverseMode } from '@/shared/hooks/game/useSmartReverseMode';
 import {
@@ -148,6 +153,9 @@ const VocabMCQ = ({ selectedWordObjs, isHidden }: VocabMCQProps) => {
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
   const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
+  const { isCrazyMode } = useCrazyMode();
+  const { recordCorrect: recordCrazyStreakCorrect, recordWrong: recordCrazyStreakWrong } =
+    useCrazyModeStreak();
 
   // Quiz type: 'meaning' or 'reading'
   const [quizType, setQuizType] = useState<'meaning' | 'reading'>('meaning');
@@ -326,6 +334,10 @@ const VocabMCQ = ({ selectedWordObjs, isHidden }: VocabMCQProps) => {
     incrementVocabularyCorrect();
     // Reset wrong streak on correct answer (Requirement 10.2)
     resetWrongStreak();
+    // Track CrazyMode streak
+    if (isCrazyMode) {
+      recordCrazyStreakCorrect();
+    }
   };
 
   const handleWrongAnswer = (selectedOption: string) => {
@@ -350,6 +362,10 @@ const VocabMCQ = ({ selectedWordObjs, isHidden }: VocabMCQProps) => {
     recordWrongAnswer();
     // Track wrong streak for achievements (Requirement 10.2)
     incrementWrongStreak();
+    // Reset CrazyMode streak on wrong answer
+    if (isCrazyMode) {
+      recordCrazyStreakWrong();
+    }
   };
 
   const generateNewCharacter = () => {
@@ -468,7 +484,10 @@ const VocabMCQ = ({ selectedWordObjs, isHidden }: VocabMCQProps) => {
             ))}
           </div>
 
-          <Stars />
+          <div className='flex items-center gap-3'>
+            {isCrazyMode && <CrazyModeStreakBadge threshold={3} />}
+            <Stars />
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

Adds a streak tracking system to Crazy Mode that tracks consecutive correct answers and persists the best streak across sessions.

## Changes

- **New store**:  - Zustand store with localStorage persistence for current/best streak
- **New component**:  - Visual badge showing current streak (🔥) with fire intensity scaling at 10/25/50 streaks
- **Integration**: Streak tracking in Kana/Kanji/Vocabulary MCQ and Input game modes
- **Achievements**: 3 new CrazyMode-specific achievements:
  - 🎪 Crazy Streak Initiate (10 streak) - 75pts
  - 🤹 Crazy Streak Master (25 streak) - 200pts  
  - 🤡 Crazy Streak Legend (50 streak) - 500pts

## How it works

1. When Crazy Mode is active (kyoki theme selected), each correct answer increments the streak
2. Wrong answers reset the streak to 0
3. Best streak is persisted in localStorage across sessions
4. Badge appears when streak >= 3, with visual intensity scaling
5. Achievement system checks against the stored best streak

## Screenshots

The badge appears below the game area with the Stars component:

- 🔥 **3-9**: Yellow badge
- 🔥 **10-24**: Slightly scaled
- 🔥 **25-49**: Larger, orange
- 🔥 **50+**: Pulsing, red-orange

## Testing

- [x] Streak increments on correct answers in all game modes
- [x] Streak resets on wrong answers
- [x] Best streak persists across page reloads
- [x] Badge only shows in Crazy Mode
- [x] Badge only shows when streak >= 3
- [x] Achievements unlock at correct thresholds