### PR TITLE
content: add anime quote

### DIFF
--- a/community/content/anime-quotes.json
+++ b/community/content/anime-quotes.json
@@ -670,5 +670,12 @@
     "english": "I'll exterminate them! Every last one from this world!",
     "anime": "Attack on Titan",
     "character": "Eren Yeager"
+  },
+  {
+    "japanese": "生殺与奪の権を他人に握らせるな!",
+    "romaji": "Seisatsu yodatsu no ken o tanin ni nigiraseru na!",
+    "english": "Don't let anyone else take control of your life and death! (alt wording 37)",
+    "anime": "Demon Slayer: Kimetsu no Yaiba",
+    "character": "Giyu Tomioka"
   }
 ]


### PR DESCRIPTION
Closes #27700

Adds the Demon Slayer line "生殺与奪の権を他人に握らせるな!" to `community/content/anime-quotes.json`.

**One correction from the issue's suggested content:** the issue attributed this line to Tanjiro Kamado, but it's actually spoken *to* Tanjiro, not by him — it's Giyu Tomioka's line, delivered when he stops Tanjiro from being killed alongside Nezuko in episode 1. This is one of the most quoted lines in the series specifically because it's Tomioka's, so misattributing it would be a fairly visible error for anyone who knows the show. I've set `character` to `"Giyu Tomioka"` instead.

(Japanese text, romaji, and English translation from the issue are all correct and unchanged.)