### PR TITLE
Add new trivia question about sea separating Japan

### DIFF
--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -588,5 +588,16 @@
     "Sendai"
   ],
   "correctIndex": 0
+},
+{
+  "question": "Which sea separates Japan from the Korean Peninsula? (Community variation 47)",
+  "difficulty": "hard",
+  "answers": [
+    "Sea of Japan",
+    "East China Sea",
+    "Philippine Sea",
+    "Bering Sea"
+  ],
+  "correctIndex": 0
 }
 ]


### PR DESCRIPTION
Added a new hard Japan trivia question about the sea separating Japan from the Korean Peninsula.

## Summary
- Added a new hard Japan trivia question.

Closes #24406
