### PR TITLE
fix(MainMenu): make homepage kanji clickable above and below content

### DIFF
--- a/features/MainMenu/index.tsx
+++ b/features/MainMenu/index.tsx
@@ -166,14 +166,14 @@ const MainMenu = () => {
       <div
         className={clsx(
           '3xl:w-2/5 flex w-full flex-col items-center gap-4 px-4 pb-16 max-md:pt-4 sm:w-3/4 md:justify-center lg:w-1/2',
-          'z-50',
+          'pointer-events-none z-50',
           !isGlassMode && 'opacity-90',
           expandDecorations && 'hidden',
         )}
       >
         <div className='flex w-full flex-row items-center justify-between gap-2 px-1'>
           <KanaDojoBanner />
-          <div className='flex w-1/2 flex-row justify-end gap-2 md:w-1/3'>
+          <div className='pointer-events-auto flex w-1/2 flex-row justify-end gap-2 md:w-1/3'>
             <button
               type='button'
               onClick={() => {
@@ -264,9 +264,11 @@ const MainMenu = () => {
             />
           </div>
         </div>
-        <Info />
+        <div className='pointer-events-auto w-full'>
+          <Info />
+        </div>
         <div className={clsx(
-          'w-full rounded-2xl',
+          'pointer-events-auto w-full rounded-2xl',
           USE_NEW_DESIGN
             ? 'border-4 border-(--border-color) bg-(--card-color) overflow-hidden'
             : 'border-1 border-(--border-color) bg-(--background-color) p-1'


### PR DESCRIPTION
Fixes #27373

## Problem
Kanji characters positioned **above or below the main content** on the homepage are visible but not clickable — no pointer cursor, no explode animation on click.

## Root cause
The homepage renders a full-screen interactive kanji grid (`Decorations`) behind the main content column. The main content column applies `opacity-90` (`!isGlassMode`), which creates a **stacking context**. Combined with DOM order, the column paints **above** the decorations grid, so the kanji in the column's vertical band (above the header row and below the menu card) never receive pointer events.

## Fix
Make the main content column `pointer-events-none` so clicks pass through to the interactive kanji grid, and re-enable `pointer-events-auto` on its interactive children so they keep working:

- header buttons/icons (bug report, theme toggle, Discord, GitHub, Ko-fi heart)
- the collapsible `Info` section (header toggle)
- the menu card links (Kana / Vocab / Kanji)

Kanji to the left/right already worked; now the ones above/below the menu do too, with the correct pointer cursor and click handling.

## Verification
- `npx tsc --noEmit` clean
- `npx eslint features/MainMenu/index.tsx` — no new errors/warnings (the 6 warnings shown are pre-existing dead code unrelated to this change)

cc @tentoumushii