### PR TITLE
feat(theme): add Soda Float theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -82,5 +82,11 @@
     "backgroundColor": "oklch(14.0% 0.075 355.0 / 1)",
     "mainColor": "oklch(68.0% 0.240 10.0 / 1)",
     "secondaryColor": "oklch(78.0% 0.195 150.0 / 1)"
+  },
+  {
+    "id": "soda-float",
+    "backgroundColor": "oklch(93.0% 0.032 150.0 / 1)",
+    "mainColor": "oklch(62.0% 0.175 155.0 / 1)",
+    "secondaryColor": "oklch(85.0% 0.095 95.0 / 1)"
   }
 ]


### PR DESCRIPTION
Closes #27945

Adds the "Soda Float" theme (melon cream soda sweetness) to `community/content/community-themes.json`, matching the backlog entry (id `soda-float`, issued: true). Appended surgically so the diff is scoped to just the new entry, not a reformat of the file.