### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -105,5 +105,6 @@
   "The term 'kigatsuku' (気がつく) means to notice or realize, and is often associated with considerate awareness.",
   "The word 'gaman' (我慢) means enduring the seemingly unbearable with patience and dignity - a core Japanese cultural value.",
   "The Japanese term 'shuudan ishiki' (集団意識) refers to strong group consciousness — prioritizing harmony within the group.",
-  "In Japan, many shops display realistic food replicas called 'shokuhin sampuru' (食品サンプル) to show menu items."
+  "In Japan, many shops display realistic food replicas called 'shokuhin sampuru' (食品サンプル) to show menu items.",
+  "Japanese train conductors point and call out each signal and sign they see - a practice called 'shisa kanko' that reduces errors by up to 85%."
 ]


### PR DESCRIPTION
Closes #27693

Added new Japan fact: "Japanese train conductors point and call out each signal and sign they see - a practice called 'shisa kanko' that reduces errors by up to 85%."

## 🔗 Related Issue

Closes #27693

