### PR TITLE
feat(theme): add Sunset Train theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -424,5 +424,11 @@
   "backgroundColor": "oklch(22.0% 0.020 235.0 / 1)",
   "mainColor": "oklch(78.0% 0.135 215.0 / 1)",
   "secondaryColor": "oklch(85.0% 0.155 90.0 / 1)"
+},
+  {
+  "id": "sunset-train",
+  "backgroundColor": "oklch(22.0% 0.052 45.0 / 1)",
+  "mainColor": "oklch(88.0% 0.165 65.0 / 1)",
+  "secondaryColor": "oklch(72.0% 0.185 35.0 / 1)"
 }
 ]


### PR DESCRIPTION
Adds the **Sunset Train** community theme as specified in the issue.

| Property | Value |
|----------|-------|
| ID | `sunset-train` |
| Background | `oklch(22.0% 0.052 45.0 / 1)` |
| Main | `oklch(88.0% 0.165 65.0 / 1)` |
| Secondary | `oklch(72.0% 0.185 35.0 / 1)` |

JSON validated after the change.

Closes #24529