### PR TITLE
feat(theme): add Plum Wood theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -490,5 +490,11 @@
   "backgroundColor": "oklch(20.0% 0.035 225.0 / 1)",
   "mainColor": "oklch(80.0% 0.120 210.0 / 1)",
   "secondaryColor": "oklch(70.0% 0.085 195.0 / 1)"
+},
+{
+  "id": "plum-wood",
+  "backgroundColor": "oklch(24.0% 0.030 20.0 / 1)",
+  "mainColor": "oklch(72.0% 0.145 5.0 / 1)",
+  "secondaryColor": "oklch(60.0% 0.080 40.0 / 1)"
 }
 ]


### PR DESCRIPTION
Closes #24902

Adds the **Plum Wood** community color theme to `community/content/community-themes.json`.

| Property | Value |
|----------|-------|
| ID | `plum-wood` |
| Background | `oklch(24.0% 0.030 20.0 / 1)` |
| Main | `oklch(72.0% 0.145 5.0 / 1)` |
| Secondary | `oklch(60.0% 0.080 40.0 / 1)` |

Vibe: ume blossoms and carved trays. JSON validated (parses cleanly, 83 themes total).

Made with [Cursor](https://cursor.com)