### PR TITLE
Add explanation for '〜おかげで' grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -60,4 +60,5 @@
   "\"〜ために\" also means \"for the sake of\" and explains purpose or reason. (practice variation 35)",
   "\"〜そうです\" can report hearsay (\"I heard that...\"). (practice variation 9)",
   "〜うちに means \"while\" or \"before\" something changes.",
+  "〜おかげで expresses gratitude for a cause, 'thanks to'. (practice variation 52)"
 ]


### PR DESCRIPTION
#27081 
## 📝 Description

Adds a new Japanese grammar point entry (〜おかげで, "thanks to") to the community grammar content file, as requested in the linked issue.

## 🔗 Related Issue

Closes #27081

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change

- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Added the new grammar point string to `community/content/japanese-grammar.json`.
2. Verified the file is still valid JSON (no missing commas, closing bracket intact).

## 📸 Screenshots/Videos (if applicable)

N/A — content-only JSON change, no UI impact.

## 📦 Additional Context

N/A