### PR TITLE
content: add new grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -15,5 +15,6 @@
   "\"〜うちに\" means \"while\" or \"before\" something changes.",
   "\"〜て以来\" means \"since (doing)\".",
   "〜てしまう can express completion or regret (\"end up doing\").",
-  "\"〜わけにはいかない\" means \"cannot (due to circumstances)\"."
+  "\"〜わけにはいかない\" means \"cannot (due to circumstances)\".",
+  "\"〜ところ\" refers to a point in time, like \"about to\", \"in the middle of\", or \"just finished\"."
 ]


### PR DESCRIPTION
Closes #28749

Adds the grammar point for 〜ところ (a point in time — "about to" / "in the middle of" / "just finished") to `community/content/japanese-grammar.json` per the issue instructions.