### PR TITLE
fix(sidebar): resolve hydration mismatch from storage-dependent useState initializers

### DIFF
--- a/shared/ui-composite/Menu/Sidebar.tsx
+++ b/shared/ui-composite/Menu/Sidebar.tsx
@@ -355,47 +355,34 @@ const Sidebar = () => {
   const [loadedExperiments, setLoadedExperiments] = useState<Experiment[]>([]);
   const [isMobileViewport, setIsMobileViewport] = useState(false);
   const isVisible = useScrollVisibility();
-  const [isDesktopSidebarCollapsed, setIsDesktopSidebarCollapsed] = useState(
-    () => {
-      if (typeof window === 'undefined') return false;
-      return (
-        sessionStorage.getItem(SIDEBAR_DESKTOP_COLLAPSED_STORAGE_KEY) === 'true'
-      );
-    },
-  );
-  const [hasVisitedPreferences, setHasVisitedPreferences] = useState(() => {
-    if (typeof window === 'undefined') return false;
-
-    return (
-      localStorage.getItem(SIDEBAR_PREFERENCES_VISITED_STORAGE_KEY) === 'true'
-    );
-  });
+  const [isDesktopSidebarCollapsed, setIsDesktopSidebarCollapsed] =
+    useState(false);
+  const [hasVisitedPreferences, setHasVisitedPreferences] = useState(false);
 
   // Collapse state for all collapsible sections
-  const [isAcademyExpanded, setIsAcademyExpanded] = useState(() => {
-    if (typeof window === 'undefined') return false;
+  const [isAcademyExpanded, setIsAcademyExpanded] = useState(false);
+  const [isToolsExpanded, setIsToolsExpanded] = useState(false);
+  const [isExperimentsExpanded, setIsExperimentsExpanded] = useState(false);
 
-    const stored = sessionStorage.getItem(
-      `${SIDEBAR_SECTION_STORAGE_PREFIX}academy`,
+  // Sync from sessionStorage/localStorage on mount (browser only)
+  useEffect(() => {
+    setIsDesktopSidebarCollapsed(
+      sessionStorage.getItem(SIDEBAR_DESKTOP_COLLAPSED_STORAGE_KEY) === 'true',
     );
-    return stored === null ? false : stored === 'true';
-  });
-  const [isToolsExpanded, setIsToolsExpanded] = useState(() => {
-    if (typeof window === 'undefined') return false;
-
-    const stored = sessionStorage.getItem(
-      `${SIDEBAR_SECTION_STORAGE_PREFIX}tools`,
+    setHasVisitedPreferences(
+      localStorage.getItem(SIDEBAR_PREFERENCES_VISITED_STORAGE_KEY) === 'true',
     );
-    return stored === null ? false : stored === 'true';
-  });
-  const [isExperimentsExpanded, setIsExperimentsExpanded] = useState(() => {
-    if (typeof window === 'undefined') return false;
-
-    const stored = sessionStorage.getItem(
-      `${SIDEBAR_SECTION_STORAGE_PREFIX}experiments`,
-    );
-    return stored === null ? false : stored === 'true';
-  });
+    for (const [stateKey, setter] of [
+      ['academy', setIsAcademyExpanded],
+      ['tools', setIsToolsExpanded],
+      ['experiments', setIsExperimentsExpanded],
+    ] as const) {
+      const stored = sessionStorage.getItem(
+        `${SIDEBAR_SECTION_STORAGE_PREFIX}${stateKey}`,
+      );
+      if (stored !== null) setter(stored === 'true');
+    }
+  }, []);
 
   useEffect(() => {
     const EXPERIMENTS_ORDER_KEY = 'sidebar-experiments-order';


### PR DESCRIPTION
## 📝 Description

Fix Sidebar hydration mismatch: 5 `useState` lazy initializers read `localStorage`/`sessionStorage` with `typeof window` guards, producing different HTML between server (always `false`) and client (persisted state). Replaced with plain `useState(false)` + single `useEffect` that syncs storage on mount.

## 🔗 Related Issue

_No related issue_

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change

- [x] `fix`: Bug fix

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Visit `/kana`, refresh → no hydration error in console
2. Expand/collapse Academy section → refresh, state persists
3. Toggle desktop sidebar collapse → refresh, state persists