### PR TITLE
fix(ci): validate fork PR files through API

### DIFF
--- a/.github/workflows/pr-community-review.yml
+++ b/.github/workflows/pr-community-review.yml
@@ -67,14 +67,6 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
-      - name: Checkout PR head
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr-head
-          fetch-depth: 1
-          persist-credentials: false
 
       - name: Validate and process contribution
         uses: actions/github-script@v7
@@ -308,17 +300,27 @@ jobs:
             }
 
             for (const file of contentPaths.filter(function(file) { return file.endsWith('.json'); })) {
-              const filePath = path.join('pr-head', file);
-              if (!fs.existsSync(filePath)) {
-                errors.push(`${file} was not found in the PR checkout`);
-                continue;
-              }
-              try {
-                JSON.parse(fs.readFileSync(filePath, 'utf8'));
-              } catch (e) {
-                errors.push(`Invalid JSON in ${file}: ${e.message}`);
-              }
-            }
+  try {
+    const headRepo = context.payload.pull_request.head.repo;
+
+    const response = await github.rest.repos.getContent({
+      owner: headRepo.owner.login,
+      repo: headRepo.name,
+      path: file,
+      ref: context.payload.pull_request.head.sha
+    });
+
+    if (Array.isArray(response.data) || response.data.type !== 'file') {
+      errors.push(`${file} could not be retrieved as a file from the PR`);
+      continue;
+    }
+
+    const content = Buffer.from(response.data.content, 'base64').toString('utf8');
+    JSON.parse(content);
+  } catch (e) {
+    errors.push(`Invalid JSON in ${file}: ${e.message}`);
+  }
+}
 
             try {
               foundIssue = await findMatchingIssue(validationType);


### PR DESCRIPTION
## 📝 Description

Fix the Community Contribution Auto-Review workflow so fork pull requests
can be validated without checking out untrusted fork code in a
`pull_request_target` workflow.

The workflow now retrieves changed JSON files through the GitHub API using
the pull request's head repository and exact head SHA.

## 🐞 Problem

The previous workflow attempted to use `actions/checkout@v4` to check out the
fork PR head from a `pull_request_target` workflow.

GitHub rejected this with:

> Refusing to check out fork pull request code from a
> 'pull_request_target' workflow.

## 🔧 Solution

- Remove the fork PR checkout.
- Retrieve changed JSON files using `github.rest.repos.getContent()`.
- Validate the retrieved content with `JSON.parse()`.
- Use the PR's exact head SHA when retrieving files.

This avoids checking out untrusted fork code while preserving the workflow's
ability to validate PR content.

## 🧪 Testing

- `git diff --check` passes.
- Verified there are no remaining `pr-head` references.
- Verified the workflow uses the GitHub API for JSON validation.

## 🔗 Related

This fixes the Community Contribution Auto-Review failure encountered by fork
pull requests.