### PR TITLE
fix(content): correct invalid JSON syntax in community-themes.json

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -102,9 +102,9 @@
     "secondaryColor": "oklch(80.0% 0.115 65.0 / 1)"
   },
   {
-  id: 'morning-dew',
-  backgroundColor: 'oklch(93.0% 0.025 155.0 / 1)',
-  mainColor: 'oklch(50.0% 0.155 160.0 / 1)',
-  secondaryColor: 'oklch(65.0% 0.120 170.0 / 1)'
-  },
+    "id": "morning-dew",
+    "backgroundColor": "oklch(93.0% 0.025 155.0 / 1)",
+    "mainColor": "oklch(50.0% 0.155 160.0 / 1)",
+    "secondaryColor": "oklch(65.0% 0.120 170.0 / 1)"
+  }
 ]


### PR DESCRIPTION
`community/content/community-themes.json` on `main` is currently invalid JSON. PR #28156 merged a new "morning-dew" theme entry with unquoted object keys and single-quoted string values (`id: 'morning-dew'` instead of `"id": "morning-dew"`), plus a trailing comma before the closing `]`. Running `JSON.parse()` on the file as it stands on `main` throws:

`SyntaxError: Expected property name or '}' in JSON at position 3229`

This PR corrects the syntax of that one entry only (proper double-quoted keys/values, trailing comma removed) — no data or values were changed.