### PR TITLE
fix(about): make "View on GitHub" button text visible under all themes

### DIFF
--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -221,7 +221,7 @@ export default function AboutPage() {
         href='https://github.com/lingdojo/kanadojo'
         target='_blank'
         rel='noopener noreferrer'
-        className='mb-12 inline-flex items-center gap-2 rounded-lg bg-(--main-color) px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90'
+        className='mb-12 inline-flex items-center gap-2 rounded-lg bg-(--main-color) px-6 py-3 font-semibold text-(--background-color) transition-opacity hover:opacity-90'
       >
         View on GitHub →
       </a>
@@ -260,4 +260,3 @@ export default function AboutPage() {
     </LegalLayout>
   );
 }
-


### PR DESCRIPTION
## Summary
Fixes #25874. In the About page **Open Source** section, the "View on GitHub →" button hardcoded `text-white` on a `bg-(--main-color)` background. Themes whose `--main-color` is light (e.g. **Crimson Coder**) render the white label invisibly, so the button looks blank.

This switches the label to the theme-adaptive **`text-(--background-color)`** — the convention already used for `bg-(--main-color)` buttons across the codebase (ActionButton, button, Sidebar, SessionSummaryScreen, …) — so the text stays legible under every theme.

## Test
- `npm run check` (`tsc --noEmit` + `eslint`) passes with 0 errors.
- Confirmed the "View on GitHub" label is visible under Crimson Coder and other light `--main-color` themes.

## Pre-merge checklist
- [x] Starred the repo ⭐
- [x] Code follows project style guidelines
- [x] Changes tested locally (`npm run check`)
- [x] PR title is descriptive
- [x] Linked issue with `Closes #25874`

Closes #25874

---
<sub>Independently cross-reviewed with a second AI model before submission.</sub>
