### PR TITLE
content: add 〜やすい grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -88,5 +88,6 @@
   "\"〜にとって\" means \"for / to (someone)\".",
   "\"〜ておく\" means \"do in advance\" or \"leave as is\".",
   "\"〜てもらう\" means \"receive a favor\" from someone. (practice variation 16)",
-  "\"〜ようにする\" means \"make an effort to...\""
+  "\"〜ようにする\" means \"make an effort to...\"",
+  "\"〜やすい\" attaches to verb stems to mean \"easy to do\". (practice variation 44)"
 ]


### PR DESCRIPTION
Closes #28289

Adds to `community/content/japanese-grammar.json`:

> "〜やすい" attaches to verb stems to mean "easy to do". (practice variation 44)

Checked before adding: not already in the file, the file still parses as JSON, and all 86 pre-existing entries are byte-identical.