### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -316,5 +316,11 @@
     "romaji": "Kuchi wa wazawai no moto",
     "english": "The mouth is the source of disaster",
     "meaning": "Careless words cause trouble"
+  },
+  {
+    "japanese": "毒を食らわば皿まで",
+    "romaji": "Doku wo kurawaba sara made",
+    "english": "If you eat poison, eat the plate too",
+    "meaning": "If you must do something risky, go all the way"
   }
 ]


### PR DESCRIPTION
Adds the Japanese proverb 毒を食らわば皿まで (Doku wo kurawaba sara made) to `community/content/japanese-proverbs.json`.

| Field | Value |
|---|---|
| Japanese | 毒を食らわば皿まで |
| Reading | Doku wo kurawaba sara made |
| English | If you eat poison, eat the plate too |
| Meaning | If you must do something risky, go all the way |

Checked before submitting: the entry is not a duplicate (neither the Japanese nor the romaji already appears in the file), it follows the exact same key order and indentation as the existing 53 entries, and the file still parses as valid JSON (53 → 54 entries).

Closes #28597