### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -318,9 +318,15 @@
     "meaning": "Careless words cause trouble"
   },
   {
-  "japanese": "七転び八起き",
-  "romaji": "Nanakorobi yaoki",
-  "english": "Fall seven times, get up eight",
-  "meaning": "Never give up"
+    "japanese": "七転び八起き",
+    "romaji": "Nanakorobi yaoki",
+    "english": "Fall seven times, get up eight",
+    "meaning": "Never give up"
+  },
+  {
+    "japanese": "犬も歩けば棒に当たる",
+    "romaji": "Inu mo arukeba bou ni ataru",
+    "english": "Even a walking dog will hit a stick",
+    "meaning": "Try anything and you might get lucky (or unlucky)"
   }
 ]


### PR DESCRIPTION
Closes #28746

Adds the proverb 犬も歩けば棒に当たる (Inu mo arukeba bou ni ataru — "Even a walking dog will hit a stick") to `community/content/japanese-proverbs.json` per the issue instructions.