### PR TITLE
feat(theme): add Bamboo Mist theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -328,5 +328,11 @@
     "backgroundColor": "oklch(20.0% 0.040 235.0 / 1)",
     "mainColor": "oklch(78.0% 0.205 35.0 / 1)",
     "secondaryColor": "oklch(88.0% 0.065 210.0 / 1)"
+  },
+  {
+    "id": "bamboo-mist",
+    "backgroundColor": "oklch(24.0% 0.032 150.0 / 1)",
+    "mainColor": "oklch(78.0% 0.145 145.0 / 1)",
+    "secondaryColor": "oklch(68.0% 0.085 130.0 / 1)"
   }
 ]

--- a/community/content/community-themes.test.ts
+++ b/community/content/community-themes.test.ts
@@ -67,4 +67,16 @@ describe('community-themes.json', () => {
   it('yukata-blue should have a unique id among themes', () => {
     expect(themes.filter(t => t.id === 'yukata-blue').length).toBe(1);
   });
+
+  it('should contain the bamboo-mist theme with correct colors', () => {
+    const theme = themes.find(t => t.id === 'bamboo-mist');
+    expect(theme).toBeDefined();
+    expect(theme).toHaveProperty('backgroundColor', 'oklch(24.0% 0.032 150.0 / 1)');
+    expect(theme).toHaveProperty('mainColor', 'oklch(78.0% 0.145 145.0 / 1)');
+    expect(theme).toHaveProperty('secondaryColor', 'oklch(68.0% 0.085 130.0 / 1)');
+  });
+
+  it('bamboo-mist should have a unique id among themes', () => {
+    expect(themes.filter(t => t.id === 'bamboo-mist').length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

- add the Bamboo Mist community theme with the requested OKLCH colors
- add regression coverage for its exact colors and unique ID

## Testing

- `npx vitest run community/content/community-themes.test.ts -t bamboo-mist`
- `npm run check`

Closes #26073