### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -460,5 +460,11 @@
     "romaji": "Warau kado ni wa fuku kitaru",
     "english": "Fortune comes to a laughing gate",
     "meaning": "Good fortune comes to those who smile"
+  },
+  {
+    "japanese": "木を見て森を見ず",
+    "romaji": "Ki wo mite mori wo mizu",
+    "english": "See the trees but not the forest",
+    "meaning": "Miss the bigger picture"
   }
 ]


### PR DESCRIPTION
## Summary

Add a new Japanese proverb to the community proverbs collection, as requested in #26941.

- **Japanese:** 木を見て森を見ず
- **Romaji:** Ki wo mite mori wo mizu
- **English:** See the trees but not the forest
- **Meaning:** Miss the bigger picture

## Changes
- Appended the new proverb object to `community/content/japanese-proverbs.json`

Closes #26941