### PR TITLE
fix(kana): resolve identical kana causing quiz hang #24300

### DIFF
--- a/features/Kana/components/Game/TilesMode.tsx
+++ b/features/Kana/components/Game/TilesMode.tsx
@@ -212,9 +212,35 @@ const KanaTilesMode = ({
     const distractorSource = isReverse ? selectedKana : selectedRomaji;
     const distractors: string[] = [];
     const usedAnswers = new Set(answerChars);
+
+    const markIdenticalTwins = (char: string, set: Set<string> | string[]) => {
+      const add = (c: string) => {
+        if (set instanceof Set) set.add(c);
+        else if (!set.includes(c)) set.push(c);
+      };
+      if (char === 'へ') add('ヘ');
+      if (char === 'ヘ') add('へ');
+      if (char === 'べ') add('ベ');
+      if (char === 'ベ') add('べ');
+      if (char === 'ぺ') add('ペ');
+      if (char === 'ペ') add('ぺ');
+    };
+
+    answerChars.forEach(c => markIdenticalTwins(c, usedAnswers));
+
     for (let i = 0; i < distractorCount; i++) {
       const available = distractorSource.filter(
-        c => !usedAnswers.has(c) && !distractors.includes(c),
+        c => {
+          if (usedAnswers.has(c) || distractors.includes(c)) return false;
+          // Check if identical twin is already in distractors
+          if (c === 'へ' && distractors.includes('ヘ')) return false;
+          if (c === 'ヘ' && distractors.includes('へ')) return false;
+          if (c === 'べ' && distractors.includes('ベ')) return false;
+          if (c === 'ベ' && distractors.includes('べ')) return false;
+          if (c === 'ぺ' && distractors.includes('ペ')) return false;
+          if (c === 'ペ' && distractors.includes('ぺ')) return false;
+          return true;
+        }
       );
       if (available.length === 0) break;
       const selected = available[random.integer(0, available.length - 1)];

--- a/features/Kana/lib/getUniqueIncorrectOptions.ts
+++ b/features/Kana/lib/getUniqueIncorrectOptions.ts
@@ -8,11 +8,26 @@ export const getUniqueIncorrectOptions = (
   count: number,
 ): string[] => {
   const seen = new Set([correctAnswer]);
+
+  // Prevent identical-looking kana (へ/ヘ, べ/ベ, ぺ/ペ) from appearing together
+  const markIdenticalTwins = (char: string) => {
+    if (char === 'へ') seen.add('ヘ');
+    if (char === 'ヘ') seen.add('へ');
+    if (char === 'べ') seen.add('ベ');
+    if (char === 'ベ') seen.add('べ');
+    if (char === 'ぺ') seen.add('ペ');
+    if (char === 'ペ') seen.add('ぺ');
+  };
+
+  markIdenticalTwins(correctAnswer);
+
   const options: string[] = [];
 
   for (const candidate of candidates) {
     if (options.length >= count) break;
     if (seen.has(candidate)) continue;
+
+    markIdenticalTwins(candidate);
 
     seen.add(candidate);
     options.push(candidate);

--- a/features/Kana/lib/isKanaInputAnswerCorrect.ts
+++ b/features/Kana/lib/isKanaInputAnswerCorrect.ts
@@ -54,7 +54,20 @@ export const isKanaInputAnswerCorrect = ({
 
   if (isReverse) {
     // Reverse mode: user types the kana character itself.
-    return normalizedInput === targetChar.normalize('NFC');
+    // Replace identical-looking Katakana with Hiragana to prevent quiz hanging
+    // when users type one but the target is the other (e.g. へ / ヘ, べ / ベ, ぺ / ペ)
+    const inputForComparison = normalizedInput
+      .replace(/ヘ/g, 'へ')
+      .replace(/ベ/g, 'べ')
+      .replace(/ペ/g, 'ぺ');
+
+    const targetForComparison = targetChar
+      .normalize('NFC')
+      .replace(/ヘ/g, 'へ')
+      .replace(/ベ/g, 'べ')
+      .replace(/ペ/g, 'ぺ');
+
+    return inputForComparison === targetForComparison;
   }
 
   // Normal mode: user types romaji. Compare case- and Unicode-insensitively.


### PR DESCRIPTION
## 📝 Description

Fixes a bug where identical-looking Kana (such as Hiragana `へ` and Katakana `ヘ`, as well as `べ/ベ` and `ぺ/ペ`) cause quizzes to become impossible to complete or cause them to hang. 

Specifically, this PR makes the following changes:
- **Typing Quiz (`Input.tsx`)**: In reverse mode (where the prompt is Romaji and the user types Kana via an IME), the input checking logic in `isKanaInputAnswerCorrect.ts` now normalizes identical Katakana twins (ヘ, ベ, ペ) to their Hiragana forms before comparison. This ensures that typing the visual equivalent won't mark the answer as wrong, preventing users from getting indefinitely stuck.
- **Multiple Choice & Tiles Mode**: Updated `getUniqueIncorrectOptions.ts` and `TilesMode.tsx` distractor logic to ensure that an identical Kana twin is never randomly chosen as an incorrect option when the other is the correct answer.

## 🔗 Related Issue

Closes #24300

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Run a typing quiz (Input mode) with Reverse Mode enabled (where prompt is `he`). Verify that typing either Hiragana `へ` or Katakana `ヘ` is accepted as correct.
2. Run an MCQ and Tiles Mode quiz containing `he`. Verify that `へ` and `ヘ` never appear simultaneously as options on the same screen.
3. Verified the same behavior applies for `be` (べ/ベ) and `pe` (ぺ/ペ).

<!--
**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

*No visual UI changes. The identical characters just no longer appear simultaneously as distractors.*

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

This completely resolves the issue without needing to hack fonts or add visual text hints, maintaining the clean UI of the application.
