### PR TITLE
Expand the game quotes dataset and restore missing entries

### DIFF
--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -357,115 +357,185 @@
     "character": "Solid Snake"
   },
   {
-  "japanese": "冒険の始まりだ！",
-  "romaji": "Bouken no hajimari da!",
-  "english": "This is the beginning of the adventure!",
-  "game": "Dragon Quest XI",
-  "character": "Hero / party lines"
-},
-  {
-  "japanese": "まだまだだね",
-  "romaji": "Mada mada da ne",
-  "english": "You still have lots more to work on.",
-  "game": "The Prince of Tennis: Sweat & Tears 2",
-  "character": "Ryoma Echizen"
+    "japanese": "冒険の始まりだ！",
+    "romaji": "Bouken no hajimari da!",
+    "english": "This is the beginning of the adventure!",
+    "game": "Dragon Quest XI",
+    "character": "Hero / party lines"
   },
   {
-  "japanese": "覚悟はいいか？ 俺はできてる。",
-  "romaji": "Kakugo wa ii ka? Ore wa dekiteru.",
-  "english": "Are you prepared? I am.",
-  "game": "JoJo’s Bizarre Adventure: All-Star Battle",
-  "character": "Giorno Giovanna"
-},
+    "japanese": "まだまだだね",
+    "romaji": "Mada mada da ne",
+    "english": "You still have lots more to work on.",
+    "game": "The Prince of Tennis: Sweat & Tears 2",
+    "character": "Ryoma Echizen"
+  },
   {
-  "japanese": "この戦い、負けられない！",
-  "romaji": "Kono tatakai, makerarenai!",
-  "english": "I can't lose this fight!",
-  "game": "Fire Emblem series",
-  "character": "Various protagonists"
-},
+    "japanese": "覚悟はいいか？ 俺はできてる。",
+    "romaji": "Kakugo wa ii ka? Ore wa dekiteru.",
+    "english": "Are you prepared? I am.",
+    "game": "JoJo’s Bizarre Adventure: All-Star Battle",
+    "character": "Giorno Giovanna"
+  },
   {
-  "japanese": "この戦い、負けられない！",
-  "romaji": "Kono tatakai, makerarenai!",
-  "english": "I can't lose this fight!",
-  "game": "Fire Emblem series",
-  "character": "Various protagonists"
-},
-{
-  "japanese": "勝つと思うな、思えば負けよ",
-  "romaji": "Katsu to omou na, omoeba makeyo",
-  "english": "If you only think of winning, you lose.",
-  "game": "Samurai game proverb line",
-  "character": "Musashi reference"
-},
-{
-  "japanese": "生きるってのは、戦うってことだ",
-  "romaji": "Ikiru tte no wa, tatakau tte koto da",
-  "english": "To live is to fight.",
-  "game": "Yakuza: Like a Dragon",
-  "character": "Ichiban Kasuga"
-},
-{
-  "japanese": "俺は悪くねぇ！",
-  "romaji": "Ore wa warukunee!",
-  "english": "It's not my fault!",
-  "game": "Tales of the Abyss",
-  "character": "Luke fon Fabre"
-},
-{
-  "japanese": "行くぞ、みんな！",
-  "romaji": "Iku zo, minna!",
-  "english": "Let's go, everyone!",
-  "game": "Kingdom Hearts series (JP dub)",
-  "character": "Sora"
-},
+    "japanese": "この戦い、負けられない！",
+    "romaji": "Kono tatakai, makerarenai!",
+    "english": "I can't lose this fight!",
+    "game": "Fire Emblem series",
+    "character": "Various protagonists"
+  },
   {
-  "japanese": "俺たちの物語は、ここからだ",
-  "romaji": "Oretachi no monogatari wa, koko kara da",
-  "english": "Our story starts here.",
-  "game": "Tales series",
-  "character": "Various endings"
-},
+    "japanese": "この戦い、負けられない！",
+    "romaji": "Kono tatakai, makerarenai!",
+    "english": "I can't lose this fight!",
+    "game": "Fire Emblem series",
+    "character": "Various protagonists"
+  },
   {
-  "japanese": "それもまた一興",
-  "romaji": "Sore mo mata ikkyo",
-  "english": "That too has its charm.",
-  "game": "Onimusha series",
-  "character": "Nobunaga Oda"
-},
-{
-  "japanese": "ここからが本番だ",
-  "romaji": "Koko kara ga honban da",
-  "english": "The real challenge starts now.",
-  "game": "Monster Hunter series",
-  "character": "Guild Handler lines"
-},
+    "japanese": "勝つと思うな、思えば負けよ",
+    "romaji": "Katsu to omou na, omoeba makeyo",
+    "english": "If you only think of winning, you lose.",
+    "game": "Samurai game proverb line",
+    "character": "Musashi reference"
+  },
   {
-  "japanese": "約束された勝利の剣",
-  "romaji": "Yakusoku sareta shouri no ken",
-  "english": "The Sword of Promised Victory.",
-  "game": "Fate/stay night [Realta Nua]",
-  "character": "Saber"
-},
+    "japanese": "生きるってのは、戦うってことだ",
+    "romaji": "Ikiru tte no wa, tatakau tte koto da",
+    "english": "To live is to fight.",
+    "game": "Yakuza: Like a Dragon",
+    "character": "Ichiban Kasuga"
+  },
   {
-  "japanese": "まだまだだね",
-  "romaji": "Mada mada da ne",
-  "english": "You still have lots more to work on.",
-  "game": "The Prince of Tennis: Sweat & Tears 2",
-  "character": "Ryoma Echizen"
-}, 
+    "japanese": "俺は悪くねぇ！",
+    "romaji": "Ore wa warukunee!",
+    "english": "It's not my fault!",
+    "game": "Tales of the Abyss",
+    "character": "Luke fon Fabre"
+  },
   {
-  "japanese": "俺は悪くねぇ！",
-  "romaji": "Ore wa warukunee!",
-  "english": "It's not my fault!",
-  "game": "Tales of the Abyss",
-  "character": "Luke fon Fabre"
-},
+    "japanese": "行くぞ、みんな！",
+    "romaji": "Iku zo, minna!",
+    "english": "Let's go, everyone!",
+    "game": "Kingdom Hearts series (JP dub)",
+    "character": "Sora"
+  },
   {
-  "japanese": "俺たちの物語は、ここからだ",
-  "romaji": "Oretachi no monogatari wa, koko kara da",
-  "english": "Our story starts here.",
-  "game": "Tales series",
-  "character": "Various endings"
-}
+    "japanese": "俺たちの物語は、ここからだ",
+    "romaji": "Oretachi no monogatari wa, koko kara da",
+    "english": "Our story starts here.",
+    "game": "Tales series",
+    "character": "Various endings"
+  },
+  {
+    "japanese": "それもまた一興",
+    "romaji": "Sore mo mata ikkyo",
+    "english": "That too has its charm.",
+    "game": "Onimusha series",
+    "character": "Nobunaga Oda"
+  },
+  {
+    "japanese": "ここからが本番だ",
+    "romaji": "Koko kara ga honban da",
+    "english": "The real challenge starts now.",
+    "game": "Monster Hunter series",
+    "character": "Guild Handler lines"
+  },
+  {
+    "japanese": "約束された勝利の剣",
+    "romaji": "Yakusoku sareta shouri no ken",
+    "english": "The Sword of Promised Victory.",
+    "game": "Fate/stay night [Realta Nua]",
+    "character": "Saber"
+  },
+  {
+    "japanese": "まだまだだね",
+    "romaji": "Mada mada da ne",
+    "english": "You still have lots more to work on.",
+    "game": "The Prince of Tennis: Sweat & Tears 2",
+    "character": "Ryoma Echizen"
+  },
+  {
+    "japanese": "俺は悪くねぇ！",
+    "romaji": "Ore wa warukunee!",
+    "english": "It's not my fault!",
+    "game": "Tales of the Abyss",
+    "character": "Luke fon Fabre"
+  },
+  {
+    "japanese": "俺たちの物語は、ここからだ",
+    "romaji": "Oretachi no monogatari wa, koko kara da",
+    "english": "Our story starts here.",
+    "game": "Tales series",
+    "character": "Various endings"
+  },
+  {
+    "japanese": "かゆい　うま",
+    "romaji": "Kayui... uma...",
+    "english": "Itchy... tasty...",
+    "game": "Biohazard (Resident Evil 1)",
+    "character": "Keeper's Diary"
+  },
+  {
+    "japanese": "お前も「家族」だ",
+    "romaji": "Omae mo 'kazoku' da",
+    "english": "You're 'family' now.",
+    "game": "Biohazard 7: Resident Evil",
+    "character": "Jack Baker"
+  },
+  {
+    "japanese": "そう、関係ないね",
+    "romaji": "Sou, kankeinai ne",
+    "english": "Indeed, it's none of my business.",
+    "game": "Romancing SaGa",
+    "character": "Gray / Protagonist choice"
+  },
+  {
+    "japanese": "殺してでも　うばいとる",
+    "romaji": "Koroshite demo ubaitoru",
+    "english": "I'll steal it even if I have to kill you!",
+    "game": "Romancing SaGa",
+    "character": "Protagonist choice"
+  },
+  {
+    "japanese": "おれは　しょうきに　もどった！",
+    "romaji": "Ore wa shouki ni modotta!",
+    "english": "I have returned to my senses!",
+    "game": "Final Fantasy IV",
+    "character": "Kain Highwind"
+  },
+  {
+    "japanese": "ゆうべはおたのしみでしたね",
+    "romaji": "Yuube wa o-tanoshimi deshita ne",
+    "english": "You had a good time last night, didn't you?",
+    "game": "Dragon Quest I",
+    "character": "Innkeeper"
+  },
+  {
+    "japanese": "いいセンスだ",
+    "romaji": "Ii sensu da",
+    "english": "You're pretty good.",
+    "game": "Metal Gear Solid 3: Snake Eater",
+    "character": "Naked Snake"
+  },
+  {
+    "japanese": "これは、おれの物語だ！",
+    "romaji": "Kore wa, ore no monogatari da!",
+    "english": "This is my story!",
+    "game": "Final Fantasy X",
+    "character": "Tidus"
+  },
+  {
+    "japanese": "ウボァー",
+    "romaji": "Uboaaー",
+    "english": "Uboaaー",
+    "game": "Final Fantasy II",
+    "character": "Emperor Mateus"
+  },
+  {
+    "japanese": "穏やかじゃないですね",
+    "romaji": "Odayaka janai desu ne",
+    "english": "This is not peaceful, is it?",
+    "game": "Xenoblade Chronicles",
+    "character": "Shulk"
+  }
 ]


### PR DESCRIPTION
## Summary

This pull request expands the game quotes dataset by adding additional Japanese game quotes and restoring entries that were unintentionally removed during previous updates.

## Changes

- Added new Japanese game quote entries.
- Restored missing quotes that were accidentally removed.
- Included romaji transliterations and English translations where applicable.
- Preserved the existing dataset structure and formatting.

## Notes

- No existing schema or data format was changed.
- This update is focused solely on improving the completeness of the dataset.
- Existing functionality should remain unaffected.

Thank you for reviewing!