### PR TITLE
feat(theme): add Papercraft White theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -438,9 +438,15 @@
   "secondaryColor": "oklch(40.0% 0.110 250.0 / 1)"
 },
   {
-  id: 'spring-bamboo',
-  backgroundColor: 'oklch(93.0% 0.018 150.0 / 1)',
-  mainColor: 'oklch(55.0% 0.145 145.0 / 1)',
-  secondaryColor: 'oklch(70.0% 0.085 120.0 / 1)'
-},
+    "id": "spring-bamboo",
+    "backgroundColor": "oklch(93.0% 0.018 150.0 / 1)",
+    "mainColor": "oklch(55.0% 0.145 145.0 / 1)",
+    "secondaryColor": "oklch(70.0% 0.085 120.0 / 1)"
+  },
+  {
+    "id": "papercraft-white",
+    "backgroundColor": "oklch(98.0% 0.005 90.0 / 1)",
+    "mainColor": "oklch(35.0% 0.165 255.0 / 1)",
+    "secondaryColor": "oklch(55.0% 0.145 200.0 / 1)"
+  }
 ]


### PR DESCRIPTION
## 📝 What changed?

Added the **Papercraft White** color theme to the community themes list, resolving issue #26937.

New theme `papercraft-white`:
- Background: `oklch(98.0% 0.005 90.0 / 1)`
- Main: `oklch(35.0% 0.165 255.0 / 1)`
- Secondary: `oklch(55.0% 0.145 200.0 / 1)`

Also fixed `community/content/community-themes.json` so it parses as valid JSON (converted the trailing `spring-bamboo` entry to quoted keys and removed a stray trailing comma before the closing bracket).

## 🔗 Related issue

Closes #26937

## 🧪 How did you test it?

- Verified `community/content/community-themes.json` parses with `JSON.parse` (valid JSON array).
- Confirmed the new `papercraft-white` entry is present with the exact color values from the issue.

## 📸 Screenshots or video

N/A (data-only change).

## 📦 Notes

The upstream `community-themes.json` on `main` was not strictly valid JSON (the `spring-bamboo` entry used unquoted keys, and a trailing comma preceded the closing bracket). To pass the repo's `pr-community-review` JSON validation, I converted that entry to proper JSON while keeping its values unchanged. No other entries were modified.
