### PR TITLE
content: add new trivia question

### DIFF
--- a/community/content/japan-trivia-medium.json
+++ b/community/content/japan-trivia-medium.json
@@ -63,5 +63,16 @@
     "difficulty": "medium",
     "answers": ["Nagano", "Sapporo", "Niigata", "Sendai"],
     "correctIndex": 0
+  },
+  {
+    "question": "Which Japanese castle was the seat of the Tokugawa shogunate? (Community variation 40)",
+    "difficulty": "medium",
+    "answers": [
+      "Edo Castle",
+      "Himeji Castle",
+      "Matsumoto Castle",
+      "Osaka Castle"
+    ],
+    "correctIndex": 0
   }
 ]


### PR DESCRIPTION
## What

Adds a new medium-difficulty trivia question to `community/content/japan-trivia-medium.json`:

> Which Japanese castle was the seat of the Tokugawa shogunate? (Community variation 40)

Closes #28736.

## Why

The community trivia bank is grown via good-first-issue contributions; this adds a new question as requested in #28736.

## How verified

- JSON parsed successfully with Node (`require(...)`) — 11 entries, valid syntax.
- Diff limited to appending one entry plus the trailing comma.