### PR TITLE
fix(input): accept optional infinitive prefix in meanings

### DIFF
--- a/features/Kanji/__tests__/isKanjiAnswerCorrect.test.ts
+++ b/features/Kanji/__tests__/isKanjiAnswerCorrect.test.ts
@@ -14,6 +14,26 @@ describe('isKanjiAnswerCorrect', () => {
     expect(isKanjiAnswerCorrect(kanji, ' china ', false)).toBe(true);
   });
 
+  it.each(['speak', 'Speak', 'to speak', '  TO   SPEAK  '])(
+    'accepts optional infinitive prefix in meaning answer %s',
+    answer => {
+      const verb = { ...kanji, meanings: ['to speak'] };
+
+      expect(isKanjiAnswerCorrect(verb, answer, false)).toBe(true);
+    },
+  );
+
+  it('does not remove an infinitive prefix from reverse answers', () => {
+    const prefixedReading = {
+      ...kanji,
+      kanjiChar: 'to speak',
+      kunyomi: [],
+      onyomi: [],
+    };
+
+    expect(isKanjiAnswerCorrect(prefixedReading, 'speak', true)).toBe(false);
+  });
+
   it.each([' 漢 ', ' から ', ' カン '])(
     'normalizes reverse answer %s',
     answer => {

--- a/features/Kanji/lib/isKanjiAnswerCorrect.ts
+++ b/features/Kanji/lib/isKanjiAnswerCorrect.ts
@@ -3,6 +3,9 @@ import type { IKanjiObj } from '@/entities/kanji';
 const normalize = (value: string): string =>
   value.trim().normalize('NFC').toLowerCase();
 
+const normalizeMeaning = (value: string): string =>
+  normalize(value).replace(/^to\s+/, '');
+
 const normalizeReading = (value: string): string =>
   normalize(value.split(' ')[0] ?? '');
 
@@ -11,12 +14,14 @@ export const isKanjiAnswerCorrect = (
   answer: string,
   isReverse: boolean | undefined,
 ): boolean => {
-  const normalizedAnswer = normalize(answer);
+  const normalizedAnswer = isReverse
+    ? normalize(answer)
+    : normalizeMeaning(answer);
   if (!normalizedAnswer) return false;
 
   if (!isReverse) {
     return kanji.meanings.some(
-      meaning => normalize(meaning) === normalizedAnswer,
+      meaning => normalizeMeaning(meaning) === normalizedAnswer,
     );
   }
 

--- a/features/Vocabulary/__tests__/isVocabularyMeaningAnswerCorrect.test.ts
+++ b/features/Vocabulary/__tests__/isVocabularyMeaningAnswerCorrect.test.ts
@@ -15,6 +15,27 @@ describe('isVocabularyMeaningAnswerCorrect', () => {
     );
   });
 
+  it.each(['speak', 'Speak', 'to speak', '  TO   SPEAK  '])(
+    'accepts optional infinitive prefix in meaning answer %s',
+    answer => {
+      const verb = { ...vocabulary, meanings: ['to speak'] };
+
+      expect(isVocabularyMeaningAnswerCorrect(verb, answer, false)).toBe(true);
+    },
+  );
+
+  it('does not remove an infinitive prefix from reverse answers', () => {
+    const prefixedWord = {
+      ...vocabulary,
+      word: 'to speak',
+      reading: 'to speak',
+    };
+
+    expect(
+      isVocabularyMeaningAnswerCorrect(prefixedWord, 'speak', true),
+    ).toBe(false);
+  });
+
   it.each([' アメリカ ', 'amerika', 'あめりか'])(
     'accepts reverse answer %s without requiring an IME',
     answer => {

--- a/features/Vocabulary/lib/isVocabularyMeaningAnswerCorrect.ts
+++ b/features/Vocabulary/lib/isVocabularyMeaningAnswerCorrect.ts
@@ -4,17 +4,22 @@ import type { IVocabObj } from '@/entities/vocabulary';
 const normalize = (value: string): string =>
   value.trim().normalize('NFC').toLowerCase();
 
+const normalizeMeaning = (value: string): string =>
+  normalize(value).replace(/^to\s+/, '');
+
 export const isVocabularyMeaningAnswerCorrect = (
   vocabulary: IVocabObj,
   answer: string,
   isReverse: boolean | undefined,
 ): boolean => {
-  const normalizedAnswer = normalize(answer);
+  const normalizedAnswer = isReverse
+    ? normalize(answer)
+    : normalizeMeaning(answer);
   if (!normalizedAnswer) return false;
 
   if (!isReverse) {
     return vocabulary.meanings.some(
-      meaning => normalize(meaning) === normalizedAnswer,
+      meaning => normalizeMeaning(meaning) === normalizedAnswer,
     );
   }
 


### PR DESCRIPTION
## Description

Accepts English meaning answers with or without the infinitive prefix `to ` in Vocabulary and Kanji input modes. For example, `Speak`, `speak`, and `to speak` all match a stored meaning of `to speak`.

The infinitive-prefix rule is scoped exclusively to English meaning comparisons. Reverse-mode Japanese word and reading comparisons retain their existing normalization behavior.

Closes #24282

## Testing

- Added Vocabulary and Kanji regression tests for capitalization, whitespace, and the optional `to ` prefix
- Added reverse-mode regression tests proving the prefix is not removed from words or readings
- `npm test -- features/Vocabulary/__tests__/isVocabularyMeaningAnswerCorrect.test.ts features/Kanji/__tests__/isKanjiAnswerCorrect.test.ts` (24 tests passed)
- `npm run check` (passed; existing repository warnings only)