### PR TITLE
feat(theme): add Digital Oni theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -76,5 +76,11 @@
     "backgroundColor": "oklch(18.0% 0.028 255.0 / 1)",
     "mainColor": "oklch(92.0% 0.020 95.0 / 1)",
     "secondaryColor": "oklch(65.0% 0.105 270.0 / 1)"
+  },
+  {
+    "id": "digital-oni",
+    "backgroundColor": "oklch(14.0% 0.075 355.0 / 1)",
+    "mainColor": "oklch(68.0% 0.240 10.0 / 1)",
+    "secondaryColor": "oklch(78.0% 0.195 150.0 / 1)"
   }
 ]


### PR DESCRIPTION
## 📝 What changed?

Added the Digital Oni community theme with the requested background, main, and secondary OKLCH colors. The issue example was adapted to valid JSON syntax for the destination file.

## 🔗 Related issue

Closes #27933

## 🧪 How did you test it?

- `jq empty community/content/community-themes.json`
- `git diff --check upstream/main...HEAD`
- Confirmed the `digital-oni` theme ID appears exactly once

## 📸 Screenshots or video

Not included — this is a data-only theme entry with no UI code changes.

## 📦 Notes

All color values match the issue specification exactly.
