### PR TITLE
fix(data): correct kawa kanji and reading in N5 datasets

### DIFF
--- a/public/data-kanji/N5.json
+++ b/public/data-kanji/N5.json
@@ -861,7 +861,7 @@
       "sen セン"
     ],
     "kunyomi": [
-      "kawa カワ"
+      "kawa かわ"
     ],
     "meanings": [
       "river",

--- a/public/data-vocab/n5.json
+++ b/public/data-vocab/n5.json
@@ -1032,12 +1032,6 @@
     "waller_definition": "River"
   },
   {
-    "jmdict_seq": "1390020",
-    "kana": "かわ",
-    "kanji": "河",
-    "waller_definition": "River"
-  },
-  {
     "jmdict_seq": "1577200",
     "kana": "かわいい",
     "kanji": "",


### PR DESCRIPTION
## 📝 Description

This PR fixes an issue where the kanji for "kawa" (river) was incorrectly presented in the N5 dataset. 

Specifically:
- Removed the advanced N2 kanji `河` from `public/data-vocab/n5.json` so beginners only see the correct N5 kanji `川`.
- Fixed the kunyomi reading for `川` in `public/data-kanji/N5.json`, which was mistakenly written in katakana (`カワ`) instead of the correct hiragana (`かわ`).

## 🔗 Related Issue

Closes #25166

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Verified `public/data-vocab/n5.json` to ensure `河` is removed and `川` remains as the sole N5 kanji for river.
2. Verified `public/data-kanji/N5.json` to ensure the kunyomi reading for `川` properly displays as `かわ` in hiragana.

<!--
**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Content/Data verification
-->

## 📸 Screenshots/Videos (if applicable)

*N/A - backend data JSON changes only.*

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

The bug reported that the wrong kanji was displayed for "river" (kawa) in the app. This occurred because `河` was improperly included in the N5 vocab lists instead of sticking strictly to `川`.
