### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ npm run check
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.com/#lingdojo/kana-dojo&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.dera.page/#lingdojo/kana-dojo&Date)
 
 </div>
 

--- a/docs/translations/README.id.md
+++ b/docs/translations/README.id.md
@@ -28,7 +28,7 @@
 
 ## Riwayat Bintang
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lingdojo/kana-dojo&type=date&legend=top-left)](https://www.star-history.com/#lingdojo/kana-dojo&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lingdojo/kana-dojo&type=date&legend=top-left)](https://star-history.dera.page/#lingdojo/kana-dojo&type=date&legend=top-left)
 
 **Platform estetis, minimalis, dan sangat dapat disesuaikan untuk menguasai bahasa Jepang yang terinspirasi oleh Monkeytype**
 

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -8,7 +8,7 @@
 
 ## Storico Stelle
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lingdojo/kana-dojo&type=date&legend=top-left)](https://www.star-history.com/#lingdojo/kana-dojo&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lingdojo/kana-dojo&type=date&legend=top-left)](https://star-history.dera.page/#lingdojo/kana-dojo&type=date&legend=top-left)
 
 **Una piattaforma esteticamente bella e minimalista per padroneggiare il Giapponese ispirata a MonkeyType**
 

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -101,7 +101,7 @@ Next.js 15 · React 19 · TypeScript · Tailwind CSS · shadcn/ui · Zustand · 
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.com/#lingdojo/kana-dojo&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.dera.page/#lingdojo/kana-dojo&Date)
 
 </div>
 

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -109,7 +109,7 @@ Next.js 15 · React 19 · TypeScript · Tailwind CSS · shadcn/ui · Zustand · 
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.com/#lingdojo/kana-dojo&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.dera.page/#lingdojo/kana-dojo&Date)
 
 </div>
 

--- a/docs/translations/README.ua.md
+++ b/docs/translations/README.ua.md
@@ -28,7 +28,7 @@
 
 ## Історія зірок
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lingdojo/kana-dojo&type=date&legend=top-left)](https://www.star-history.com/#lingdojo/kana-dojo&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lingdojo/kana-dojo&type=date&legend=top-left)](https://star-history.dera.page/#lingdojo/kana-dojo&type=date&legend=top-left)
 
 **Естетична, мінімалістична та надзвичайно гнучка платформа для опанування японської мови, натхненна Monkeytype**
 

--- a/docs/translations/README.vi.md
+++ b/docs/translations/README.vi.md
@@ -115,7 +115,7 @@ Hoan nghênh mọi đóng góp! Cho dù bạn đang sửa lỗi, thêm tính nă
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.com/#lingdojo/kana-dojo&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=lingdojo/kana-dojo&type=Date)](https://star-history.dera.page/#lingdojo/kana-dojo&Date)
 
 </div>
 


### PR DESCRIPTION
The star history chart in the README was broken because of GitHub stargazer API restrictions, which caused the chart to stop rendering. This change updates the README and its translations to use a working star history service so the chart displays correctly again.