### PR TITLE
feat(theme): add Kumo Sky theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -364,5 +364,11 @@
   "backgroundColor": "oklch(19.0% 0.050 20.0 / 1)",
   "mainColor": "oklch(65.0% 0.195 25.0 / 1)",
   "secondaryColor": "oklch(78.0% 0.105 85.0 / 1)"
+},
+  {
+  "id": "kumo-sky",
+  "backgroundColor": "oklch(90.0% 0.020 220.0 / 1)",
+  "mainColor": "oklch(60.0% 0.090 215.0 / 1)",
+  "secondaryColor": "oklch(70.0% 0.060 200.0 / 1)"
 }
 ]


### PR DESCRIPTION
## Summary

This PR adds the **Kumo Sky** (`kumo-sky`) theme to the community themes collection. The theme uses a soft, overcast sky palette — light cool background, muted blue main color, and a gentle secondary tone — giving learners a calm, minimal visual environment inspired by cloudy Japanese skies.

Fixes #24216 — [Good First Issue] ☁️ Add new Community Theme: Kumo Sky

## What changed

**`community/content/community-themes.json`**
- Problem: The `kumo-sky` theme was specified in Issue #24216 but not yet present in the themes data file.
- Change: Appended the new theme object at the end of the array before the closing `]`. No existing entries were modified.

## Acceptance criteria

- [x] `kumo-sky` object appended to `community/content/community-themes.json`
- [x] All four required fields present: `id`, `backgroundColor`, `mainColor`, `secondaryColor`
- [x] OKLCH color format used, consistent with all other entries
- [x] JSON remains valid (comma after previous last entry, no trailing comma after new entry)
- [x] No existing entries modified

## How to test

1. Open `community/content/community-themes.json` in this PR's diff
2. Confirm the last entry is the new `kumo-sky` object with the correct color values
3. Copy the full file content and validate at jsonlint.com — should parse without errors
4. Edge case: confirm no other theme IDs were accidentally altered

## Notes

- No schema changes
- No new dependencies added
- No server/API changes
- No breaking changes to existing consumers
- Color values match the palette specified in the issue exactly
- Strictly additive: only one new object appended at the tail of the array