### PR TITLE
feat(theme): add Komorebi Green theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -366,10 +366,15 @@
   "secondaryColor": "oklch(60.0% 0.125 30.0 / 1)"
 },
   {
-  id: 'matcha-foam',
-  backgroundColor: 'oklch(92.0% 0.020 140.0 / 1)',
-  mainColor: 'oklch(58.0% 0.165 140.0 / 1)',
-  secondaryColor: 'oklch(72.0% 0.115 95.0 / 1)'
-},
-
+    "id": "matcha-foam",
+    "backgroundColor": "oklch(92.0% 0.020 140.0 / 1)",
+    "mainColor": "oklch(58.0% 0.165 140.0 / 1)",
+    "secondaryColor": "oklch(72.0% 0.115 95.0 / 1)"
+  },
+  {
+    "id": "komorebi-green",
+    "backgroundColor": "oklch(22.0% 0.030 150.0 / 1)",
+    "mainColor": "oklch(78.0% 0.135 145.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.090 110.0 / 1)"
+  }
 ]


### PR DESCRIPTION
## Summary

- Adds the Komorebi Green community theme with the colors specified in the issue.
- Normalizes the preceding `matcha-foam` entry to valid JSON so the community content validation passes.

Closes #26324