### PR TITLE
fix(game): prevent rapid double clicks from skipping MCQ questions

### DIFF
--- a/features/Kana/components/Game/MCQ.tsx
+++ b/features/Kana/components/Game/MCQ.tsx
@@ -131,6 +131,8 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
 
   const kanaGroupIndices = useKanaStore(state => state.kanaGroupIndices);
 
+  const isProcessingRef = useRef(false);
+
   const selectedKana = useMemo(
     () => kanaGroupIndices.map(i => kana[i].kana).flat(),
     [kanaGroupIndices],
@@ -279,6 +281,10 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
     getIncorrectOptions,
   ]);
 
+  useEffect(() => {
+    isProcessingRef.current = false;
+  }, [correctKanaChar, correctRomajiCharReverse, wrongSelectedAnswers]);
+
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {
@@ -422,6 +428,9 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
 
   const handleOptionClick = useCallback(
     (selectedChar: string) => {
+      if (isProcessingRef.current) return;
+      isProcessingRef.current = true;
+
       if (!isReverse) {
         // Normal pick mode logic
         if (selectedChar === correctRomajiChar) {

--- a/features/Kanji/components/Game/MCQ.tsx
+++ b/features/Kanji/components/Game/MCQ.tsx
@@ -163,6 +163,8 @@ const KanjiMCQ = ({ selectedKanjiObjs, isHidden }: KanjiMCQProps) => {
     correctKanjiObj as IKanjiObj,
   );
 
+  const isProcessingRef = useRef(false);
+
   // What to display as the question
   const displayChar = isReverse ? correctKanjiObj?.meanings[0] : correctChar;
 
@@ -210,6 +212,7 @@ const KanjiMCQ = ({ selectedKanjiObjs, isHidden }: KanjiMCQProps) => {
 
   // Update shuffled options when correctChar or isReverse changes
   useEffect(() => {
+    isProcessingRef.current = false;
     setShuffledOptions(
       [targetChar, ...getIncorrectOptions()].sort(
         () => random.real(0, 1) - 0.5,
@@ -241,6 +244,9 @@ const KanjiMCQ = ({ selectedKanjiObjs, isHidden }: KanjiMCQProps) => {
 
   // Handle tiles mode correct answer
   const handleOptionClick = (selectedOption: string) => {
+    if (isProcessingRef.current) return;
+    isProcessingRef.current = true;
+
     if (selectedOption === targetChar) {
       setDisplayAnswerSummary(true);
       handleCorrectAnswer();

--- a/features/Kanji/components/Game/MCQ.tsx
+++ b/features/Kanji/components/Game/MCQ.tsx
@@ -221,6 +221,13 @@ const KanjiMCQ = ({ selectedKanjiObjs, isHidden }: KanjiMCQProps) => {
     setWrongSelectedAnswers([]);
   }, [correctChar, isReverse]);
 
+  // A wrong answer keeps the current prompt on screen. Release the synchronous
+  // event lock only after its disabled-button state has committed, so another
+  // available option can be selected without accepting duplicate rapid input.
+  useEffect(() => {
+    isProcessingRef.current = false;
+  }, [wrongSelectedAnswers]);
+
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {

--- a/features/Vocabulary/components/Game/MCQ.tsx
+++ b/features/Vocabulary/components/Game/MCQ.tsx
@@ -175,6 +175,8 @@ const VocabMCQ = ({ selectedWordObjs, isHidden }: VocabMCQProps) => {
     correctWordObj as IVocabObj,
   );
 
+  const isProcessingRef = useRef(false);
+
   // What to display as the question
   const displayChar = isReverse ? correctWordObj?.meanings[0] : correctChar;
 
@@ -224,6 +226,7 @@ const VocabMCQ = ({ selectedWordObjs, isHidden }: VocabMCQProps) => {
 
   // Update shuffled options when correctChar or isReverse changes
   useEffect(() => {
+    isProcessingRef.current = false;
     if (!hasWords) return;
     setShuffledOptions(
       [targetChar ?? '', ...getIncorrectOptions()].sort(
@@ -252,6 +255,9 @@ const VocabMCQ = ({ selectedWordObjs, isHidden }: VocabMCQProps) => {
   }, [hasWords, shuffledOptions.length]);
 
   const handleOptionClick = (selectedOption: string) => {
+    if (isProcessingRef.current) return;
+    isProcessingRef.current = true;
+
     if (selectedOption === targetChar) {
       setDisplayAnswerSummary(true);
       handleCorrectAnswer();

--- a/features/Vocabulary/components/Game/MCQ.tsx
+++ b/features/Vocabulary/components/Game/MCQ.tsx
@@ -236,6 +236,13 @@ const VocabMCQ = ({ selectedWordObjs, isHidden }: VocabMCQProps) => {
     setWrongSelectedAnswers([]);
   }, [correctChar, hasWords, isReverse, quizType]);
 
+  // A wrong answer keeps the current prompt on screen. Release the synchronous
+  // event lock only after its disabled-button state has committed, so another
+  // available option can be selected without accepting duplicate rapid input.
+  useEffect(() => {
+    isProcessingRef.current = false;
+  }, [wrongSelectedAnswers]);
+
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   useEffect(() => {


### PR DESCRIPTION
## 📝 Description

Fixes #24296
Fixes #24292 

Users were experiencing instances where questions would randomly be skipped during MCQ rounds (and sometimes resulting in the game abruptly halting if they reached the end prematurely). 

This was caused by React's asynchronous state updates. When a user double-clicked or spammed the keyboard shortcut for an answer very quickly, the `handleOptionClick` method would fire multiple times before the component had a chance to render the next question. This resulted in the same answer being validated and counted multiple times, inadvertently skipping the next set of questions.

**Changes:**
- Added a strict `isProcessingRef` guard across all MCQ components (`Kana/MCQ.tsx`, `Kanji/MCQ.tsx`, `Vocabulary/MCQ.tsx`).
- The guard immediately locks upon the first click and automatically unlocks when the next question successfully renders.

## 🔗 Related Issue

Closes #24296
Closes #24292

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing ones)
- [ ] `chore`: Build process, dependency updates, or other miscellaneous changes