### PR TITLE
chore(eslint): suppress eslint false-positive

### DIFF
--- a/shared/ui-composite/navigation/BackToTop.tsx
+++ b/shared/ui-composite/navigation/BackToTop.tsx
@@ -155,6 +155,18 @@ export default function BackToTop() {
   }, []);
 
   useEffect(() => {
+    // `window.innerHeight`/`visualViewport.height` don't exist during SSR, so
+    // `stableVh` starts at the SSR-safe literal '100dvh' and can only be
+    // resolved to a real pixel value once we're guaranteed to be on the
+    // client (i.e. inside an effect, after mount). Reading it eagerly in the
+    // component body (or via a lazy useState initializer) would run during
+    // the client's hydration render too, producing a different value than
+    // the server-rendered markup and causing a hydration mismatch on the
+    // '--stable-vh' style property. This is a legitimate one-time
+    // measurement of an external, browser-only value on mount, not the
+    // "subscribe then setState in a callback" shape the rule expects, so the
+    // warning here is a false positive for this pattern.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     updateStableVh(true);
 
     if (typeof document === 'undefined') return;


### PR DESCRIPTION
## 📝 Description

Suppresses a false-positive from ESLint. In this specific case I feel we should suppress the warning, see the comment added in the code for more details.

## 🔗 Related Issue

Relates to #23381 

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [x] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  `npm run check`
2.  `./node_modules/.bin/eslint shared/ui-composite/navigation/BackToTop.tsx`