### PR TITLE
fix(observability): make Sentry configuration fork-safe

### DIFF
--- a/app/sentry-example-page/page.tsx
+++ b/app/sentry-example-page/page.tsx
@@ -1,13 +1,13 @@
-"use client";
+'use client';
 
-import * as Sentry from "@sentry/nextjs";
-import Head from "next/head";
-import { useEffect, useState } from "react";
+import * as Sentry from '@sentry/nextjs';
+import Head from 'next/head';
+import { useEffect, useState } from 'react';
 
 class SentryExampleFrontendError extends Error {
   constructor(message: string | undefined) {
     super(message);
-    this.name = "SentryExampleFrontendError";
+    this.name = 'SentryExampleFrontendError';
   }
 }
 
@@ -16,10 +16,10 @@ export default function Page() {
   const [isConnected, setIsConnected] = useState(true);
 
   useEffect(() => {
-    Sentry.logger.info("Sentry example page loaded");
+    Sentry.logger.info('Sentry example page loaded');
     async function checkConnectivity() {
       const result = await Sentry.diagnoseSdkConnectivity();
-      setIsConnected(result !== "sentry-unreachable");
+      setIsConnected(result !== 'sentry-unreachable');
     }
     checkConnectivity();
   }, []);
@@ -28,40 +28,33 @@ export default function Page() {
     <div>
       <Head>
         <title>sentry-example-page</title>
-        <meta name="description" content="Test Sentry for your Next.js app!" />
+        <meta name='description' content='Test Sentry for your Next.js app!' />
       </Head>
 
       <main>
-        <div className="flex-spacer" />
+        <div className='flex-spacer' />
         <svg
-          height="40"
-          width="40"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          role="img"
-          aria-label="Sentry logo"
+          height='40'
+          width='40'
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          role='img'
+          aria-label='Sentry logo'
         >
           <path
-            d="M21.85 2.995a3.698 3.698 0 0 1 1.353 1.354l16.303 28.278a3.703 3.703 0 0 1-1.354 5.053 3.694 3.694 0 0 1-1.848.496h-3.828a31.149 31.149 0 0 0 0-3.09h3.815a.61.61 0 0 0 .537-.917L20.523 5.893a.61.61 0 0 0-1.057 0l-3.739 6.494a28.948 28.948 0 0 1 9.63 10.453 28.988 28.988 0 0 1 3.499 13.78v1.542h-9.852v-1.544a19.106 19.106 0 0 0-2.182-8.85 19.08 19.08 0 0 0-6.032-6.829l-1.85 3.208a15.377 15.377 0 0 1 6.382 12.484v1.542H3.696A3.694 3.694 0 0 1 0 34.473c0-.648.17-1.286.494-1.849l2.33-4.074a8.562 8.562 0 0 1 2.689 1.536L3.158 34.17a.611.611 0 0 0 .538.917h8.448a12.481 12.481 0 0 0-6.037-9.09l-1.344-.772 4.908-8.545 1.344.77a22.16 22.16 0 0 1 7.705 7.444 22.193 22.193 0 0 1 3.316 10.193h3.699a25.892 25.892 0 0 0-3.811-12.033 25.856 25.856 0 0 0-9.046-8.796l-1.344-.772 5.269-9.136a3.698 3.698 0 0 1 3.2-1.849c.648 0 1.285.17 1.847.495Z"
-            fill="currentcolor"
+            d='M21.85 2.995a3.698 3.698 0 0 1 1.353 1.354l16.303 28.278a3.703 3.703 0 0 1-1.354 5.053 3.694 3.694 0 0 1-1.848.496h-3.828a31.149 31.149 0 0 0 0-3.09h3.815a.61.61 0 0 0 .537-.917L20.523 5.893a.61.61 0 0 0-1.057 0l-3.739 6.494a28.948 28.948 0 0 1 9.63 10.453 28.988 28.988 0 0 1 3.499 13.78v1.542h-9.852v-1.544a19.106 19.106 0 0 0-2.182-8.85 19.08 19.08 0 0 0-6.032-6.829l-1.85 3.208a15.377 15.377 0 0 1 6.382 12.484v1.542H3.696A3.694 3.694 0 0 1 0 34.473c0-.648.17-1.286.494-1.849l2.33-4.074a8.562 8.562 0 0 1 2.689 1.536L3.158 34.17a.611.611 0 0 0 .538.917h8.448a12.481 12.481 0 0 0-6.037-9.09l-1.344-.772 4.908-8.545 1.344.77a22.16 22.16 0 0 1 7.705 7.444 22.193 22.193 0 0 1 3.316 10.193h3.699a25.892 25.892 0 0 0-3.811-12.033 25.856 25.856 0 0 0-9.046-8.796l-1.344-.772 5.269-9.136a3.698 3.698 0 0 1 3.2-1.849c.648 0 1.285.17 1.847.495Z'
+            fill='currentcolor'
           />
         </svg>
         <h1>sentry-example-page</h1>
 
-        <p className="description">
-          Click the button below, and view the sample error on the Sentry{" "}
+        <p className='description'>
+          Click the button below, and view the sample error on your Sentry
+          Issues Page. For more details about setting up Sentry,{' '}
           <a
-            target="_blank"
-            rel="noopener"
-            href="https://zephyr-software.sentry.io/issues/?project=4511608067981312"
-          >
-            Issues Page
-          </a>
-          . For more details about setting up Sentry,{" "}
-          <a
-            target="_blank"
-            rel="noopener"
-            href="https://docs.sentry.io/platforms/javascript/guides/nextjs/"
+            target='_blank'
+            rel='noopener'
+            href='https://docs.sentry.io/platforms/javascript/guides/nextjs/'
           >
             read our docs
           </a>
@@ -69,23 +62,25 @@ export default function Page() {
         </p>
 
         <button
-          type="button"
+          type='button'
           onClick={async () => {
-            Sentry.logger.info("User clicked the button, throwing a sample error");
+            Sentry.logger.info(
+              'User clicked the button, throwing a sample error',
+            );
             await Sentry.startSpan(
               {
-                name: "Example Frontend/Backend Span",
-                op: "test",
+                name: 'Example Frontend/Backend Span',
+                op: 'test',
               },
               async () => {
-                const res = await fetch("/api/sentry-example-api");
+                const res = await fetch('/api/sentry-example-api');
                 if (!res.ok) {
                   setHasSentError(true);
                 }
               },
             );
             throw new SentryExampleFrontendError(
-              "This error is raised on the frontend of the example page.",
+              'This error is raised on the frontend of the example page.',
             );
           }}
           disabled={!isConnected}
@@ -94,9 +89,9 @@ export default function Page() {
         </button>
 
         {hasSentError ? (
-          <p className="success">Error sent to Sentry.</p>
+          <p className='success'>Error sent to Sentry.</p>
         ) : !isConnected ? (
-          <div className="connectivity-error">
+          <div className='connectivity-error'>
             <p>
               It looks like network requests to Sentry are being blocked, which
               will prevent errors from being captured. Try disabling your
@@ -104,10 +99,10 @@ export default function Page() {
             </p>
           </div>
         ) : (
-          <div className="success_placeholder" />
+          <div className='success_placeholder' />
         )}
 
-        <div className="flex-spacer" />
+        <div className='flex-spacer' />
       </main>
 
       <style>{`

--- a/docs/VERCEL_DEPLOYMENT.md
+++ b/docs/VERCEL_DEPLOYMENT.md
@@ -75,23 +75,59 @@ For each pull request:
 
 ### Required Variables
 
-| Variable                        | Description                      | Where to Get                                              |
-| ------------------------------- | -------------------------------- | --------------------------------------------------------- |
-| `GOOGLE_TRANSLATE_API_KEY`      | Google Cloud Translation API key | [Google Cloud Console](https://console.cloud.google.com/) |
-| `NEXT_PUBLIC_GA_ID`             | Google Analytics measurement ID  | [Google Analytics](https://analytics.google.com/)         |
-| `NEXT_PUBLIC_POSTHOG_KEY`       | PostHog API key (client)         | [PostHog](https://posthog.com/)                           |
-| `POSTHOG_API_KEY`               | PostHog API key (server, optional; falls back to `NEXT_PUBLIC_POSTHOG_KEY`) | [PostHog](https://posthog.com/)                 |
-| `POSTHOG_HOST`                  | PostHog host (optional; falls back to `NEXT_PUBLIC_POSTHOG_HOST`) | [PostHog](https://posthog.com/)                           |
-| `NEXT_PUBLIC_SUPABASE_URL`      | Supabase project URL             | [Supabase](https://supabase.com/)                         |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anonymous key           | [Supabase](https://supabase.com/)                         |
+| Variable                        | Description                                                                 | Where to Get                                              |
+| ------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `GOOGLE_TRANSLATE_API_KEY`      | Google Cloud Translation API key                                            | [Google Cloud Console](https://console.cloud.google.com/) |
+| `NEXT_PUBLIC_GA_ID`             | Google Analytics measurement ID                                             | [Google Analytics](https://analytics.google.com/)         |
+| `NEXT_PUBLIC_POSTHOG_KEY`       | PostHog API key (client)                                                    | [PostHog](https://posthog.com/)                           |
+| `POSTHOG_API_KEY`               | PostHog API key (server, optional; falls back to `NEXT_PUBLIC_POSTHOG_KEY`) | [PostHog](https://posthog.com/)                           |
+| `POSTHOG_HOST`                  | PostHog host (optional; falls back to `NEXT_PUBLIC_POSTHOG_HOST`)           | [PostHog](https://posthog.com/)                           |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Supabase project URL                                                        | [Supabase](https://supabase.com/)                         |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anonymous key                                                      | [Supabase](https://supabase.com/)                         |
 
 ### Optional Variables
 
 | Variable              | Description                       | Default |
 | --------------------- | --------------------------------- | ------- |
 | `DISCORD_WEBHOOK_URL` | Discord webhook for notifications | Not set |
-| `SENTRY_DSN`          | Sentry error tracking             | Not set |
 | `ANALYZE`             | Bundle analysis                   | `false` |
+
+### Sentry (optional, opt-in)
+
+Sentry is **disabled by default**. When no DSN is configured the SDK is a no-op:
+no errors, logs, or PII are sent, and no source maps are uploaded. A fork that
+sets no Sentry variables stays fully silent. To use Sentry, set the variables
+below explicitly — nothing is hardcoded.
+
+#### Runtime
+
+| Variable                              | Scope         | Default | Description                                                     |
+| ------------------------------------- | ------------- | ------- | --------------------------------------------------------------- |
+| `SENTRY_DSN`                          | server / edge | not set | DSN for server and edge error reporting                         |
+| `NEXT_PUBLIC_SENTRY_DSN`              | client        | not set | DSN for browser error reporting; inlined into the client bundle |
+| `SENTRY_ENABLE_LOGS`                  | server / edge | `false` | Enable Sentry structured logs (`Sentry.logger`)                 |
+| `NEXT_PUBLIC_SENTRY_ENABLE_LOGS`      | client        | `false` | Same, for the browser                                           |
+| `SENTRY_SEND_DEFAULT_PII`             | server / edge | `false` | Attach default PII (IP, user id, headers, …) to events          |
+| `NEXT_PUBLIC_SENTRY_SEND_DEFAULT_PII` | client        | `false` | Same, for the browser                                           |
+
+Booleans use the literal string `true` (not `1`). `SENTRY_*` targets server and
+edge; the `NEXT_PUBLIC_*` variants target the browser.
+
+#### Source map upload (build-time)
+
+Uploaded only when **all four** of the following are set:
+
+| Variable                    | Description                                       |
+| --------------------------- | ------------------------------------------------- |
+| `SENTRY_UPLOAD_SOURCE_MAPS` | `true` enables source map upload                  |
+| `SENTRY_AUTH_TOKEN`         | **Secret.** Token used to authenticate the upload |
+| `SENTRY_ORG`                | Sentry organization slug                          |
+| `SENTRY_PROJECT`            | Sentry project slug                               |
+
+> **Migration note (official deployment).** These values were previously
+> hardcoded. Configure `SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`, the logs/PII
+> flags, and the source map upload variables before merging, or error reporting
+> and source map upload will silently stop.
 
 ### Setting Environment Variables
 

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,16 +1,20 @@
 // instrumentation-client.ts
 import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: 'https://a6f82883d78e424ee7b578556b78743d@o4511608063197184.ingest.us.sentry.io/4511608067981312',
-  // Performance rescue: Sentry Replay is intentionally disabled for now.
-  // integrations: [Sentry.replayIntegration()],
-  tracesSampleRate: 0.1,
-  enableLogs: true,
-  // replaysSessionSampleRate: 0.1,
-  // replaysOnErrorSampleRate: 1.0,
-  sendDefaultPii: true,
-});
+const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    // Performance rescue: Sentry Replay is intentionally disabled for now.
+    // integrations: [Sentry.replayIntegration()],
+    tracesSampleRate: 0.1,
+    enableLogs: process.env.NEXT_PUBLIC_SENTRY_ENABLE_LOGS === 'true',
+    // replaysSessionSampleRate: 0.1,
+    // replaysOnErrorSampleRate: 1.0,
+    sendDefaultPii: process.env.NEXT_PUBLIC_SENTRY_SEND_DEFAULT_PII === 'true',
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
 
@@ -64,10 +68,6 @@ if (typeof window !== 'undefined' && !sessionStorage.getItem(RELOAD_FLAG)) {
     }
   });
 }
-if (process.env.NODE_ENV === 'development') {
-  console.log('PostHog client instrumentation disabled in development mode.');
-}
-
 /*
  * Performance rescue: PostHog is intentionally disabled without deleting the
  * integration. Re-enable only after a measured analytics rollout.

--- a/next.config.ts
+++ b/next.config.ts
@@ -220,40 +220,58 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withSentryConfig(withBundleAnalyzer(withNextIntl(nextConfig)), {
-  // For all available options, see:
-  // https://www.npmjs.com/package/@sentry/webpack-plugin#options
+// Fork-safe: apply the Sentry build plugin when runtime Sentry is enabled (DSN set).
+// Source map upload is independently gated and requires explicit opt-in + credentials.
+const sentryRuntimeEnabled = Boolean(
+  process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+);
 
-  org: "zephyr-software",
+const shouldUploadSourceMaps =
+  sentryRuntimeEnabled &&
+  process.env.SENTRY_UPLOAD_SOURCE_MAPS === 'true' &&
+  Boolean(process.env.SENTRY_AUTH_TOKEN) &&
+  Boolean(process.env.SENTRY_ORG) &&
+  Boolean(process.env.SENTRY_PROJECT);
 
-  project: "javascript-nextjs",
+const config = withBundleAnalyzer(withNextIntl(nextConfig));
 
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
+export default sentryRuntimeEnabled
+  ? withSentryConfig(config, {
+      // For all available options, see:
+      // https://www.npmjs.com/package/@sentry/webpack-plugin#options
+      org: process.env.SENTRY_ORG,
+      project: process.env.SENTRY_PROJECT,
+      authToken: process.env.SENTRY_AUTH_TOKEN,
 
-  // For all available options, see:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+      // Only print logs for uploading source maps in CI
+      silent: !process.env.CI,
 
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: true,
+      // Upload a larger set of source maps for prettier stack traces (increases build time)
+      widenClientFileUpload: true,
 
-  // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
-  // This can increase your server load as well as your hosting bill.
-  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
-  // side errors will fail.
-  tunnelRoute: "/monitoring",
+      // Disable source map upload unless explicitly opted in
+      sourcemaps: {
+        disable: !shouldUploadSourceMaps,
+      },
 
-  webpack: {
-    // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-    // See the following for more information:
-    // https://docs.sentry.io/product/crons/
-    // https://vercel.com/docs/cron-jobs
-    automaticVercelMonitors: true,
+      // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+      // This can increase your server load as well as your hosting bill.
+      // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+      // side errors will fail.
+      tunnelRoute: '/monitoring',
 
-    // Tree-shaking options for reducing bundle size
-    treeshake: {
-      // Automatically tree-shake Sentry logger statements to reduce bundle size
-      removeDebugLogging: true,
-    },
-  },
-});
+      webpack: {
+        // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+        // See the following for more information:
+        // https://docs.sentry.io/product/crons/
+        // https://vercel.com/docs/cron-jobs
+        automaticVercelMonitors: true,
+
+        // Tree-shaking options for reducing bundle size
+        treeshake: {
+          // Automatically tree-shake Sentry logger statements to reduce bundle size
+          removeDebugLogging: true,
+        },
+      },
+    })
+  : config;

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -3,18 +3,23 @@
 // Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: "https://a6f82883d78e424ee7b578556b78743d@o4511608063197184.ingest.us.sentry.io/4511608067981312",
+const dsn = process.env.SENTRY_DSN;
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+// Fork-safe: without a DSN the SDK stays disabled and sends nothing.
+if (dsn) {
+  Sentry.init({
+    dsn,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+    tracesSampleRate: 1,
 
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
-});
+    // Enable logs to be sent to Sentry
+    enableLogs: process.env.SENTRY_ENABLE_LOGS === 'true',
+
+    // Enable sending user PII (Personally Identifiable Information)
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
+    sendDefaultPii: process.env.SENTRY_SEND_DEFAULT_PII === 'true',
+  });
+}

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -2,18 +2,23 @@
 // The config you add here will be used whenever the server handles a request.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import * as Sentry from "@sentry/nextjs";
+import * as Sentry from '@sentry/nextjs';
 
-Sentry.init({
-  dsn: "https://a6f82883d78e424ee7b578556b78743d@o4511608063197184.ingest.us.sentry.io/4511608067981312",
+const dsn = process.env.SENTRY_DSN;
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+// Fork-safe: without a DSN the SDK stays disabled and sends nothing.
+if (dsn) {
+  Sentry.init({
+    dsn,
 
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
+    // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
+    tracesSampleRate: 1,
 
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
-});
+    // Enable logs to be sent to Sentry
+    enableLogs: process.env.SENTRY_ENABLE_LOGS === 'true',
+
+    // Enable sending user PII (Personally Identifiable Information)
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
+    sendDefaultPii: process.env.SENTRY_SEND_DEFAULT_PII === 'true',
+  });
+}


### PR DESCRIPTION
## 📝 Description

Sentry is hardcoded to the official `zephyr-software` project, so any fork reports errors into the upstream account. This PR makes Sentry **fork-safe**: disabled by default, opt-in via environment variables.

- `sentry.server.config.ts` / `sentry.edge.config.ts` / `instrumentation-client.ts`: read the DSN from env and skip `Sentry.init()` entirely when unset.
- `next.config.ts`: apply `withSentryConfig` only when a DSN is present; `org` / `project` / `authToken` come from env; source-map upload is gated behind `SENTRY_UPLOAD_SOURCE_MAPS=true` + credentials.
- `enableLogs` and `sendDefaultPii` now default to `false` (opt-in).
- `app/sentry-example-page/page.tsx`: remove the hardcoded upstream Issues-Page link.
- `docs/VERCEL_DEPLOYMENT.md`: document the new variables.

**New environment variables**

| Scope | Variables |
| --- | --- |
| Runtime (server/edge) | `SENTRY_DSN`, `SENTRY_ENABLE_LOGS`, `SENTRY_SEND_DEFAULT_PII` |
| Runtime (client) | `NEXT_PUBLIC_SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_ENABLE_LOGS`, `NEXT_PUBLIC_SENTRY_SEND_DEFAULT_PII` |
| Source maps (build) | `SENTRY_UPLOAD_SOURCE_MAPS`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` |

**Behavior**

| Environment | Result |
| --- | --- |
| No Sentry vars | SDK disabled — no events, no source-map upload (safe default) |
| DSN only | Errors reported to that DSN; no source-map upload |
| DSN + upload vars | Errors reported + source maps uploaded |

**Backward compatibility** — the official deployment must now set these variables explicitly; with the previous values, behavior is unchanged.

## 🔗 Related Issue

N/A — no linked issue.

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change

- [x] `refactor`
- [x] `docs`
- [x] `fix`

## 🧪 How Has This Been Tested?

1. `tsc` + `eslint` pass (pre-commit hook).
2. Manual build: no-env (Sentry skipped) and DSN-only.
3. `sourcemaps.disable` confirmed valid in `@sentry/nextjs@10.x`.

## 📦 Additional Context

Pairs with the `codex/personal-vercel-hobby-guide` branch (personal Hobby deployment guide, separate PR).

