### PR TITLE
feat(theme): add Inkstone theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -46,5 +46,11 @@
     "backgroundColor": "oklch(25.0% 0.028 145.0 / 1)",
     "mainColor": "oklch(62.0% 0.115 135.0 / 1)",
     "secondaryColor": "oklch(75.0% 0.075 90.0 / 1)"
-}
+  },
+  {
+    "id": "inkstone",
+    "backgroundColor": "oklch(15.0% 0.018 260.0 / 1)",
+    "mainColor": "oklch(78.0% 0.040 230.0 / 1)",
+    "secondaryColor": "oklch(50.0% 0.030 255.0 / 1)"
+  }
 ]


### PR DESCRIPTION
Closes #27692

Adds the **Inkstone** community theme — "carved slate and quiet study" — to `community/content/community-themes.json`.

```json
{
  "id": "inkstone",
  "backgroundColor": "oklch(15.0% 0.018 260.0 / 1)",
  "mainColor": "oklch(78.0% 0.040 230.0 / 1)",
  "secondaryColor": "oklch(50.0% 0.030 255.0 / 1)"
}
```

Verified:
- Matches the queued entry in `community/backlog/theme-backlog.json` (`id: inkstone`, `issued: true`) exactly
- `id` doesn't collide with any existing theme (checked against all 8 current entries, including the similarly-named `inkstone-blue` which is a different backlog entry)
- File still parses as valid JSON (`python3 -m json.tool` and `node scripts/fix-community-content-json.mjs` both pass with 0 repairs needed)