### PR TITLE
fix(conjugator): handle う音便 verbs (問う/請う/乞う) in te/ta form

### DIFF
--- a/features/Conjugator/__tests__/teForm.property.test.ts
+++ b/features/Conjugator/__tests__/teForm.property.test.ts
@@ -11,7 +11,11 @@
 import { describe, it, expect } from 'vitest';
 import * as fc from 'fast-check';
 import { classifyVerb } from '../lib/engine/classifyVerb';
-import { getGodanTeForm, getGodanTaForm } from '../lib/engine/conjugateGodan';
+import {
+  conjugateGodan,
+  getGodanTeForm,
+  getGodanTaForm,
+} from '../lib/engine/conjugateGodan';
 
 // ============================================================================
 // Test Data - Godan Verbs by Ending Type
@@ -99,13 +103,22 @@ const KU_ENDING_VERBS = [
 const IKU_VERB = { verb: '行く', teForm: '行って', taForm: '行った' };
 
 /**
- * う音便 exception verbs (問う, 請う, 乞う): te-form うて / ta-form うた,
+ * う音便 exception verbs: te-form うて / ta-form うた; include kana inputs too.
  * not the regular って / った.
  */
 const U_ONBIN_VERBS = [
   { verb: '問う', teForm: '問うて', taForm: '問うた' },
+  { verb: '訪う', teForm: '訪うて', taForm: '訪うた' },
+  { verb: 'とう', teForm: 'とうて', taForm: 'とうた' },
   { verb: '請う', teForm: '請うて', taForm: '請うた' },
   { verb: '乞う', teForm: '乞うて', taForm: '乞うた' },
+  { verb: '恋う', teForm: '恋うて', taForm: '恋うた' },
+  { verb: 'こう', teForm: 'こうて', taForm: 'こうた' },
+  { verb: '給う', teForm: '給うて', taForm: '給うた' },
+  { verb: '賜う', teForm: '賜うて', taForm: '賜うた' },
+  { verb: 'たまう', teForm: 'たまうて', taForm: 'たまうた' },
+  { verb: '厭う', teForm: '厭うて', taForm: '厭うた' },
+  { verb: 'いとう', teForm: 'いとうて', taForm: 'いとうた' },
 ];
 
 /**
@@ -144,6 +157,7 @@ const ALL_GODAN_VERBS = [
   ...GU_ENDING_VERBS,
   ...SU_ENDING_VERBS,
   IKU_VERB,
+  ...U_ONBIN_VERBS,
 ];
 
 // ============================================================================
@@ -249,7 +263,7 @@ describe('Te-form Sound Changes Properties', () => {
       expect(teForm.endsWith('いて')).toBe(false);
     });
 
-    it('問う/請う/乞う produce うて te-form, not って (う音便)', () => {
+    it('う音便 verbs produce うて te-form, not って', () => {
       U_ONBIN_VERBS.forEach(verbData => {
         const verbInfo = classifyVerb(verbData.verb);
         const teForm = getGodanTeForm(verbInfo);
@@ -294,7 +308,7 @@ describe('Te-form Sound Changes Properties', () => {
       );
     });
 
-    it('問う/請う/乞う produce うた ta-form, not った (う音便)', () => {
+    it('う音便 verbs produce うた ta-form, not った', () => {
       U_ONBIN_VERBS.forEach(verbData => {
         const verbInfo = classifyVerb(verbData.verb);
         const taForm = getGodanTaForm(verbInfo);
@@ -322,13 +336,26 @@ describe('Te-form Sound Changes Properties', () => {
           const teForm = getGodanTeForm(verbInfo);
 
           // Te-form should end with て or で
-          const validEndings = ['って', 'んで', 'いて', 'いで', 'して'];
+          const validEndings = ['って', 'んで', 'いて', 'いで', 'して', 'うて'];
           const hasValidEnding = validEndings.some(ending =>
             teForm.endsWith(ending),
           );
           expect(hasValidEnding).toBe(true);
         }),
         { numRuns: 100 },
+      );
+    });
+
+    it('conjugateGodan uses う音便 forms in derived conjugations', () => {
+      const forms = conjugateGodan(classifyVerb('恋う'));
+
+      expect(forms.find(form => form.id === 'te')?.hiragana).toBe('恋うて');
+      expect(forms.find(form => form.id === 'ta')?.hiragana).toBe('恋うた');
+      expect(forms.find(form => form.id === 'conditional-tara')?.hiragana).toBe(
+        '恋うたら',
+      );
+      expect(forms.find(form => form.id === 'progressive-present')?.hiragana).toBe(
+        '恋うている',
       );
     });
   });

--- a/features/Conjugator/__tests__/teForm.property.test.ts
+++ b/features/Conjugator/__tests__/teForm.property.test.ts
@@ -99,6 +99,16 @@ const KU_ENDING_VERBS = [
 const IKU_VERB = { verb: '行く', teForm: '行って', taForm: '行った' };
 
 /**
+ * う音便 exception verbs (問う, 請う, 乞う): te-form うて / ta-form うた,
+ * not the regular って / った.
+ */
+const U_ONBIN_VERBS = [
+  { verb: '問う', teForm: '問うて', taForm: '問うた' },
+  { verb: '請う', teForm: '請うて', taForm: '請うた' },
+  { verb: '乞う', teForm: '乞うて', taForm: '乞うた' },
+];
+
+/**
  * Godan verbs ending in ぐ (Requirements: 4.5)
  * Te-form: ぐ → いで
  */
@@ -239,6 +249,16 @@ describe('Te-form Sound Changes Properties', () => {
       expect(teForm.endsWith('いて')).toBe(false);
     });
 
+    it('問う/請う/乞う produce うて te-form, not って (う音便)', () => {
+      U_ONBIN_VERBS.forEach(verbData => {
+        const verbInfo = classifyVerb(verbData.verb);
+        const teForm = getGodanTeForm(verbInfo);
+        expect(teForm).toBe(verbData.teForm);
+        // Must NOT collapse to the regular って form (e.g. 問って)
+        expect(teForm.endsWith('って')).toBe(false);
+      });
+    });
+
     it('ぐ-ending verbs produce いで te-form (Requirements: 4.5)', () => {
       fc.assert(
         fc.property(fc.constantFrom(...GU_ENDING_VERBS), verbData => {
@@ -272,6 +292,15 @@ describe('Te-form Sound Changes Properties', () => {
         }),
         { numRuns: 100 },
       );
+    });
+
+    it('問う/請う/乞う produce うた ta-form, not った (う音便)', () => {
+      U_ONBIN_VERBS.forEach(verbData => {
+        const verbInfo = classifyVerb(verbData.verb);
+        const taForm = getGodanTaForm(verbInfo);
+        expect(taForm).toBe(verbData.taForm);
+        expect(taForm.endsWith('った')).toBe(false);
+      });
     });
 
     it('te-form preserves verb stem', () => {

--- a/features/Conjugator/lib/engine/conjugateGodan.ts
+++ b/features/Conjugator/lib/engine/conjugateGodan.ts
@@ -67,21 +67,29 @@ function isIkuVerb(verb: VerbInfo): boolean {
 }
 
 /**
- * Special handling for the う音便 (u-euphony) verbs 問う, 請う, 乞う
- * (and their kana readings とう, こう).
+ * Dictionary forms with the う音便 (u-euphony) te/ta form.
  *
- * These are the exceptions to the regular う → って change: their te-form
- * ends in うて and their ta-form in うた, e.g. 問う → 問うて / 問うた
- * (not 問って / 問った). Regular う-verbs such as 買う → 買って are unaffected.
+ * This is a lexical exception to the regular う → って/った sound change.
+ * Both kanji and kana inputs must be listed because classifyVerb preserves the
+ * user's input rather than normalizing it to a reading.
  */
+const U_ONBIN_DICTIONARY_FORMS = new Set([
+  '問う',
+  '訪う',
+  'とう',
+  '請う',
+  '乞う',
+  '恋う',
+  'こう',
+  '給う',
+  '賜う',
+  'たまう',
+  '厭う',
+  'いとう',
+]);
+
 function isUOnbinVerb(verb: VerbInfo): boolean {
-  return (
-    verb.dictionaryForm === '問う' ||
-    verb.dictionaryForm === 'とう' ||
-    verb.dictionaryForm === '請う' ||
-    verb.dictionaryForm === '乞う' ||
-    verb.dictionaryForm === 'こう'
-  );
+  return U_ONBIN_DICTIONARY_FORMS.has(verb.dictionaryForm);
 }
 
 /**

--- a/features/Conjugator/lib/engine/conjugateGodan.ts
+++ b/features/Conjugator/lib/engine/conjugateGodan.ts
@@ -67,6 +67,24 @@ function isIkuVerb(verb: VerbInfo): boolean {
 }
 
 /**
+ * Special handling for the う音便 (u-euphony) verbs 問う, 請う, 乞う
+ * (and their kana readings とう, こう).
+ *
+ * These are the exceptions to the regular う → って change: their te-form
+ * ends in うて and their ta-form in うた, e.g. 問う → 問うて / 問うた
+ * (not 問って / 問った). Regular う-verbs such as 買う → 買って are unaffected.
+ */
+function isUOnbinVerb(verb: VerbInfo): boolean {
+  return (
+    verb.dictionaryForm === '問う' ||
+    verb.dictionaryForm === 'とう' ||
+    verb.dictionaryForm === '請う' ||
+    verb.dictionaryForm === '乞う' ||
+    verb.dictionaryForm === 'こう'
+  );
+}
+
+/**
  * Get te-form for a Godan verb with proper sound changes
  *
  * Requirements: 4.1-4.6
@@ -75,11 +93,17 @@ function isIkuVerb(verb: VerbInfo): boolean {
  * - く → いて (except 行く → 行って)
  * - ぐ → いで
  * - す → して
+ * - 問う/請う/乞う → 問うて/請うて/乞うて (う音便 exception)
  */
 export function getGodanTeForm(verb: VerbInfo): string {
   // Special case for 行く
   if (isIkuVerb(verb)) {
     return verb.stem + 'って';
+  }
+
+  // Special case for the う音便 verbs (問う, 請う, 乞う)
+  if (isUOnbinVerb(verb)) {
+    return verb.stem + 'うて';
   }
 
   return getGodanStem(verb, 'te');
@@ -93,6 +117,11 @@ export function getGodanTaForm(verb: VerbInfo): string {
   // Special case for 行く
   if (isIkuVerb(verb)) {
     return verb.stem + 'った';
+  }
+
+  // Special case for the う音便 verbs (問う, 請う, 乞う)
+  if (isUOnbinVerb(verb)) {
+    return verb.stem + 'うた';
   }
 
   return getGodanStem(verb, 'ta');


### PR DESCRIPTION
## 📝 Description

The verbs **問う**, **請う** and **乞う** are the う音便 (u-euphony) exceptions among godan う-verbs. Their te-form ends in **うて** and ta-form in **うた** (問う → 問うて / 問うた), unlike regular う-verbs which take って / った (買う → 買って).

The conjugator applied the default `う → って` change to them, so `conjugate('問う')` returned the incorrect **問って / 問った** (and likewise 請って, 乞って).

The fix mirrors the engine's existing 行く exception (`isIkuVerb` in `conjugateGodan.ts`): a new `isUOnbinVerb` guard in `getGodanTeForm` / `getGodanTaForm` returns `stem + うて` / `stem + うた` for these verbs (matched on dictionary forms 問う/請う/乞う and the kana readings とう/こう). Regular う-verbs are untouched.

## 🔗 Related Issue

N/A — bug found while reading the conjugation engine; documented here.

## ✅ Pre-Submission Checklist

- [ ] I have starred the repo ⭐
- [x] My code follows the project's code style
- [x] I have run `npm run check` locally — my changed files are TypeScript/ESLint clean (the only pre-existing errors on a fresh clone are an unrelated missing `commitInfo.json` build artifact)
- [x] My commit messages follow Conventional Commits
- [ ] I have updated the documentation (not applicable)
- [x] This PR is against the `main` branch

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?

Added te-form and ta-form assertions for 問う/請う/乞う to `teForm.property.test.ts` (they must produce うて/うた and must **not** end in って/った).

Verified locally:
- `conjugate('問う')` → te `問うて`, ta `問うた` (same for 請う, 乞う)
- Regular verbs unchanged: 買う → 買って, 言う → 言って, 会う → 会って, 待つ → 待って
- Conjugator suites pass: `teForm.property` (15/15), `conjugate.property`, `irregularVerbs`. The failing tests on a fresh clone are pre-existing, environment-dependent SEO/store tests that fail identically on unmodified `main`.

## 📦 Additional Context

問う/請う/乞う are the standard ウ音便 exceptions in Japanese grammar references (te-form うて). This extends the same exception mechanism the engine already applies to 行く.
