### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -61,5 +61,6 @@
   "Japanese blood donation has such high demand that mobile donation buses give out snacks, drinks, and lottery tickets as thanks.",
   "Japan's elderly population is so large that adult diapers outsell baby diapers - reflecting one of the world's fastest-aging societies.",
   "The concept of 'seijaku' (静寂) means profound silence, often used to describe the quiet of temples or deep forests." ,
-  "'Natsukashii' (懐かしい) describes a warm, nostalgic feeling when recalling the past."
+  "'Natsukashii' (懐かしい) describes a warm, nostalgic feeling when recalling the past.",
+  "There's a Japanese word 'betsu-bara' (別腹) meaning 'separate stomach' - the idea that there's always room for dessert even when full."
 ]


### PR DESCRIPTION
Closes #28237

Adds the betsu-bara (別腹) fact to `community/content/japan-facts.json`, exactly as specified in the issue.

Verified the file still parses as valid JSON and the entry count goes 63 → 64.