### PR TITLE
fix(kana): add ta/te challenge group to address issue #24283

### DIFF
--- a/features/Kana/data/kana.ts
+++ b/features/Kana/data/kana.ts
@@ -354,4 +354,10 @@ export const kana: KanaGroup[] = [
     romanji: ['ku', 'ke', 'ta'],
     groupName: 'challenge.katakana.kuketa',
   },
+  {
+    // タ (ta) vs テ (te) — commonly confused by beginners (see issue #24283)
+    kana: ['タ', 'テ'],
+    romanji: ['ta', 'te'],
+    groupName: 'challenge.katakana.tate',
+  },
 ];


### PR DESCRIPTION
Users were confusing katakana ta (ta) and te (te), which look visually similar to beginners. This led to the reported mismatch between 'tai' and 'tei'. The food vocabulary data was already correct (tai = sea bream).

Adds a new challenge.katakana.tate group pairing ta and te together so learners can drill the distinction between these two similar characters.

Closes #24283

## 📝 Description

This PR addresses the confusion beginners face between the visually similar Katakana characters `タ` (ta) and `テ` (te), which led to incorrect matching reports for "tai" vs "tei" in the Katakana chart. 

To help learners drill the distinction, a new specific challenge group (`challenge.katakana.tate`) pairing `ta` and `te` together has been added to the Katakana challenge mode dataset.

## 🔗 Related Issue

Closes #24283

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Navigate to the **Kana** dojo and select **Katakana**.
2. Scroll to the Challenge Mode groupings and verify that the `ta` vs `te` challenge grouping (`challenge.katakana.tate`) is available and selectable.
3. Start a practice round with this group and verify that it only queries `タ` (ta) and `テ` (te).

<!--
**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

*(You can add a screenshot of the new challenge group in the menu here before you submit)*

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

The vocabulary translation for `tai` (sea bream) in the food vocabulary data was already correct, the bug specifically applied to user character recognition which is resolved by this new drill group.
```