### PR TITLE
feat(theme): add Tokyo Metro theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -496,5 +496,11 @@
     "backgroundColor": "oklch(17.0% 0.055 290.0 / 1)",
     "mainColor": "oklch(82.0% 0.195 310.0 / 1)",
     "secondaryColor": "oklch(74.0% 0.140 20.0 / 1)"
-  }
+  },
+  {
+  id: 'tokyo-metro',
+  backgroundColor: 'oklch(20.0% 0.025 260.0 / 1)',
+  mainColor: 'oklch(70.0% 0.180 145.0 / 1)',
+  secondaryColor: 'oklch(80.0% 0.120 50.0 / 1)'
+}
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -502,5 +502,5 @@
   backgroundColor: 'oklch(20.0% 0.025 260.0 / 1)',
   mainColor: 'oklch(70.0% 0.180 145.0 / 1)',
   secondaryColor: 'oklch(80.0% 0.120 50.0 / 1)'
-}
+  }
 ]

--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -498,9 +498,9 @@
     "secondaryColor": "oklch(74.0% 0.140 20.0 / 1)"
   },
   {
-  id: 'tokyo-metro',
-  backgroundColor: 'oklch(20.0% 0.025 260.0 / 1)',
-  mainColor: 'oklch(70.0% 0.180 145.0 / 1)',
-  secondaryColor: 'oklch(80.0% 0.120 50.0 / 1)'
+    "id": "tokyo-metro",
+    "backgroundColor": "oklch(20.0% 0.025 260.0 / 1)",
+    "mainColor": "oklch(70.0% 0.180 145.0 / 1)",
+    "secondaryColor": "oklch(80.0% 0.120 50.0 / 1)"
   }
 ]


### PR DESCRIPTION
## 📝 Description
Adds a new "Tokyo Metro" color theme to `community/content/community-themes.json`, as requested in the linked issue.

- id: `tokyo-metro`
- backgroundColor: `oklch(20.0% 0.025 260.0 / 1)`
- mainColor: `oklch(70.0% 0.180 145.0 / 1)`
- secondaryColor: `oklch(80.0% 0.120 50.0 / 1)`

## 🔗 Related Issue
Closes #27316

## ✅ Pre-Submission Checklist
- [ ] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change
- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?
**Test Steps:**
1. Added the new theme object to `community-themes.json`
2. Verified the file is still valid JSON

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)