### PR TITLE
ci(auto-review): stop checking out fork PR code in pull_request_target

### DIFF
--- a/.github/workflows/pr-community-review.yml
+++ b/.github/workflows/pr-community-review.yml
@@ -67,22 +67,11 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
-      - name: Checkout PR head
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
-          path: pr-head
-          fetch-depth: 1
-          persist-credentials: false
-
       - name: Validate and process contribution
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.AUTOMATION_PR_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            const path = require('path');
             const templates = require('./.github/templates/messages.cjs');
             const t = templates.communityReview;
 
@@ -307,14 +296,28 @@ jobs:
               }
             }
 
+            // The fork's changed files are fetched through the GitHub API at the
+            // PR head SHA and parsed as data only; fork code is never checked out
+            // or executed in this trusted pull_request_target context.
+            const headRepo = context.payload.pull_request.head.repo;
+            const headSha = context.payload.pull_request.head.sha;
             for (const file of contentPaths.filter(function(file) { return file.endsWith('.json'); })) {
-              const filePath = path.join('pr-head', file);
-              if (!fs.existsSync(filePath)) {
-                errors.push(`${file} was not found in the PR checkout`);
+              let rawContent;
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner: headRepo.owner.login,
+                  repo: headRepo.name,
+                  path: file,
+                  ref: headSha,
+                  mediaType: { format: 'raw' },
+                });
+                rawContent = data;
+              } catch (e) {
+                errors.push(`Could not fetch ${file} from the PR head: ${e.message}`);
                 continue;
               }
               try {
-                JSON.parse(fs.readFileSync(filePath, 'utf8'));
+                JSON.parse(rawContent);
               } catch (e) {
                 errors.push(`Invalid JSON in ${file}: ${e.message}`);
               }


### PR DESCRIPTION
## Problem

The **Community Contribution Auto-Review** workflow (`pr-community-review.yml`) is failing for contributions from forks with:

```
Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities.
```

GitHub Actions now blocks `actions/checkout` of fork `pull_request` code inside `pull_request_target` workflows (see <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/> and the `allow-unsafe-pr-checkout` opt-in).

## Fix

The workflow never executed fork code — it only read the changed `community/content/*.json` files as data to validate them. This PR removes the `Checkout PR head` step entirely and fetches the changed JSON files through the GitHub API (`repos.getContent` against the PR head SHA with the `raw` media type) instead:

- No fork code is ever placed on disk or executed in the trusted `pull_request_target` context — better than the `allow-unsafe-pr-checkout: true` opt-in.
- The base-branch checkout stays, since the github-script still requires `.github/templates/messages.cjs` from the base.
- Validation behavior is unchanged: changed `community/content/*.json` files are still JSON-parsed, and failures still produce the same error comments.

## Verification

- YAML parses; the extracted github-script is brace/paren-balanced and keeps the same controls (file listing, path allow-listing, JSON validation, issue auto-linking, review comment).
- `fs`/`path` requires were dropped since nothing on disk is read from the PR anymore.