### PR TITLE
content: add new grammar point

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -16,5 +16,6 @@
   "\"〜て以来\" means \"since (doing)\".",
   "〜てしまう can express completion or regret (\"end up doing\").",
   "\"〜わけにはいかない\" means \"cannot (due to circumstances)\".",
-  "\"〜てもらう\" means \"receive a favor\" from someone. (practice variation 16)"
+  "\"〜てもらう\" means \"receive a favor\" from someone. (practice variation 16)",
+  "\"〜せいで\" indicates a negative cause, \"because of\". (practice variation 53)"
 ]


### PR DESCRIPTION
## Summary
- Added a new Japanese grammar point explaining 〜せいで.
- 〜せいで indicates a negative cause, meaning "because of".

Closes #28853