### PR TITLE
Add Japanese proverb about missing the bigger picture

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -522,21 +522,27 @@
     "meaning": "The grass is always greener on the other side"
   },
   {
-  "japanese": "花より団子",
-  "romaji": "Hana yori dango",
-  "english": "Dumplings over flowers",
-  "meaning": "Practicality over appearance"
+    "japanese": "花より団子",
+    "romaji": "Hana yori dango",
+    "english": "Dumplings over flowers",
+    "meaning": "Practicality over appearance"
   },
   {
-  "japanese": "石の上にも三年",
-  "romaji": "Ishi no ue ni mo san nen",
-  "english": "Three years on a stone",
-  "meaning": "Perseverance brings results"
+    "japanese": "石の上にも三年",
+    "romaji": "Ishi no ue ni mo san nen",
+    "english": "Three years on a stone",
+    "meaning": "Perseverance brings results"
   },
   {
-  "japanese": "出る杭は打たれる",
-  "romaji": "Deru kui wa utareru",
-  "english": "The nail that sticks out gets hammered down",
-  "meaning": "Those who stand out may face criticism"
+    "japanese": "出る杭は打たれる",
+    "romaji": "Deru kui wa utareru",
+    "english": "The nail that sticks out gets hammered down",
+    "meaning": "Those who stand out may face criticism"
+  },
+  {
+    "japanese": "木を見て森を見ず",
+    "romaji": "Ki wo mite mori wo mizu",
+    "english": "See the trees but not the forest",
+    "meaning": "Missing the bigger picture"
   }
 ]


### PR DESCRIPTION
Add new entry to the Japanese proverbs collection: "木を見て森を見ず" (Ki wo mite mori wo mizu) - a proverb that illustrates the concept of focusing too narrowly on details while overlooking the larger context.

## 📝 Description

...

## 🔗 Related Issue

Closes #27716

## ✅ Pre-Submission Checklist

- [ ] I have starred the repo ⭐
- [ ] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [ ] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

<!--
**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

...

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

...
