### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -61,5 +61,6 @@
   "Japanese blood donation has such high demand that mobile donation buses give out snacks, drinks, and lottery tickets as thanks.",
   "Japan's elderly population is so large that adult diapers outsell baby diapers - reflecting one of the world's fastest-aging societies.",
   "The concept of 'seijaku' (静寂) means profound silence, often used to describe the quiet of temples or deep forests." ,
-  "'Natsukashii' (懐かしい) describes a warm, nostalgic feeling when recalling the past."
+  "'Natsukashii' (懐かしい) describes a warm, nostalgic feeling when recalling the past.",
+  "Japan’s 'shrine stamps' called 'goshuin' (御朱印) are calligraphy seals collected in special books by visitors."
 ]


### PR DESCRIPTION
Closes #28245

Adds the goshuin (御朱印) shrine-stamp fact to `community/content/japan-facts.json`, exactly as specified in the issue.

Verified the file still parses as valid JSON and the entry count goes 63 → 64. Appended textually so the rest of the file keeps its existing formatting and the diff stays to the one line added.