### PR TITLE
content: add new grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -51,7 +51,7 @@
   "\"〜てくれる\" indicates someone does a favor for the speaker.",
   "「〜ようです」means \"it seems like\" and is based on observation.",
   "\"〜てしまう\" can express completion or regret (\"end up doing\").",
-  "\"〜てもらう\" means \"receive a favor\" from someone. (practice variation 16)"
+  "\"〜てもらう\" means \"receive a favor\" from someone. (practice variation 16)",
   "\"〜のに\" expresses contrast or regret, similar to even though. (practice variation 23)",
   "\"〜うちに\" means \"while\" or \"before\" something changes. (practice variation 40)",
   "\"〜わけがない\" means \"there is no way that...\".",
@@ -68,5 +68,6 @@
   "〜うちに means \"while\" or \"before\" something changes.",
   "〜おかげで expresses gratitude for a cause, 'thanks to'. (practice variation 52)",
   "\"〜わりに\" means \"despite / considering...\".",
-  "〜ことになる indicates something was decided (by others or circumstances)."
+  "〜ことになる indicates something was decided (by others or circumstances).",
+  "\"〜につれて\" means \"as... changes, ... also changes\"."
 ]


### PR DESCRIPTION
Closes #27219

Adds the grammar point:

> "〜につれて" means "as... changes, ... also changes".

Appended to `community/content/japanese-grammar.json` per the issue instructions.

Also repairs the file: the previous entry was missing its trailing comma, which left `japanese-grammar.json` unparseable (JSON parse error at line 55). The file now parses with 71 entries.

Verified: `python3 -m json.tool` passes on the updated file.