### PR TITLE
content: add new trivia question

### DIFF
--- a/community/content/japan-trivia-medium.json
+++ b/community/content/japan-trivia-medium.json
@@ -1,13 +1,14 @@
 [
   {
     "question": "What is the traditional Japanese tea ceremony called?",
+    "difficulty": "medium",
     "answers": [
       "Sado",
       "Judo",
       "Kendo",
       "Shodo"
     ],
-    "correctAnswerIndex": 0
+    "correctIndex": 0
   },
   {
     "question": "Which Japanese city is known for its deer roaming freely in a large park? (Community variation 12)",
@@ -30,15 +31,16 @@
       "Matsue"
     ],
     "correctIndex": 0
+  },
+  {
+    "question": "What is the name of Japan’s largest lake?",
+    "difficulty": "medium",
+    "answers": [
+      "Lake Biwa",
+      "Lake Towada",
+      "Lake Ashi",
+      "Lake Shinji"
+    ],
+    "correctIndex": 0
   }
 ]
-{
-  "question": "Which city is known for the historic district of Higashiyama?",
-  "answers": [
-    "Kanazawa",
-    "Kagoshima",
-    "Nara",
-    "Matsue"
-  ],
-  "correctIndex": 0
-}


### PR DESCRIPTION
## Summary
- Adds a medium trivia question: Japan's largest lake (Lake Biwa)
- Repairs invalid trailing JSON in `community/content/japan-trivia-medium.json` and aligns the first entry with the `correctIndex` schema

Closes #27823

## Test plan
- [ ] Confirm `community/content/japan-trivia-medium.json` is valid JSON
- [ ] Confirm the new question appears with `correctIndex: 0` (Lake Biwa)


Made with [Cursor](https://cursor.com)