### PR TITLE
fix(game): let Enter dismiss streak milestone overlay

### DIFF
--- a/shared/ui-composite/Game/StreakMilestoneOverlay.test.tsx
+++ b/shared/ui-composite/Game/StreakMilestoneOverlay.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import StreakMilestoneOverlay from '@/shared/ui-composite/Game/StreakMilestoneOverlay';
+
+const playClick = vi.fn();
+
+vi.mock('canvas-confetti', () => ({ default: vi.fn() }));
+
+vi.mock('@/features/Preferences', () => ({
+  useThemePreferences: () => ({ isGlassMode: true }),
+}));
+
+vi.mock('@/shared/hooks/generic/useAudio', () => ({
+  useClick: () => ({ playClick }),
+}));
+
+vi.mock('@/shared/ui-composite/Game/GameBottomBar', () => ({
+  GameBottomBar: ({
+    actionLabel,
+    buttonRef,
+    onAction,
+  }: {
+    actionLabel: string;
+    buttonRef: React.RefObject<HTMLButtonElement>;
+    onAction: () => void;
+  }) => (
+    <button ref={buttonRef} onClick={onAction}>
+      {actionLabel}
+    </button>
+  ),
+}));
+
+vi.mock('@/shared/ui-composite/layout/BottomBar', () => ({
+  default: () => null,
+}));
+
+afterEach(() => {
+  playClick.mockClear();
+  delete window.__kanaDojoContinueShortcutSuppressedUntil;
+});
+
+describe('StreakMilestoneOverlay keyboard handling', () => {
+  it('focuses Skip when the milestone opens', () => {
+    render(<StreakMilestoneOverlay milestone={10} onDismiss={vi.fn()} />);
+
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: 'skip' }),
+    );
+  });
+
+  it.each([
+    ['Enter', 'Enter'],
+    ['Space', ' '],
+  ])('uses %s to dismiss without reaching the game', (_, key) => {
+    const onDismiss = vi.fn();
+    const gameKeyDown = vi.fn();
+    window.addEventListener('keydown', gameKeyDown);
+
+    render(<StreakMilestoneOverlay milestone={10} onDismiss={onDismiss} />);
+    fireEvent.keyDown(document.body, { key, code: key === ' ' ? 'Space' : key });
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(playClick).toHaveBeenCalledOnce();
+    expect(gameKeyDown).not.toHaveBeenCalled();
+    expect(window.__kanaDojoContinueShortcutSuppressedUntil).toBeGreaterThan(
+      performance.now(),
+    );
+
+    window.removeEventListener('keydown', gameKeyDown);
+  });
+
+  it('ignores repeated shortcut keydown events', () => {
+    const onDismiss = vi.fn();
+    render(<StreakMilestoneOverlay milestone={10} onDismiss={onDismiss} />);
+
+    fireEvent.keyDown(document.body, { key: 'Enter', repeat: true });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('removes shortcut listeners when the milestone closes', () => {
+    const onDismiss = vi.fn();
+    const { rerender } = render(
+      <StreakMilestoneOverlay milestone={10} onDismiss={onDismiss} />,
+    );
+
+    rerender(<StreakMilestoneOverlay milestone={null} onDismiss={onDismiss} />);
+    fireEvent.keyDown(document.body, { key: 'Enter' });
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
+++ b/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
@@ -15,7 +15,9 @@ import { ENABLE_EVERY_QUESTION_AD_OVERLAY } from '@/shared/utils/game/streakMile
 
 const STREAK_MILESTONE_AD_SLOT = '2642983933';
 const ENABLE_STREAK_MILESTONE_DECORATIONS = true;
-const ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS = false;
+// Let Enter/Space dismiss the overlay so type-mode keyboard users don't
+// accidentally trigger the underlying "next" control (#27829).
+const ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS = true;
 // Keep the placement code intact, but do not mount AdSense during the audit.
 const ENABLE_STREAK_MILESTONE_AD = false;
 const isStreakMilestoneAdEnabled =
@@ -86,7 +88,13 @@ export default function StreakMilestoneOverlay({
   const skipButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    if (!ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS || !milestone) return;
+    if (!milestone) return;
+
+    // Move keyboard focus to Skip so Enter targets this dialog, not the
+    // type-mode "next" button still mounted underneath.
+    skipButtonRef.current?.focus();
+
+    if (!ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS) return;
 
     const isSkipShortcut = (event: KeyboardEvent) =>
       event.key === 'Enter' || event.code === 'Space' || event.key === ' ';
@@ -109,6 +117,7 @@ export default function StreakMilestoneOverlay({
       skipButtonRef.current?.click();
     };
 
+    // Capture-phase listeners win over the game Input "continue" handlers.
     window.addEventListener('keydown', handleKeyDown, true);
     window.addEventListener('keyup', absorbShortcut, true);
     window.addEventListener('keypress', absorbShortcut, true);

--- a/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
+++ b/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
@@ -92,9 +92,13 @@ export default function StreakMilestoneOverlay({
 
     // Move keyboard focus to Skip so Enter targets this dialog, not the
     // type-mode "next" button still mounted underneath.
-    skipButtonRef.current?.focus();
+    const focusSkip = () => skipButtonRef.current?.focus();
+    focusSkip();
+    const focusFrame = requestAnimationFrame(focusSkip);
 
-    if (!ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS) return;
+    if (!ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS) {
+      return () => cancelAnimationFrame(focusFrame);
+    }
 
     const isSkipShortcut = (event: KeyboardEvent) =>
       event.key === 'Enter' || event.code === 'Space' || event.key === ' ';
@@ -123,6 +127,7 @@ export default function StreakMilestoneOverlay({
     window.addEventListener('keypress', absorbShortcut, true);
 
     return () => {
+      cancelAnimationFrame(focusFrame);
       window.removeEventListener('keydown', handleKeyDown, true);
       window.removeEventListener('keyup', absorbShortcut, true);
       window.removeEventListener('keypress', absorbShortcut, true);

--- a/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
+++ b/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
@@ -92,13 +92,9 @@ export default function StreakMilestoneOverlay({
 
     // Move keyboard focus to Skip so Enter targets this dialog, not the
     // type-mode "next" button still mounted underneath.
-    const focusSkip = () => skipButtonRef.current?.focus();
-    focusSkip();
-    const focusFrame = requestAnimationFrame(focusSkip);
+    skipButtonRef.current?.focus();
 
-    if (!ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS) {
-      return () => cancelAnimationFrame(focusFrame);
-    }
+    if (!ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS) return;
 
     const isSkipShortcut = (event: KeyboardEvent) =>
       event.key === 'Enter' || event.code === 'Space' || event.key === ' ';
@@ -127,7 +123,6 @@ export default function StreakMilestoneOverlay({
     window.addEventListener('keypress', absorbShortcut, true);
 
     return () => {
-      cancelAnimationFrame(focusFrame);
       window.removeEventListener('keydown', handleKeyDown, true);
       window.removeEventListener('keyup', absorbShortcut, true);
       window.removeEventListener('keypress', absorbShortcut, true);


### PR DESCRIPTION
## Summary
- Enables streak-milestone overlay keyboard shortcuts (Enter / Space → Skip)
- Focuses the Skip button when the overlay opens so type-mode keyboard users don't hit the underlying Next control

Closes #27829

## Root cause
`ENABLE_STREAK_MILESTONE_KEYBOARD_SHORTCUTS` was `false`, so Enter bubbled to the Kana type-mode Input \"continue\" handler while the congrats dialog was visible.

## Test plan
- [ ] Kana Training → type mode → hit a streak milestone (e.g. 10)
- [ ] Press Enter → overlay dismisses (Skip), does not advance via the hidden Next button
- [ ] Space also dismisses
- [ ] Mouse click Skip still works


Made with [Cursor](https://cursor.com)