### PR TITLE
content: fix JSON syntax error in anime-quotes.json

### DIFF
--- a/community/content/anime-quotes.json
+++ b/community/content/anime-quotes.json
@@ -524,17 +524,19 @@
     "anime": "JoJo's Bizarre Adventure: Diamond is Unbreakable",
     "character": "Yoshikage Kira"
   },
-  {
+
+{
     "japanese": "俺はガンダムだ！",
     "romaji": "Ore wa Gandamu da!",
     "english": "I am Gundam!(alt wording 25) (alt wording 77)",
     "anime": "Mobile Suit Gundam 00",
     "character": "Setsuna F. Seiei"
+  },
+  {
+    "japanese": "だが断る",
+    "romaji": "Daga kotowaru",
+    "english": "But I refuse. (alt wording 4)",
+    "anime": "JoJo's Bizarre Adventure: Diamond is Unbreakable",
+    "character": "Rohan Kishibe"
   }
-  "japanese": "だが断る",
-  "romaji": "Daga kotowaru",
-  "english": "But I refuse. (alt wording 4)",
-  "anime": "JoJo's Bizarre Adventure: Diamond is Unbreakable",
-  "character": "Rohan Kishibe"
-}
 ]


### PR DESCRIPTION
 Fixed a JSON syntax error at the end of `community/content/anime-quotes.json`:
- Missing comma after the "Setsuna F. Seiei" object
- Missing opening brace `{` for the last object (Rohan Kishibe quote)

This was causing the JSON file to be invalid. Verified the file parses correctly after the fix.

Note: The requested Kakashi Hatake quote from the good first issue was already present in the file (appears twice), so no new quote was added — this PR only fixes the syntax error that was blocking valid JSON.