### PR TITLE
content: add komorebi Japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -64,5 +64,6 @@
   "'Natsukashii' (懐かしい) describes a warm, nostalgic feeling when recalling the past.",
   "There's a Japanese word 'betsu-bara' (別腹) meaning 'separate stomach' - the idea that there's always room for dessert even when full.",
   "Japan has a shrine where you can pray for better Wi-Fi signal - the Kanda Myojin Shrine in Tokyo blesses electronics.",
-  "The Japanese word 'ganbarimasu' (頑張ります) is said before attempting something difficult - a commitment to do your absolute best."
+  "The Japanese word 'ganbarimasu' (頑張ります) is said before attempting something difficult - a commitment to do your absolute best.",
+  "There's a Japanese word 'komorebi' (木漏れ日) specifically for sunlight filtering through leaves - no direct English translation exists."
 ]


### PR DESCRIPTION
Closes #28294

Adds to `community/content/japan-facts.json`:

> There's a Japanese word 'komorebi' (木漏れ日) specifically for sunlight filtering through leaves - no direct English translation exists.

Checked before adding: the fact is **not already in the file** (several open content issues here have already been merged, so I verified against the file rather than trusting the issue being open), the file still parses as JSON, and all 66 pre-existing entries are byte-identical.