### PR TITLE
fix(kana): strip inner spaces in romaji validation to fix multi-chara…

### DIFF
--- a/features/Kana/__tests__/isKanaInputAnswerCorrect.test.ts
+++ b/features/Kana/__tests__/isKanaInputAnswerCorrect.test.ts
@@ -134,6 +134,21 @@ describe('isKanaInputAnswerCorrect', () => {
     ).toBe(true);
   });
 
+  it('accepts whitespace-separated romaji for a multi-character prompt', () => {
+    // Classic Input should accept the natural "chi te" entry for ちて.
+    expect(
+      isKanaInputAnswerCorrect({
+        inputValue: 'chi te',
+        correctChar: 'ちて',
+        targetChar: 'chite',
+        isReverse: false,
+        altRomanjiMap,
+        promptParts: ['ち', 'て'],
+        answerParts: ['chi', 'te'],
+      }),
+    ).toBe(true);
+  });
+
   it('accepts alternative romaji for a multi-character prompt', () => {
     // し has alt 'si', so 'sibu' should be accepted for prompt しぶ
     expect(
@@ -201,6 +216,18 @@ describe('isKanaInputAnswerCorrect', () => {
         answerParts: ['シ', 'ツ'],
       }),
     ).toBe(false);
+  });
+
+  it('accepts whitespace between kana in reverse mode', () => {
+    expect(
+      isKanaInputAnswerCorrect({
+        inputValue: 'シ ツ',
+        correctChar: 'shitsu',
+        targetChar: 'シツ',
+        isReverse: true,
+        altRomanjiMap,
+      }),
+    ).toBe(true);
   });
 
   it('rejects incorrect romaji for a multi-character prompt', () => {

--- a/features/Kana/lib/isKanaGameAnswerCorrect.test.ts
+++ b/features/Kana/lib/isKanaGameAnswerCorrect.test.ts
@@ -9,6 +9,7 @@ describe('isKanaGameAnswerCorrect', () => {
     expect(isKanaGameAnswerCorrect(shi, 'shi', false)).toBe(true);
     expect(isKanaGameAnswerCorrect(shi, 'SHI', false)).toBe(true);
     expect(isKanaGameAnswerCorrect(shi, ' shi ', false)).toBe(true);
+    expect(isKanaGameAnswerCorrect(shi, 's h i', false)).toBe(true);
   });
 
   it('accepts alternative romanizations in normal mode', () => {

--- a/features/Kana/lib/isKanaGameAnswerCorrect.ts
+++ b/features/Kana/lib/isKanaGameAnswerCorrect.ts
@@ -17,9 +17,9 @@ export const isKanaGameAnswerCorrect = (
   isReverse: boolean | undefined,
 ): boolean => {
   if (isReverse) {
-    return answer.trim() === question.kana;
+    return answer.replace(/\s+/g, '') === question.kana;
   }
-  const normalized = answer.trim().toLowerCase();
+  const normalized = answer.replace(/\s+/g, '').toLowerCase();
   return (
     normalized === question.romaji.toLowerCase() ||
     question.altRomanji.some(alt => normalized === alt.toLowerCase())

--- a/features/Kana/lib/isKanaInputAnswerCorrect.ts
+++ b/features/Kana/lib/isKanaInputAnswerCorrect.ts
@@ -46,15 +46,15 @@ export const isKanaInputAnswerCorrect = ({
   promptParts,
   answerParts,
 }: KanaInputAnswerOptions): boolean => {
-  // Normalize Unicode form and strip surrounding whitespace so that input
-  // from an IME or copy-paste (which may arrive in a different NFC/NFD form)
+  // Normalize Unicode form and strip ALL whitespace so that input
+  // from an IME, copy-paste, or with intentional spaces (e.g. "chi te")
   // is compared on equal footing with the stored answer.
-  const normalizedInput = inputValue.trim().normalize('NFC');
+  const normalizedInput = inputValue.replace(/\s+/g, '').normalize('NFC');
   if (!normalizedInput) return false;
 
   if (isReverse) {
     // Reverse mode: user types the kana character itself.
-    return normalizedInput === targetChar.normalize('NFC');
+    return normalizedInput === targetChar.replace(/\s+/g, '').normalize('NFC');
   }
 
   // Normal mode: user types romaji. Compare case- and Unicode-insensitively.


### PR DESCRIPTION
## 📝 Description

Replaced `.trim()` with `.replace(/\s+/g, '')` in `isKanaInputAnswerCorrect` and `isKanaGameAnswerCorrect` to globally strip whitespaces before evaluating answers. 

This resolves a bug in the Kana Input game (specifically when the Adaptive Target Length is > 1) where users would intuitively type spaces between character components (e.g. typing `chi te` for `ちて`). Previously, this input was marked incorrect and displayed `chite` as the fallback, generating confusing feedback and autocorrected bug reports (e.g. "Marked Chite wrong").

## 🔗 Related Issue

Closes #24149

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Simulated a multi-character Kana input prompt (e.g., `ち` and `て` combining to require `chite`).
2. Input `chi te` (with a space) and verified that the game accepts the answer correctly rather than failing it.
3. Added space-inclusive test expectations (e.g., validating `'s h i'` against `し`) to the `isKanaGameAnswerCorrect.test.ts` test suite.

<!--
**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->

## 📸 Screenshots/Videos (if applicable)

*(Leave blank or attach a screenshot of a successful `chi te` input if you have one)*

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

The bug report submitted via Tally titled "Mark Chite marked wrong when it is correct answer" was actually an autocorrect of the user attempting to write "Marked `chi te` wrong".
```