### PR TITLE
fix(content): repair invalid JSON in community-themes.json

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -204,11 +204,11 @@
     "secondaryColor": "oklch(88.0% 0.095 85.0 / 1)"
   },
   {
-     "id": "matcha-drift",
-     "backgroundColor": "oklch(18.5% 0.035 140.0 / 1)",
-     "mainColor":"oklch(76.0% 0.140 135.0 / 1)",
-     "secondaryColor": "oklch(72.0% 0.070 80.0 / 1)",
-   },
+    "id": "matcha-drift",
+    "backgroundColor": "oklch(18.5% 0.035 140.0 / 1)",
+    "mainColor": "oklch(76.0% 0.140 135.0 / 1)",
+    "secondaryColor": "oklch(72.0% 0.070 80.0 / 1)"
+  },
   {
     "id": "soba-slate",
     "backgroundColor": "oklch(18.0% 0.015 250.0 / 1)",


### PR DESCRIPTION
## Description

This PR repairs the broken JSON syntax in `community/content/community-themes.json`. The file currently fails `JSON.parse` on `main` (trailing comma after the `matcha-drift` entry), which blocks the community CI check requiring valid JSON for all files under `community/content/`.

### Fixes applied

- ➖ Removed trailing comma after the `matcha-drift` entry
- 🔧 Restored 4-space indentation and consistent `"key": "value"` spacing on that entry


### Validation

```
$ node -e "JSON.parse(require('fs').readFileSync('community/content/community-themes.json','utf8')); console.log('valid')"
valid
```

- ✅ Valid JSON
- ✅ Theme count unchanged: **36** (`firefly-field` present, nothing added or removed)
- ✅ Only file touched: `community/content/community-themes.json`

Related to #28945
