### PR TITLE
content: add new grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -80,5 +80,6 @@
   "\"〜ために\" also means \"for the sake of\" and explains purpose or reason. (practice variation 35)",
   "\"〜ようです\" means \"it seems like\" and is based on observation.",
   "\"〜たい\" attaches to a verb stem to express \"want to do\" something. (practice variation 3)",
-  "\"〜なければならない\" means \"must\" or \"have to\" do something. (practice variation 13)"
+  "\"〜なければならない\" means \"must\" or \"have to\" do something. (practice variation 13)",
+  "\"〜ほど\" can express degree, like \"so... that\". (practice variation 54)"
 ]


### PR DESCRIPTION
Closes #27688

Adds the "〜ほど" (degree, "so... that") grammar point to `community/content/japanese-grammar.json`, matching the backlog entry (`grammar-backlog.json`, id 139, practice variation 54).

Note: the issue's copy-paste snippet had unescaped interior quotes (`""〜ほど" can express degree...`), which would have broken the JSON if pasted literally — I used the correctly-escaped string from the backlog instead and verified the file still parses (`python3 -m json.tool`, and `node scripts/fix-community-content-json.mjs` reports 0 repairs needed).