### PR TITLE
feat(theme): add Taisho Cafe theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -118,5 +118,11 @@
     "backgroundColor": "oklch(22.0% 0.035 140.0 / 1)",
     "mainColor": "oklch(74.0% 0.145 135.0 / 1)",
     "secondaryColor": "oklch(65.0% 0.085 115.0 / 1)"
+  },
+  {
+    "id": "taisho-cafe",
+    "backgroundColor": "oklch(18.0% 0.028 65.0 / 1)",
+    "mainColor": "oklch(72.0% 0.115 65.0 / 1)",
+    "secondaryColor": "oklch(60.0% 0.085 25.0 / 1)"
   }
 ]


### PR DESCRIPTION
Closes #28236

Adds the `taisho-cafe` community theme to `community/content/community-themes.json` with the four oklch values given in the issue.

One deviation worth flagging: the issue supplies the entry as a ```typescript block with unquoted keys and a trailing comma. Pasted verbatim into a `.json` file that would not parse, so it is added here as valid JSON — quoted keys, no trailing comma — matching the twenty themes already in the file.

Verified the file still parses and that the new entry carries exactly the same key set (`id`, `backgroundColor`, `mainColor`, `secondaryColor`) as every existing theme.