### PR TITLE
fix: add bottom padding to theme picker modal scroll container

### DIFF
--- a/shared/ui-composite/Modals/WelcomeModal.tsx
+++ b/shared/ui-composite/Modals/WelcomeModal.tsx
@@ -469,7 +469,7 @@ const WelcomeModal = () => {
               </p>
             </div>
 
-            <div className='scrollbar-thin scrollbar-thumb-(--border-color) scrollbar-track-transparent max-h-[45vh] space-y-6 overflow-y-auto px-1 sm:max-h-96'>
+            <div className='scrollbar-thin scrollbar-thumb-(--border-color) scrollbar-track-transparent max-h-[45vh] space-y-6 overflow-y-auto px-1 pb-18 sm:max-h-96'>
               {themeSets
                 .filter(
                   themeSet =>


### PR DESCRIPTION
## Summary
- Adds `pb-18` to the scrollable theme grid container in the "Choose Your Theme" onboarding modal
- Fixes the last row of theme cards being clipped when scrolled to the bottom

Closes #23811

## Test plan
- [x] Ran `npm run dev`, opened the theme picker modal, scrolled to the bottom, confirmed the last row is now fully visible