### PR TITLE
fix(kana): accept alternative romanizations in Blitz and Gauntlet

### DIFF
--- a/features/Kana/components/Blitz.tsx
+++ b/features/Kana/components/Blitz.tsx
@@ -6,6 +6,7 @@ import { useStatsStore } from '@/features/Progress';
 import { generateKanaQuestion } from '@/features/Kana/lib/generateKanaQuestions';
 import { flattenKanaGroups } from '@/features/Kana/lib/flattenKanaGroup';
 import type { KanaCharacter } from '@/features/Kana/lib/flattenKanaGroup';
+import { isKanaGameAnswerCorrect } from '@/features/Kana/lib/isKanaGameAnswerCorrect';
 import { getSelectionLabels } from '@/shared/utils/selectionFormatting';
 import { shuffle } from '@/shared/utils/shuffle';
 import Blitz, { type BlitzConfig } from '@/shared/ui-composite/Blitz';
@@ -52,14 +53,8 @@ export default function BlitzKana() {
       isReverse ? question.romaji : question.kana,
     inputPlaceholder: 'Type the romaji...',
     modeDescription: 'Mode: Type (See kana → Type romaji)',
-    checkAnswer: (question, answer, isReverse) => {
-      if (isReverse) {
-        // Reverse: answer should be the kana character
-        return answer.trim() === question.kana;
-      }
-      // Normal: answer should match romaji
-      return answer.toLowerCase() === question.romaji.toLowerCase();
-    },
+    checkAnswer: (question, answer, isReverse) =>
+      isKanaGameAnswerCorrect(question, answer, isReverse),
     getCorrectAnswer: (question, isReverse) =>
       isReverse ? question.kana : question.romaji,
     // Pick mode support with reverse mode
@@ -99,4 +94,3 @@ export default function BlitzKana() {
 
   return <Blitz config={config} />;
 }
-

--- a/features/Kana/components/Gauntlet.tsx
+++ b/features/Kana/components/Gauntlet.tsx
@@ -5,6 +5,7 @@ import useKanaStore from '@/features/Kana/store/useKanaStore';
 import { generateKanaQuestion } from '@/features/Kana/lib/generateKanaQuestions';
 import { flattenKanaGroups } from '@/features/Kana/lib/flattenKanaGroup';
 import type { KanaCharacter } from '@/features/Kana/lib/flattenKanaGroup';
+import { isKanaGameAnswerCorrect } from '@/features/Kana/lib/isKanaGameAnswerCorrect';
 import { getSelectionLabels } from '@/shared/utils/selectionFormatting';
 import { shuffle } from '@/shared/utils/shuffle';
 import Gauntlet, { type GauntletConfig } from '@/shared/ui-composite/Gauntlet';
@@ -39,12 +40,8 @@ const GauntletKana: React.FC<GauntletKanaProps> = ({ onCancel }) => {
     generateQuestion: items => generateKanaQuestion(items),
     renderQuestion: (question, isReverse) =>
       isReverse ? question.romaji : question.kana,
-    checkAnswer: (question, answer, isReverse) => {
-      if (isReverse) {
-        return answer.trim() === question.kana;
-      }
-      return answer.toLowerCase() === question.romaji.toLowerCase();
-    },
+    checkAnswer: (question, answer, isReverse) =>
+      isKanaGameAnswerCorrect(question, answer, isReverse),
     getCorrectAnswer: (question, isReverse) =>
       isReverse ? question.kana : question.romaji,
     generateOptions: (question, items, count, isReverse) => {
@@ -86,4 +83,3 @@ const GauntletKana: React.FC<GauntletKanaProps> = ({ onCancel }) => {
 };
 
 export default GauntletKana;
-

--- a/features/Kana/lib/flattenKanaGroup.ts
+++ b/features/Kana/lib/flattenKanaGroup.ts
@@ -3,6 +3,7 @@ import { kana } from '../data/kana';
 export type KanaCharacter = {
   kana: string;
   romaji: string;
+  altRomanji: string[];
   group: string;
 };
 
@@ -13,6 +14,7 @@ export function flattenKanaGroups(indices: number[]): KanaCharacter[] {
     return group.kana.map((char, idx) => ({
       kana: char,
       romaji: group.romanji[idx],
+      altRomanji: group.altRomanji?.[idx] ?? [],
       group: group.groupName,
     }));
   });

--- a/features/Kana/lib/isKanaGameAnswerCorrect.test.ts
+++ b/features/Kana/lib/isKanaGameAnswerCorrect.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { isKanaGameAnswerCorrect } from './isKanaGameAnswerCorrect';
+
+const shi = { kana: 'し', romaji: 'shi', altRomanji: ['si'] };
+const a = { kana: 'あ', romaji: 'a', altRomanji: [] };
+
+describe('isKanaGameAnswerCorrect', () => {
+  it('accepts the primary romaji (case- and whitespace-insensitive)', () => {
+    expect(isKanaGameAnswerCorrect(shi, 'shi', false)).toBe(true);
+    expect(isKanaGameAnswerCorrect(shi, 'SHI', false)).toBe(true);
+    expect(isKanaGameAnswerCorrect(shi, ' shi ', false)).toBe(true);
+  });
+
+  it('accepts alternative romanizations in normal mode', () => {
+    // Regression: Blitz/Gauntlet previously only accepted the primary romaji,
+    // so "si" for し was wrongly marked incorrect while the main Type mode
+    // accepted it.
+    expect(isKanaGameAnswerCorrect(shi, 'si', false)).toBe(true);
+    expect(isKanaGameAnswerCorrect(shi, 'SI', false)).toBe(true);
+  });
+
+  it('rejects an incorrect romaji', () => {
+    expect(isKanaGameAnswerCorrect(shi, 'su', false)).toBe(false);
+    expect(isKanaGameAnswerCorrect(a, 'si', false)).toBe(false);
+  });
+
+  it('matches the kana character itself in reverse mode', () => {
+    expect(isKanaGameAnswerCorrect(shi, 'し', true)).toBe(true);
+    expect(isKanaGameAnswerCorrect(shi, ' し ', true)).toBe(true);
+    expect(isKanaGameAnswerCorrect(shi, 'shi', true)).toBe(false);
+  });
+});

--- a/features/Kana/lib/isKanaGameAnswerCorrect.ts
+++ b/features/Kana/lib/isKanaGameAnswerCorrect.ts
@@ -1,0 +1,27 @@
+import type { KanaCharacter } from './flattenKanaGroup';
+
+/**
+ * Shared answer check for the Kana game modes (Blitz, Gauntlet, ...).
+ *
+ * In normal mode the user types romaji: the primary romanization and any
+ * registered alternative (e.g. "si" for し, "hu" for ふ) are accepted, matching
+ * the main Type mode. In reverse mode the user types the kana character itself.
+ *
+ * Centralising this keeps the modes consistent - previously Blitz and Gauntlet
+ * only accepted the primary romaji, so alternatives valid in the main mode were
+ * marked wrong.
+ */
+export const isKanaGameAnswerCorrect = (
+  question: Pick<KanaCharacter, 'kana' | 'romaji' | 'altRomanji'>,
+  answer: string,
+  isReverse: boolean | undefined,
+): boolean => {
+  if (isReverse) {
+    return answer.trim() === question.kana;
+  }
+  const normalized = answer.trim().toLowerCase();
+  return (
+    normalized === question.romaji.toLowerCase() ||
+    question.altRomanji.some(alt => normalized === alt.toLowerCase())
+  );
+};


### PR DESCRIPTION
Alternative romanizations are accepted in the main Type mode but rejected in Blitz and Gauntlet. This makes the modes consistent.

## Problem

`features/Kana/data/kana.ts` defines alternative romanizations per character (`altRomanji`) - e.g. し -> `si`, ふ -> `hu`, ん -> `nn`. The main Type mode honours them via `isKanaInputAnswerCorrect` + `altRomanjiMap`, so typing `si` for し is correct there.

Blitz and Gauntlet re-implemented the answer check independently:

```ts
return answer.toLowerCase() === question.romaji.toLowerCase();
```

That only accepts the primary romaji, so `si` for し is marked **wrong** in those modes. The same input is correct in one mode and incorrect in another.

## Fix

- `flattenKanaGroups` now carries `altRomanji` onto each `KanaCharacter`. It was being dropped during flattening, which is why the game modes had no access to it.
- Extracted `isKanaGameAnswerCorrect`, a shared helper both Blitz and Gauntlet now use, so the two copies of the matching rules cannot drift apart again. It accepts the primary romaji and any registered alternative (case- and whitespace-insensitive); reverse mode still matches the kana character itself, unchanged.

## Tests

Added `isKanaGameAnswerCorrect.test.ts` covering the primary romaji, the alternatives (the regression), incorrect input, and reverse mode. The full `features/Kana` suite passes (15 tests), and `tsc --noEmit`, eslint and prettier are clean.