### PR TITLE
fix(progress): track vocabularyCorrect and answer time in vocab Input mode

### DIFF
--- a/features/Progress/__tests__/useGameStatsFacade.test.ts
+++ b/features/Progress/__tests__/useGameStatsFacade.test.ts
@@ -1,0 +1,117 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { statsApi } from '@/shared/events';
+import useStatsStore from '../store/useStatsStore';
+import { useGameStats } from '../facade/useGameStats';
+
+// The facade wires achievement prompts, which transitively pull in the
+// Progress barrel and next-intl routing — mock it to keep this test focused.
+vi.mock('@/features/Achievements/hooks/useAchievementPrompts', () => ({
+  useAchievementPrompts: () => ({
+    checkForAchievementProgress: vi.fn(),
+    recentPrompts: [],
+    clearPrompts: vi.fn(),
+  }),
+}));
+
+describe('useGameStats facade — correct-answer stat tracking', () => {
+  beforeEach(() => {
+    // Reset the store to a clean state (persist layer is bypassed for tests).
+    useStatsStore.setState({
+      numCorrectAnswers: 0,
+      numWrongAnswers: 0,
+      currentStreak: 0,
+      allTimeStats: {
+        totalSessions: 0,
+        totalCorrect: 0,
+        totalIncorrect: 0,
+        bestStreak: 0,
+        characterMastery: {},
+        hiraganaCorrect: 0,
+        katakanaCorrect: 0,
+        kanjiCorrectByLevel: {},
+        vocabularyCorrect: 0,
+        gauntletStats: {
+          totalRuns: 0,
+          completedRuns: 0,
+          normalCompleted: 0,
+          hardCompleted: 0,
+          instantDeathCompleted: 0,
+          perfectRuns: 0,
+          noDeathRuns: 0,
+          livesRegenerated: 0,
+          bestStreak: 0,
+        },
+        blitzStats: {
+          totalRuns: 0,
+          bestRunScore: 0,
+          bestRunAccuracy: 0,
+          correctAnswers: 0,
+          wrongAnswers: 0,
+          bestStreak: 0,
+        },
+        fastestAnswerMs: Infinity,
+        answerTimesMs: [],
+        dojosUsed: [],
+        modesUsed: [],
+        challengeModesUsed: [],
+        trainingDays: [],
+        currentWrongStreak: 0,
+        maxWrongStreak: 0,
+      },
+    });
+  });
+
+  it('increments vocabularyCorrect for vocabulary correct answers', () => {
+    renderHook(() => useGameStats());
+
+    act(() => {
+      statsApi.recordCorrect('vocabulary', '食べる');
+    });
+
+    expect(useStatsStore.getState().allTimeStats.vocabularyCorrect).toBe(1);
+
+    act(() => {
+      statsApi.recordCorrect('vocabulary', '飲む');
+    });
+
+    expect(useStatsStore.getState().allTimeStats.vocabularyCorrect).toBe(2);
+  });
+
+  it('does not increment vocabularyCorrect for non-vocabulary content', () => {
+    renderHook(() => useGameStats());
+
+    act(() => {
+      statsApi.recordCorrect('kana', 'あ');
+      statsApi.recordCorrect('kanji', '日');
+    });
+
+    expect(useStatsStore.getState().allTimeStats.vocabularyCorrect).toBe(0);
+  });
+
+  it('records answer time metadata from vocabulary correct answers', () => {
+    renderHook(() => useGameStats());
+
+    act(() => {
+      statsApi.recordCorrect('vocabulary', '食べる', { timeTaken: 1234 });
+    });
+
+    const allTimeStats = useStatsStore.getState().allTimeStats;
+    expect(allTimeStats.fastestAnswerMs).toBe(1234);
+    expect(allTimeStats.answerTimesMs).toContain(1234);
+  });
+
+  it('records the fastest answer time across multiple answers', () => {
+    renderHook(() => useGameStats());
+
+    act(() => {
+      statsApi.recordCorrect('vocabulary', '食べる', { timeTaken: 2500 });
+      statsApi.recordCorrect('vocabulary', '飲む', { timeTaken: 800 });
+    });
+
+    const allTimeStats = useStatsStore.getState().allTimeStats;
+    expect(allTimeStats.fastestAnswerMs).toBe(800);
+    expect(allTimeStats.answerTimesMs).toContain(2500);
+    expect(allTimeStats.answerTimesMs).toContain(800);
+  });
+});

--- a/features/Progress/facade/useGameStats.ts
+++ b/features/Progress/facade/useGameStats.ts
@@ -46,6 +46,21 @@ export function useGameStats(): GameStatsActions {
       'correct',
       (event: StatEvent) => {
         store.incrementCorrectAnswers();
+
+        const contentType = event.contentType || 'general';
+
+        // Content-specific tracking so vocabulary Input/Reverse-Input modes are
+        // counted like MCQ/Tiles (which call incrementVocabularyCorrect directly).
+        if (contentType === 'vocabulary') {
+          store.incrementVocabularyCorrect();
+        }
+
+        // Feed answer-time metadata (emitted by vocab Input) into speed tracking,
+        // matching the direct-hook game modes.
+        if (event.metadata?.timeTaken !== undefined) {
+          store.recordAnswerTime(event.metadata.timeTaken);
+        }
+
         // Update character history based on content type
         if (event.character) {
           store.addCharacterToHistory(event.character);
@@ -53,7 +68,6 @@ export function useGameStats(): GameStatsActions {
         }
 
         // Trigger achievement progress check for correct answers
-        const contentType = event.contentType || 'general';
         checkForAchievementProgress(contentType, true);
       },
     );
@@ -79,6 +93,7 @@ export function useGameStats(): GameStatsActions {
       unsubIncorrect();
       unsubSession();
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store]);
 
   return {


### PR DESCRIPTION
Fixes #27161

## Problem
Correct answers in Vocabulary **Input** / **Reverse-Input** modes were never added to `allTimeStats.vocabularyCorrect`, and their answer times were never recorded. These are the only vocab modes that track stats through the events facade (`features/Progress/facade/useGameStats.ts`); MCQ and Tiles call `incrementVocabularyCorrect()` directly, so the three vocab modes were inconsistent:
- vocab-correct stat stayed 0 for Input-mode answers
- vocab `content_correct` achievements (`word_collector`, `lexicon_builder`, `dictionary_devotee`, `vocabulary_virtuoso`) got no progress from Input mode
- `fastestAnswerMs` / `answerTimesMs` never received the `timeTaken` that `Input.tsx` emits

## Fix
In the facade's `'correct'` subscriber:
- call `store.incrementVocabularyCorrect()` when `contentType === 'vocabulary'`
- forward `event.metadata.timeTaken` to `store.recordAnswerTime(...)`

No double-counting risk: the facade hook is only rendered by vocab Input (`Input.tsx`), which is the only mode that emits `timeTaken` through the event bus.

## Verification
- New Vitest suite `features/Progress/__tests__/useGameStatsFacade.test.ts` (4 tests): vocab correct increments, non-vocab isolation, and fastest/answer-time tracking — all pass.
- `npm run check` (tsc + eslint): 0 errors; the one warning in the touched file is a pre-existing `exhaustive-deps` that I silenced with the repo's standard `eslint-disable-next-line` (same pattern as Kana/Kanji/Vocab game index files).
- Full `features/Progress` suite: 13 files pass; 2 property suites fail to load on pristine `main` too (pre-existing `next/navigation` module-resolution issue, unrelated).