### PR TITLE
chore: add てしまう grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -88,5 +88,6 @@
   "\"〜にとって\" means \"for / to (someone)\".",
   "\"〜ておく\" means \"do in advance\" or \"leave as is\".",
   "\"〜てもらう\" means \"receive a favor\" from someone. (practice variation 16)",
-  "\"〜ようにする\" means \"make an effort to...\""
+  "\"〜ようにする\" means \"make an effort to...\"",
+  "〜てしまう can express completion or regret (\"end up doing\")."
 ]


### PR DESCRIPTION
## Summary
Add grammar point for てしまう (expresses completion or regret) to community/content/japanese-grammar.json.

## Changes
- Added: `〜てしまう can express completion or regret ("end up doing").`

## Issue
Closes #28350