### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -97,5 +97,6 @@
   "Japan has 'shuumatsu okashi' trends where limited-edition sweets appear for a season and then disappear, making them collectible.",
   "Japan’s 'wagashi' sweets are often designed to match the season, with colors and shapes inspired by flowers or snow.",
   "'Wabi-sabi' is the appreciation of beauty in imperfection and the natural aging of materials.",
-  "Japan has professional apology agencies where you can hire someone to apologize on your behalf for serious personal matters."
+  "Japan has professional apology agencies where you can hire someone to apologize on your behalf for serious personal matters.",
+  "Japan's 'machi-nami hozon' movement preserves historic townscapes, protecting old streets so locals can still live and work there."
 ]


### PR DESCRIPTION
## Summary
Adds Japan Fact #261 to the community facts collection, as requested in the good-first-issue ticket.

## Change
Appended the following fact to `community/content/japan-facts.json`:

> Japan's 'machi-nami hozon' movement preserves historic townscapes, protecting old streets so locals can still live and work there.

## Testing
Verified the resulting file is valid JSON (parsed with `json.load` before and after the change; entry count went from 99 to 100) and that formatting/indentation matches the existing entries.

Closes #24176