### PR TITLE
fix: add missing comma in Japanese facts

### DIFF
--- a/data/japan-facts.json
+++ b/data/japan-facts.json
@@ -42,5 +42,7 @@
   "Japan has a dedicated word 'tsukemono' (漬物) for pickled vegetables - over 4,000 varieties exist throughout the country.",
   "The Japanese word 'ganbarimasu' (頑張ります) is said before attempting something difficult - a commitment to do your absolute best.",
   "The concept of 'kawaisa' (可愛さ) or cuteness is so culturally important that it influences everything from government mascots to warning signs.",
-  "The Japanese word 'shibui' (渋い) describes a subtle, unobtrusive beauty that grows on you over time - the opposite of flashy."
-  "Japan has a museum dedicated to salt, explaining its 5,000-year production history and cultural significance.","The term 'kirei' (綺麗) means both 'beautiful' and 'clean', linking aesthetics with neatness."]
+  "The Japanese word 'shibui' (渋い) describes a subtle, unobtrusive beauty that grows on you over time - the opposite of flashy.",
+  "Japan has a museum dedicated to salt, explaining its 5,000-year production history and cultural significance.",
+  "The term 'kirei' (綺麗) means both 'beautiful' and 'clean', linking aesthetics with neatness."
+]


### PR DESCRIPTION
## 📝 Description

Fix a syntax error in a Japanese facts JSON file.

## 🔗 Related Issue

No related issue.

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  `npm run check`
2.  `npm run test`
