### PR TITLE
content: add JoJo's Bizarre Adventure anime quote

### DIFF
--- a/community/content/anime-quotes.json
+++ b/community/content/anime-quotes.json
@@ -741,6 +741,13 @@
   "english": "Don't let anyone else take control of your life and death! (alt wording 37)",
   "anime": "Demon Slayer: Kimetsu no Yaiba",
   "character": "Tanjiro Kamado"
- }
+ },
+{
+  "japanese": "ロードローラーだッ！",
+  "romaji": "Rodo rora da!",
+  "english": "Road roller! (alt wording 1)",
+  "anime": "JoJo's Bizarre Adventure: Stardust Crusaders",
+  "character": "DIO"
+}
 ]
 


### PR DESCRIPTION
Closes #28297

Adds DIO's ロードローラーだッ！ to `community/content/anime-quotes.json`.

| Japanese | Romaji | English |
|---|---|---|
| ロードローラーだッ！ | Rodo rora da! | Road roller! (alt wording 1) |

**Anime:** JoJo's Bizarre Adventure: Stardust Crusaders — **Character:** DIO

Checked before adding:
- The quote is **not already in the file** (several open content issues in this repo have in fact already been merged, so I verified against the file rather than trusting the issue being open).
- The file still parses as JSON, and all 106 pre-existing entries are byte-identical — the diff is the added entry only.
- Appended textually rather than reserialising, so this does not reformat the file or collide with the other open content PRs.