### PR TITLE
chore(eslint): fix eslint warnings in BackToTop

### DIFF
--- a/shared/ui-composite/navigation/BackToTop.tsx
+++ b/shared/ui-composite/navigation/BackToTop.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronsUp } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
@@ -68,7 +69,6 @@ export default function BackToTop() {
   const { playClick } = useClick();
 
   const [visible, setVisible] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
   const [stableVh, setStableVh] = useState('100dvh');
   const [isEntering, setIsEntering] = useState(false);
   const [isExiting, setIsExiting] = useState(false);
@@ -155,8 +155,6 @@ export default function BackToTop() {
   }, []);
 
   useEffect(() => {
-    const mounted = true;
-    setIsMounted(mounted);
     updateStableVh(true);
 
     if (typeof document === 'undefined') return;
@@ -189,7 +187,7 @@ export default function BackToTop() {
 
   const isRootPath = pathname === '/' || pathname === '';
 
-  if (!isMounted || isRootPath) return null;
+  if (isRootPath) return null;
   if (!visible && !isExiting) return null;
 
   const handleClick = () => {
@@ -250,7 +248,7 @@ export default function BackToTop() {
         }
       : {};
 
-  const getExplosionStyle = (): React.CSSProperties => {
+  const getExplosionStyle = (): CSSProperties => {
     if (!USE_EXPLOSION_ANIMATION) return {};
 
     switch (animState) {
@@ -287,7 +285,7 @@ export default function BackToTop() {
           '--stable-vh': stableVh,
           ...animationStyle,
           ...getExplosionStyle(),
-        } as unknown as React.CSSProperties
+        } as unknown as CSSProperties
       }
     >
       <ChevronsUp size={USE_FLOATING_STYLE ? 24 : 32} strokeWidth={2.5} />


### PR DESCRIPTION
## 📝 Description

This fixes ESLint warnings being generated by the `shared/ui-composite/navigation/BackToTop.tsx` file.

## 🔗 Related Issue

Related to #23381.

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [x] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  `npm run check`
2.  `npm run test`

