### PR TITLE
fix: move sidebar collapse button to top

### DIFF
--- a/shared/ui-composite/Menu/Sidebar.tsx
+++ b/shared/ui-composite/Menu/Sidebar.tsx
@@ -645,6 +645,21 @@ const Sidebar = () => {
           'lg:flex lg:w-full lg:flex-col lg:gap-1',
         )}
       >
+        <button
+          onClick={toggleDesktopSidebarCollapse}
+          className={clsx(
+            'ml-1.5 hidden cursor-pointer items-center rounded-2xl px-3 py-1.5 text-(--secondary-color) transition-colors hover:bg-(--card-color) hover:text-(--main-color) lg:flex',
+          )}
+          aria-label={
+            isDesktopSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'
+          }
+        >
+          {isDesktopSidebarCollapsed ? (
+            <PanelLeftOpen className='h-5 w-5 shrink-0' />
+          ) : (
+            <PanelLeftClose className='h-5 w-5 shrink-0' />
+          )}
+        </button>
         {mainNavItems.map(item => (
           <NavLink
             key={item.href}
@@ -712,22 +727,6 @@ const Sidebar = () => {
             </div>
           );
         })}
-
-      <button
-        onClick={toggleDesktopSidebarCollapse}
-        className={clsx(
-          'hidden cursor-pointer items-center rounded-2xl px-3 py-1.5 text-(--secondary-color) transition-colors hover:bg-(--card-color) hover:text-(--main-color) lg:absolute lg:bottom-8 lg:left-5 lg:flex',
-        )}
-        aria-label={
-          isDesktopSidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'
-        }
-      >
-        {isDesktopSidebarCollapsed ? (
-          <PanelLeftOpen className='h-5 w-5 shrink-0' />
-        ) : (
-          <PanelLeftClose className='h-5 w-5 shrink-0' />
-        )}
-      </button>
     </motion.aside>
   );
 };


### PR DESCRIPTION
## 📝 Description

Fixes an issue where the sidebar collapse button becomes inaccessible when the **Experiments** section contains a long list of items.

The collapse button has been moved from the bottom of the sidebar to the top, keeping it accessible even when the sidebar content overflows.

## 🔗 Related Issue

Closes #28092 

## ✅ Pre-Submission Checklist

- [ ] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Opened the Kana dojo.
2. Expanded the sidebar.
3. Opened the **Experiments** section.
4. Verified that the long list of experiments can be scrolled.
5. Verified that the sidebar collapse button remains accessible.
6. Tested collapsing and expanding the sidebar.
7. Tested the sidebar at different screen sizes.

<!--**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)
## image1

<img width="392" height="623" alt="sidebarfix2" src="https://github.com/user-attachments/assets/6fd46c1c-2b6f-40f1-8e1c-5927ae4fbb90" />

## image2

<img width="561" height="699" alt="sidebarfix1" src="https://github.com/user-attachments/assets/77a1af72-a9a2-4811-a915-229770d84035" />

## image3

<img width="523" height="678" alt="sidebarfix3" src="https://github.com/user-attachments/assets/12e2a02f-8e48-465b-8b6a-a3afa55313bd" />





## 📦 Additional Context

`npm run check` was run locally, but it reports errors in files unrelated to this change. This PR only modifies the positioning of the sidebar collapse button.
...
