### PR TITLE
fix: normalize vocabulary answers

### DIFF
--- a/features/Vocabulary/lib/isVocabularyMeaningAnswerCorrect.ts
+++ b/features/Vocabulary/lib/isVocabularyMeaningAnswerCorrect.ts
@@ -2,7 +2,12 @@ import { toHiragana } from 'wanakana';
 import type { IVocabObj } from '@/entities/vocabulary';
 
 const normalize = (value: string): string =>
-  value.trim().normalize('NFC').toLowerCase();
+  value
+    .replace(/[\u200B-\u200D\uFEFF]/g, '')
+    .replace(/\u00A0/g, ' ')
+    .trim()
+    .normalize('NFC')
+    .toLowerCase();
 
 const normalizeMeaning = (value: string): string =>
   normalize(value).replace(/^to\s+/, '');
@@ -25,7 +30,6 @@ export const isVocabularyMeaningAnswerCorrect = (
 
   return (
     normalize(vocabulary.word) === normalizedAnswer ||
-    toHiragana(normalizedAnswer) ===
-      toHiragana(normalize(vocabulary.reading))
+    toHiragana(normalizedAnswer) === toHiragana(normalize(vocabulary.reading))
   );
 };


### PR DESCRIPTION
## What changed

Improved vocabulary answer normalization to handle hidden Unicode
characters and non-breaking spaces before comparing answers.

### Changes
- Removed zero-width characters
- Removed zero-width no-break characters
- Converted non-breaking spaces to regular spaces
- Preserved existing trimming, Unicode normalization, and lowercase handling

## Testing

- Verified the vocabulary answer validation locally
- Pre-commit ESLint and TypeScript checks passed