### PR TITLE
Update japanese-proverbs.json

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -484,5 +484,11 @@
   "romaji": "Tabi wa michizure yo wa nasake",
   "english": "Travel needs companions; life needs kindness",
   "meaning": "Relationships and compassion matter"
+},
+  {
+  "japanese": "後悔先に立たず",
+  "romaji": "Koukai saki ni tatazu",
+  "english": "Regret does not stand before",
+  "meaning": "It's too late for regrets"
 }
 ]


### PR DESCRIPTION
## 📝 Description

Added a new traditional Japanese proverb to the community content collection.

### Changes Made
- Added the proverb **後悔先に立たず**
- Included its romaji pronunciation: **Koukai saki ni tatazu**
- Added the English translation: **Regret does not stand before**
- Added the meaning: **It's too late for regrets**
- Maintained valid JSON formatting by adding the required comma before the new entry

---

## 🔗 Related Issue

Closes #24749

---

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [ ] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

---

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes
- [ ] `refactor`: Code refactor
- [ ] `test`: Test update
- [ ] `chore`: Build, CI/CD, or dependency updates

---

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Opened `community/content/japanese-proverbs.json`.
2. Added the new proverb object at the end of the JSON array.
3. Verified that the JSON syntax is valid.
4. Confirmed all required fields (`japanese`, `romaji`, `english`, `meaning`) are present.

---

## 📸 Screenshots/Videos (if applicable)

N/A

---

## 📦 Additional Context

This contribution adds another traditional Japanese proverb to the repository, helping expand the community-maintained learning resources while following the repository's contribution guidelines.