### PR TITLE
feat(theme): add Ninja Shadow theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -484,5 +484,11 @@
     "backgroundColor": "oklch(25.0% 0.015 260.0 / 1)",
     "mainColor": "oklch(75.0% 0.035 90.0 / 1)",
     "secondaryColor": "oklch(60.0% 0.025 80.0 / 1)"
+  },
+  {
+    "id": "ninja-shadow",
+    "backgroundColor": "oklch(12.0% 0.015 280.0 / 1)",
+    "mainColor": "oklch(65.0% 0.025 270.0 / 1)",
+    "secondaryColor": "oklch(55.0% 0.175 15.0 / 1)"
   }
 ]

--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -51,7 +51,7 @@
   "\"〜てくれる\" indicates someone does a favor for the speaker.",
   "「〜ようです」means \"it seems like\" and is based on observation.",
   "\"〜てしまう\" can express completion or regret (\"end up doing\").",
-  "\"〜てもらう\" means \"receive a favor\" from someone. (practice variation 16)"
+  "\"〜てもらう\" means \"receive a favor\" from someone. (practice variation 16)",
   "\"〜のに\" expresses contrast or regret, similar to even though. (practice variation 23)",
   "\"〜うちに\" means \"while\" or \"before\" something changes. (practice variation 40)",
   "\"〜わけがない\" means \"there is no way that...\".",
@@ -68,5 +68,6 @@
   "〜うちに means \"while\" or \"before\" something changes.",
   "〜おかげで expresses gratitude for a cause, 'thanks to'. (practice variation 52)",
   "\"〜わりに\" means \"despite / considering...\".",
-  "〜ことになる indicates something was decided (by others or circumstances)."
+  "〜ことになる indicates something was decided (by others or circumstances).",
+  "\"〜につれて\" means \"as... changes, ... also changes\"."
 ]


### PR DESCRIPTION
Closes #27222

Adds the `ninja-shadow` theme to `community/content/community-themes.json`:

| Property | Value |
|---|---|
| id | `ninja-shadow` |
| backgroundColor | `oklch(12.0% 0.015 280.0 / 1)` |
| mainColor | `oklch(65.0% 0.025 270.0 / 1)` |
| secondaryColor | `oklch(55.0% 0.175 15.0 / 1)` |

Verified: file parses as valid JSON with 82 themes; the new theme is last in the array.