### PR TITLE
content: add new grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -80,6 +80,7 @@
   "\"〜ために\" also means \"for the sake of\" and explains purpose or reason. (practice variation 35)",
   "\"〜ようです\" means \"it seems like\" and is based on observation.",
   "\"〜たい\" attaches to a verb stem to express \"want to do\" something. (practice variation 3)",
-  "\"〜なければならない\" means \"must\" or \"have to\" do something. (practice variation 13)\",
-  "\"〜たところ\" can mean \"just did\" something and observed a result. (practice variation 25)\"
+  "\"〜なければならない\" means \"must\" or \"have to\" do something. (practice variation 13)",
+  "\"〜たところ\" can mean \"just did\" something and observed a result. (practice variation 25)",
+  "\"〜なくてもいい\" means \"don't have to\" and lifts an obligation. (practice variation 14)"
 ]


### PR DESCRIPTION
## Summary

Adds the requested Japanese grammar point for `〜なくてもいい` to the community grammar list.

### Changes

* Added the `〜なくてもいい` grammar explanation.
* Included practice variation 14.
* Preserved valid JSON formatting.

Closes #27955
