### PR TITLE
feat(kana): add TTS pronunciation after correct answers in all game m…

### DIFF
--- a/features/Kana/components/Game/Input.tsx
+++ b/features/Kana/components/Game/Input.tsx
@@ -4,7 +4,11 @@ import { kana } from '@/features/Kana/data/kana';
 import useKanaStore from '@/features/Kana/store/useKanaStore';
 import { motion } from 'framer-motion';
 import clsx from 'clsx';
-import { useClick, useCorrect, useError } from '@/shared/hooks/generic/useAudio';
+import {
+  useClick,
+  useCorrect,
+  useError,
+} from '@/shared/hooks/generic/useAudio';
 // import GameIntel from '@/shared/ui-composite/Game/GameIntel';
 import { useStatsStore } from '@/features/Progress';
 import { useShallow } from 'zustand/react/shallow';
@@ -19,6 +23,7 @@ import { useAdaptiveTargetLength } from '@/shared/hooks/game/useAdaptiveTargetLe
 import { useThemePreferences } from '@/features/Preferences';
 import { cn } from '@/shared/utils/utils';
 import { shouldSuppressContinueKeyboardShortcut } from '@/shared/utils/game/continueShortcutGuard';
+import { useKanaPronunciation } from '@/features/Kana/hooks/useKanaPronunciation';
 
 // Get the global adaptive selector for weighted character selection
 const adaptiveSelector = getGlobalAdaptiveSelector();
@@ -85,10 +90,12 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
   const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
+  const speakKana = useKanaPronunciation();
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const justAnsweredRef = useRef(false);
+  const isPronunciationPendingRef = useRef(false);
   const {
     targetLength,
     recordCorrect: recordTargetLengthCorrect,
@@ -141,7 +148,12 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
   const buildTargetPair = useCallback(() => {
     const sourceArray = isReverse ? selectedRomaji : selectedKana;
     if (sourceArray.length === 0) {
-      return { correctChar: '', targetChar: '', promptParts: [], answerParts: [] };
+      return {
+        correctChar: '',
+        targetChar: '',
+        promptParts: [],
+        answerParts: [],
+      };
     }
 
     const used = new Set<string>();
@@ -180,13 +192,17 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
   const answerParts = pairData.answerParts;
   const pauseTimer = useCallback(() => {
     if (answerStartTimeRef.current !== null) {
-      elapsedTimeMsRef.current += performance.now() - answerStartTimeRef.current;
+      elapsedTimeMsRef.current +=
+        performance.now() - answerStartTimeRef.current;
       answerStartTimeRef.current = null;
     }
   }, []);
   const getElapsedTimeMs = useCallback(() => {
     if (answerStartTimeRef.current !== null) {
-      return elapsedTimeMsRef.current + (performance.now() - answerStartTimeRef.current);
+      return (
+        elapsedTimeMsRef.current +
+        (performance.now() - answerStartTimeRef.current)
+      );
     }
     return elapsedTimeMsRef.current;
   }, []);
@@ -220,10 +236,7 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
       const isSpace = event.code === 'Space' || event.key === ' ';
       const isContinueShortcut = isEnter || isSpace;
 
-      if (
-        isContinueShortcut &&
-        shouldSuppressContinueKeyboardShortcut()
-      ) {
+      if (isContinueShortcut && shouldSuppressContinueKeyboardShortcut()) {
         event.preventDefault();
         return;
       }
@@ -331,6 +344,14 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
       timeTakenMs: answerTimeMs,
       extra: { isReverse },
     });
+
+    isPronunciationPendingRef.current = true;
+    void speakKana((isReverse ? answerParts : promptParts).join('')).then(
+      didSpeak => {
+        isPronunciationPendingRef.current = false;
+        if (didSpeak) handleContinue();
+      },
+    );
   };
 
   const handleWrongAnswer = (wrongInput: string) => {
@@ -374,6 +395,8 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
   };
 
   const handleContinue = useCallback(() => {
+    if (isPronunciationPendingRef.current) return;
+
     playClick();
     setInputValue('');
     generateNewCharacter();
@@ -476,4 +499,3 @@ const InputGame = ({ isHidden, isReverse = false }: InputGameProps) => {
 };
 
 export default InputGame;
-

--- a/features/Kana/components/Game/MCQ.tsx
+++ b/features/Kana/components/Game/MCQ.tsx
@@ -17,6 +17,7 @@ import { useSmartReverseMode } from '@/shared/hooks/game/useSmartReverseMode';
 import { useAdaptiveOptionCount } from '@/shared/hooks/game/useAdaptiveOptionCount';
 import useClassicSessionStore from '@/shared/store/useClassicSessionStore';
 import { getUniqueIncorrectOptions } from '@/features/Kana/lib/getUniqueIncorrectOptions';
+import { useKanaPronunciation } from '@/features/Kana/hooks/useKanaPronunciation';
 
 const random = new Random();
 
@@ -128,10 +129,12 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
   const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
+  const speakKana = useKanaPronunciation();
 
   const kanaGroupIndices = useKanaStore(state => state.kanaGroupIndices);
 
   const isProcessingRef = useRef(false);
+  const isPronunciationPendingRef = useRef(false);
 
   const selectedKana = useMemo(
     () => kanaGroupIndices.map(i => kana[i].kana).flat(),
@@ -162,9 +165,7 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
   const selectedPairs2 = useMemo<Record<string, string>>(
     () =>
       Object.fromEntries(
-        selectedRomaji
-          .map((key, i) => [key, selectedKana[i] ?? ''])
-          .reverse(),
+        selectedRomaji.map((key, i) => [key, selectedKana[i] ?? '']).reverse(),
       ),
     [selectedRomaji, selectedKana],
   );
@@ -214,9 +215,7 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
         void _;
         return getUniqueIncorrectOptions(
           correctRomajiChar,
-          Object.values(incorrectPairs).sort(
-            () => random.real(0, 1) - 0.5,
-          ),
+          Object.values(incorrectPairs).sort(() => random.real(0, 1) - 0.5),
           incorrectCount,
         );
       } else {
@@ -225,9 +224,7 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
         void _;
         return getUniqueIncorrectOptions(
           correctKanaCharReverse,
-          Object.values(incorrectPairs).sort(
-            () => random.real(0, 1) - 0.5,
-          ),
+          Object.values(incorrectPairs).sort(() => random.real(0, 1) - 0.5),
           incorrectCount,
         );
       }
@@ -311,7 +308,7 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
   }, [shuffledVariants]);
 
   const handleCorrectAnswer = useCallback(
-    (correctChar: string) => {
+    async (correctChar: string) => {
       playCorrect();
       addCharacterToHistory(correctChar);
       incrementCharacterScore(correctChar, 'correct');
@@ -321,8 +318,6 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
       triggerCrazyMode();
       // Update adaptive weight system - reduces probability of mastered characters
       adaptiveSelector.updateCharacterWeight(correctChar, true);
-      // Smart algorithm decides next mode based on performance
-      decideNextMode();
       // Progressive difficulty - track correct answer
       recordDifficultyCorrect();
       // Track content-specific stats for achievements (Requirements 1.1-1.8)
@@ -345,6 +340,9 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
         optionsShown: shuffledVariants,
         extra: { isReverse },
       });
+
+      await speakKana(isReverse ? correctKanaCharReverse : correctChar);
+      decideNextMode();
     },
     [
       playCorrect,
@@ -366,6 +364,7 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
       correctRomajiCharReverse,
       shuffledVariants,
       isReverse,
+      speakKana,
     ],
   );
 
@@ -428,20 +427,23 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
 
   const handleOptionClick = useCallback(
     (selectedChar: string) => {
-      if (isProcessingRef.current) return;
+      if (isProcessingRef.current || isPronunciationPendingRef.current) return;
       isProcessingRef.current = true;
 
       if (!isReverse) {
         // Normal pick mode logic
         if (selectedChar === correctRomajiChar) {
-          handleCorrectAnswer(correctKanaChar);
-          // Use weighted selection - prioritizes characters user struggles with
-          const newKana = adaptiveSelector.selectWeightedCharacter(
-            selectedKana,
-            correctKanaChar,
-          );
-          adaptiveSelector.markCharacterSeen(newKana);
-          setCorrectKanaChar(newKana);
+          isPronunciationPendingRef.current = true;
+          void handleCorrectAnswer(correctKanaChar).then(() => {
+            // Use weighted selection - prioritizes characters user struggles with
+            const newKana = adaptiveSelector.selectWeightedCharacter(
+              selectedKana,
+              correctKanaChar,
+            );
+            adaptiveSelector.markCharacterSeen(newKana);
+            setCorrectKanaChar(newKana);
+            isPronunciationPendingRef.current = false;
+          });
         } else {
           handleWrongAnswer(selectedChar);
         }
@@ -451,14 +453,17 @@ const KanaMCQ = ({ isHidden }: KanaMCQProps) => {
           reversedPairs1[selectedChar] === correctRomajiCharReverse ||
           reversedPairs2[selectedChar] === correctRomajiCharReverse
         ) {
-          handleCorrectAnswer(correctRomajiCharReverse);
-          // Use weighted selection - prioritizes characters user struggles with
-          const newRomaji = adaptiveSelector.selectWeightedCharacter(
-            selectedRomaji,
-            correctRomajiCharReverse,
-          );
-          adaptiveSelector.markCharacterSeen(newRomaji);
-          setCorrectRomajiCharReverse(newRomaji);
+          isPronunciationPendingRef.current = true;
+          void handleCorrectAnswer(correctRomajiCharReverse).then(() => {
+            // Use weighted selection - prioritizes characters user struggles with
+            const newRomaji = adaptiveSelector.selectWeightedCharacter(
+              selectedRomaji,
+              correctRomajiCharReverse,
+            );
+            adaptiveSelector.markCharacterSeen(newRomaji);
+            setCorrectRomajiCharReverse(newRomaji);
+            isPronunciationPendingRef.current = false;
+          });
         } else {
           handleWrongAnswer(selectedChar);
         }

--- a/features/Kana/components/Game/TilesMode.tsx
+++ b/features/Kana/components/Game/TilesMode.tsx
@@ -5,7 +5,11 @@ import clsx from 'clsx';
 import { kana } from '@/features/Kana/data/kana';
 import useKanaStore from '@/features/Kana/store/useKanaStore';
 import { Random } from 'random-js';
-import { useCorrect, useError, useClick } from '@/shared/hooks/generic/useAudio';
+import {
+  useCorrect,
+  useError,
+  useClick,
+} from '@/shared/hooks/generic/useAudio';
 // import GameIntel from '@/shared/ui-composite/Game/GameIntel';
 import { getGlobalAdaptiveSelector } from '@/shared/utils/adaptiveSelection';
 import Stars from '@/shared/ui-composite/Game/Stars';
@@ -25,11 +29,11 @@ import {
   gameContentVariants,
   getAnswerRowClassName,
   getGlassModeClassName,
-
   useTilesModeActionKey,
 } from '@/shared/ui-composite/Game/TilesModeShared';
 import TilesModeGrid from '@/shared/ui-composite/Game/TilesModeGrid';
 import useClassicSessionStore from '@/shared/store/useClassicSessionStore';
+import { useKanaPronunciation } from '@/features/Kana/hooks/useKanaPronunciation';
 
 const random = new Random();
 const adaptiveSelector = getGlobalAdaptiveSelector();
@@ -88,15 +92,23 @@ const KanaTilesMode = ({
     minWordLength: 1,
     maxWordLength: 3,
   });
-  const wordLength = isWordLengthControlled ? externalWordLength : internalWordLength;
+  const wordLength = isWordLengthControlled
+    ? externalWordLength
+    : internalWordLength;
 
-  const { startAnswerTimer, pauseAnswerTimer, getAnswerTimeMs, resetAnswerTimer } =
-    useAnswerTimer();
+  const {
+    startAnswerTimer,
+    pauseAnswerTimer,
+    getAnswerTimeMs,
+    resetAnswerTimer,
+  } = useAnswerTimer();
   const { playCorrect } = useCorrect();
   const { playErrorTwice } = useError();
   const { playClick } = useClick();
   const { trigger: triggerCrazyMode } = useCrazyModeTrigger();
+  const speakKana = useKanaPronunciation();
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const isPronunciationPendingRef = useRef(false);
 
   const stats = useGameStats('kana');
   const { score, setScore } = stats;
@@ -296,6 +308,30 @@ const KanaTilesMode = ({
   // Keyboard shortcut for Enter/Space to trigger button
   useTilesModeActionKey(buttonRef);
 
+  // Handle Continue button (only for correct answers)
+  const handleContinue = useCallback(() => {
+    if (isPronunciationPendingRef.current) return;
+
+    playClick();
+    if (externalIsReverse === undefined) {
+      decideNextReverseMode();
+    }
+    if (!isWordLengthControlled) {
+      decideNextTilesProgression();
+    }
+    externalOnCorrect?.(wordData.wordChars);
+    resetGame();
+  }, [
+    playClick,
+    externalIsReverse,
+    decideNextReverseMode,
+    isWordLengthControlled,
+    decideNextTilesProgression,
+    externalOnCorrect,
+    wordData.wordChars,
+    resetGame,
+  ]);
+
   // Handle Check button
   const handleCheck = useCallback(() => {
     if (placedTileIds.length === 0) return;
@@ -310,7 +346,9 @@ const KanaTilesMode = ({
     let isCorrect = false;
 
     if (placedTileIds.length === wordData.answerChars.length) {
-      const placedArray = placedTileIds.map(id => wordData.allTiles.get(id) ?? '');
+      const placedArray = placedTileIds.map(
+        id => wordData.allTiles.get(id) ?? '',
+      );
       isCorrect = placedArray.every(
         (tile, i) => tile === wordData.answerChars[i],
       );
@@ -356,6 +394,14 @@ const KanaTilesMode = ({
         optionsShown: Array.from(wordData.allTiles.values()),
         extra: { isReverse, wordLength },
       });
+
+      isPronunciationPendingRef.current = true;
+      void speakKana(
+        (isReverse ? wordData.answerChars : wordData.wordChars).join(''),
+      ).then(didSpeak => {
+        isPronunciationPendingRef.current = false;
+        if (didSpeak) handleContinue();
+      });
     } else {
       resetAnswerTimer();
       playErrorTwice();
@@ -363,7 +409,9 @@ const KanaTilesMode = ({
       incrementWrongStreak();
       incrementWrongAnswers();
 
-      const placedArray = placedTileIds.map(id => wordData.allTiles.get(id) ?? '');
+      const placedArray = placedTileIds.map(
+        id => wordData.allTiles.get(id) ?? '',
+      );
       wordData.wordChars.forEach((char, index) => {
         incrementCharacterScore(char, 'wrong');
         adaptiveSelector.updateCharacterWeight(
@@ -435,28 +483,8 @@ const KanaTilesMode = ({
     pauseAnswerTimer,
     getAnswerTimeMs,
     resetAnswerTimer,
-  ]);
-
-  // Handle Continue button (only for correct answers)
-  const handleContinue = useCallback(() => {
-    playClick();
-    if (externalIsReverse === undefined) {
-      decideNextReverseMode();
-    }
-    if (!isWordLengthControlled) {
-      decideNextTilesProgression();
-    }
-    externalOnCorrect?.(wordData.wordChars);
-    resetGame();
-  }, [
-    playClick,
-    externalIsReverse,
-    decideNextReverseMode,
-    isWordLengthControlled,
-    decideNextTilesProgression,
-    externalOnCorrect,
-    wordData.wordChars,
-    resetGame,
+    speakKana,
+    handleContinue,
   ]);
 
   // Not enough characters for tiles mode
@@ -490,12 +518,12 @@ const KanaTilesMode = ({
           )}
         >
           {/* Word Display */}
-            <div
-              className={getGlassModeClassName(
-                'flex flex-row items-center gap-1',
-                isGlassMode,
-              )}
-            >
+          <div
+            className={getGlassModeClassName(
+              'flex flex-row items-center gap-1',
+              isGlassMode,
+            )}
+          >
             <motion.p
               className={clsx(
                 'sm:text-8xl',
@@ -550,4 +578,3 @@ const KanaTilesMode = ({
 };
 
 export default KanaTilesMode;
-

--- a/features/Kana/hooks/useKanaPronunciation.ts
+++ b/features/Kana/hooks/useKanaPronunciation.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useAudioPreferences } from '@/features/Preferences';
+import { useJapaneseTTS } from '@/features/Preferences/hooks/useJapaneseTTS';
+
+export const useKanaPronunciation = () => {
+  const { pronunciationEnabled, pronunciationSpeed, pronunciationPitch } =
+    useAudioPreferences();
+  const { speak } = useJapaneseTTS();
+
+  return useCallback(
+    (text: string) => {
+      const normalizedText = text.trim();
+      if (!pronunciationEnabled || !normalizedText)
+        return Promise.resolve(false);
+
+      return speak(normalizedText, {
+        rate: pronunciationSpeed,
+        pitch: pronunciationPitch,
+        volume: 1.0,
+      }).then(() => true);
+    },
+    [pronunciationEnabled, pronunciationPitch, pronunciationSpeed, speak],
+  );
+};

--- a/features/Preferences/hooks/useJapaneseTTS.ts
+++ b/features/Preferences/hooks/useJapaneseTTS.ts
@@ -181,6 +181,7 @@ export const useJapaneseTTS = () => {
 
       return new Promise<void>(resolve => {
         const requestId = ++speakRequestIdRef.current;
+        let synthesisErrorRetries = 0;
 
         const stopCurrentSpeech = () => {
           if (speechSynthesis.speaking || speechSynthesis.pending) {
@@ -318,6 +319,16 @@ export const useJapaneseTTS = () => {
             utterance.onerror = event => {
               if (requestId !== speakRequestIdRef.current) {
                 resolve();
+                return;
+              }
+
+              // Chrome TTS can transiently fail, retry with delay
+              if (
+                event.error === 'synthesis-failed' &&
+                synthesisErrorRetries < 2
+              ) {
+                synthesisErrorRetries++;
+                setTimeout(() => attemptSpeak(0), 200);
                 return;
               }
 


### PR DESCRIPTION
…odes

## 📝 Description

Adds automatic TTS pronunciation after correct kana answers in all three game modes. When a user answers correctly, the kana/romaji is spoken aloud before proceeding to the next question — reinforcing correct pronunciation through immediate audio feedback.

Previously, correct answers were silent. Now users hear the correct reading, strengthening the sound–symbol association that's critical for kana mastery.

## 🔗 Related Issue


## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Enable pronunciation in Preferences → Audio
2. Kana Dojo → Pick mode: answer correctly → should hear kana spoken, then auto-advance
3. Switch to Reverse-Pick mode → answer correctly → should hear romaji spoken
4. Switch to Input mode → type correct romaji → should hear kana spoken, auto-continue
5. Switch to Reverse-Input mode → type correct kana → should hear romaji spoken, auto-continue
6. Disable pronunciation in Preferences → correct answers should behave silently as before (no regression)


## 📸 Screenshots/Videos (if applicable)

...

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

- features/Kana/hooks/useKanaPronunciation.ts (new) — thin hook wrapping useJapaneseTTS with preference gating (enabled/speed/pitch). Returns false when pronunciation is off or text is empty.
- features/Kana/components/Game/MCQ.tsx — made handleCorrectAnswer async; speaks kana after answer, then runs decideNextMode and selects next character.
- features/Kana/components/Game/Input.tsx — speaks answer after correct input; auto-continues when TTS finishes, skipping the manual Continue button press.
- features/Kana/components/Game/TilesMode.tsx — speaks word after correct tile placement; auto-continues when TTS finishes. Moved handleContinue definition above handleCheck to resolve the dependency order.
