### PR TITLE
content: add new grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -54,5 +54,6 @@
   "\"〜まま\" means \"as is\" or \"unchanged\". (practice variation 26)",
   "\"〜わけではない\" means \"not necessarily\" or \"it's not that\".",
   "\"〜そうだ\" can indicate appearance, like \"it looks like\".",
-  "\"〜にとって\" means \"for / to (someone)\"."
+  "\"〜にとって\" means \"for / to (someone)\".",
+  "\"〜たばかり\" means \"just finished doing something\"."
 ]


### PR DESCRIPTION
Adds a new grammar point (〜たばかり) to community/content/japanese-grammar.json per issue #26629.

Note: the specific example given in the issue (〜を通して) was already present in the file, so I added a different, non-duplicate grammar point instead to avoid a redundant entry.

Closes #26629