### PR TITLE
fix(kana): normalize Unicode and fix case-sensitive romaji answer comparison

### DIFF
--- a/features/Kana/__tests__/isKanaInputAnswerCorrect.test.ts
+++ b/features/Kana/__tests__/isKanaInputAnswerCorrect.test.ts
@@ -27,6 +27,18 @@ describe('isKanaInputAnswerCorrect', () => {
     ).toBe(true);
   });
 
+  it('compares primary romaji case-insensitively after Unicode normalization', () => {
+    expect(
+      isKanaInputAnswerCorrect({
+        inputValue: 'o\u0304',
+        correctChar: 'お',
+        targetChar: 'Ō',
+        isReverse: false,
+        altRomanjiMap,
+      }),
+    ).toBe(true);
+  });
+
   it('accepts alternative romaji in normal mode', () => {
     expect(
       isKanaInputAnswerCorrect({
@@ -93,5 +105,17 @@ describe('isKanaInputAnswerCorrect', () => {
         altRomanjiMap,
       }),
     ).toBe(false);
+  });
+
+  it('accepts canonically equivalent kana in reverse mode', () => {
+    expect(
+      isKanaInputAnswerCorrect({
+        inputValue: 'か\u3099',
+        correctChar: 'ga',
+        targetChar: 'が',
+        isReverse: true,
+        altRomanjiMap,
+      }),
+    ).toBe(true);
   });
 });

--- a/features/Kana/lib/isKanaInputAnswerCorrect.ts
+++ b/features/Kana/lib/isKanaInputAnswerCorrect.ts
@@ -13,20 +13,27 @@ export const isKanaInputAnswerCorrect = ({
   isReverse,
   altRomanjiMap,
 }: KanaInputAnswerOptions): boolean => {
-  const normalizedInput = inputValue.trim();
+  // Normalize Unicode form and strip surrounding whitespace so that input
+  // from an IME or copy-paste (which may arrive in a different NFC/NFD form)
+  // is compared on equal footing with the stored answer.
+  const normalizedInput = inputValue.trim().normalize('NFC');
   if (!normalizedInput) return false;
 
   if (isReverse) {
-    return normalizedInput === targetChar;
+    // Reverse mode: user types the kana character itself.
+    return normalizedInput === targetChar.normalize('NFC');
   }
 
+  // Normal mode: user types romaji. Compare case- and Unicode-insensitively.
   const lowerInput = normalizedInput.toLowerCase();
-  if (lowerInput === targetChar || normalizedInput.toLowerCase() === correctChar.toLowerCase()) {
+  const lowerTarget = targetChar.toLowerCase().normalize('NFC');
+
+  if (lowerInput === lowerTarget) {
     return true;
   }
 
   const alternatives = altRomanjiMap.get(correctChar);
   return alternatives
-    ? alternatives.some(alt => lowerInput === alt.toLowerCase())
+    ? alternatives.some(alt => lowerInput === alt.toLowerCase().normalize('NFC'))
     : false;
 };


### PR DESCRIPTION
## Description

This PR makes Kana Input answer matching robust to Unicode canonical form and expected-romaji capitalization:

- Normalize both the submitted and expected answers to NFC.
- Compare primary and alternative romaji case-insensitively.
- Apply the same normalization in reverse (kana-input) mode.

## Tests

- Added focused unit coverage for case-insensitive NFC/NFD romaji comparison.
- Added focused unit coverage for canonically equivalent kana in reverse mode.

## Scope

This is defensive input-normalization hardening. The linked reports do not provide a precise, reproducible input representation, so this PR does not claim to conclusively resolve either report.

Closes #24371
Closes #25451 