### PR TITLE
fix: repair malformed video game quote entries

### DIFF
--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -404,13 +404,15 @@
   "english": "The wind is coming!",
   "game": "The Legend of Zelda: Breath of the Wild (JP)",
   "character": "Revali"
-},
+  },
   {
     "japanese": "太陽賛美 ！",
     "romaji": "Taiyō Banzai!",
     "english": "Praise the Sun!",
     "game": "Dark Souls",
     "character": "Solaire of Astora"
+  },
+  {
     "japanese": "運命なんて、変えてみせる！",
     "romaji": "Unmei nante, kaete miseru!",
     "english": "I'll change destiny!",


### PR DESCRIPTION
## 📝 Description

While reviewing `community/content/japanese-videogame-quotes.json`, I found two adjacent video game quote entries incorrectly merged into a single JSON object.

This change closes the first quote object and opens a separate object for the following quote, restoring the expected JSON structure without changing their content.

## 🔗 Related Issue

Related to #27261

## ✅ Pre-Submission Checklist

* [x] I have starred the repo ⭐
* [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
* [x] My commit message follows the Conventional Commits format
* [x] This PR is against the `main` branch

## 🎯 Type of Change

* [x] `fix`: Bug fix (non-breaking change which fixes an issue)
* [ ] `feat`: New feature
* [ ] `docs`: Documentation update
* [ ] `content`: Content update
* [ ] `style`: UI/Theme changes
* [ ] `refactor`: Code refactor
* [ ] `test`: Test update
* [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Reviewed the modified section of `japanese-videogame-quotes.json`.
2. Confirmed that the Dark Souls and Final Fantasy Type-0 quotes are now represented as two separate JSON objects.
3. Confirmed that no quote content was changed.

## 📸 Screenshots/Videos

Not applicable. This change only fixes the structure of a JSON data file.

## 📦 Additional Context

The quote requested in #27261  was already present in the file. While reviewing the file, I noticed this malformed section and corrected it instead of adding another duplicate entry.

I also noticed that the same Yakuza: Like a Dragon quote appears multiple times in the JSON file. Are these repeated entries intentional? If not, I would be happy to remove the duplicates and keep a single occurrence in a follow-up change or as part of this PR, depending on the maintainers’ preference.
