### PR TITLE
fix(vocab): update あつい definition to prevent confusion with kind

### DIFF
--- a/public/data-vocab/n5.json
+++ b/public/data-vocab/n5.json
@@ -141,7 +141,7 @@
     "jmdict_seq": "1275320",
     "kana": "あつい",
     "kanji": "厚い",
-    "waller_definition": "kind, deep, thick"
+    "waller_definition": "thick"
   },
   {
     "jmdict_seq": "1483185",


### PR DESCRIPTION
## 📝 Description

Fixed a confusing vocabulary definition for `あつい` (厚い) in the N5 data. The previous definition was `"kind, deep, thick"`, which led to user confusion during quizzes because "kind" was presented as the primary translation (which beginners typically associate with `やさしい`). 

The definition has been updated to simply `"thick"` to align with standard N5 learning expectations and prevent incorrect answers when the hiragana display shows `あつい`.

## 🔗 Related Issue

Closes #24291

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Verified the JSON data integrity in `public/data-vocab/n5.json` after the update.
2. Ensured the definition for JMDict sequence `1275320` correctly displays `"thick"`.

<!--
**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

*(No visual UI changes, only data update)*

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

The issue specifically mentioned that "the hiragana display is a tsu i. but the answer expected is kind". This update directly resolves the discrepancy.
```