### PR TITLE
content: fix invalid JSON in japanese-proverbs.json

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -318,26 +318,27 @@
     "meaning": "Careless words cause trouble"
   },
   {
-  "japanese": "七転び八起き",
-  "romaji": "Nanakorobi yaoki",
-  "english": "Fall seven times, get up eight",
-  "meaning": "Never give up"
+    "japanese": "七転び八起き",
+    "romaji": "Nanakorobi yaoki",
+    "english": "Fall seven times, get up eight",
+    "meaning": "Never give up"
   },
   {
-  "japanese": "急いては事を仕損じる",
-  "romaji": "Seite wa koto wo shisonjiru",
-  "english": "Haste will spoil things",
-  "meaning": "Haste makes waste"
+    "japanese": "急いては事を仕損じる",
+    "romaji": "Seite wa koto wo shisonjiru",
+    "english": "Haste will spoil things",
+    "meaning": "Haste makes waste"
   },
   {
-  "japanese": "二度あることは三度ある",
-  "romaji": "Nido aru koto wa sando aru",
-  "english": "What happens twice will happen a third time",
-  "meaning": "Patterns tend to repeat"
+    "japanese": "二度あることは三度ある",
+    "romaji": "Nido aru koto wa sando aru",
+    "english": "What happens twice will happen a third time",
+    "meaning": "Patterns tend to repeat"
+  },
+  {
+    "japanese": "二兎を追う者は一兎をも得ず",
+    "romaji": "Ni to wo ou mono wa itto wo mo ezu",
+    "english": "Chase two rabbits, catch none",
+    "meaning": "Focus on one thing"
   }
-  {
-  "japanese": "二兎を追う者は一兎をも得ず",
-  "romaji": "Ni to wo ou mono wa itto wo mo ezu",
-  "english": "Chase two rabbits, catch none",
-  "meaning": "Focus on one thing"
-}
+]


### PR DESCRIPTION
## Description

This PR repairs the broken JSON syntax in `community/content/japanese-proverbs.json`. The file currently fails `JSON.parse` on `main`, which means the community CI check (`pr-community-review.yml`, requiring all `community/content/` files to be valid JSON) would fail for any contribution touching this file.

### Fixes applied

- ➕ Added missing comma between the entries at line 337–338 (`二度あることは三度ある` → `二兎を追う者は一兎をも得ず`)
- ➕ Added the missing closing `]` at the end of the array
- 🔧 Restored 4-space indentation on the last 4 entries to match the rest of the file

### ⚠️ Note about issue #28939 (Proverb 163 — 雨後の筍)

I was assigned #28939, which asks contributors to add 雨後の筍 (Ugo no takenoko / backlog id 163). However, this proverb **already exists** in the content file (~line 123) with identical romaji, english and meaning fields:

```json
{
  "japanese": "雨後の筍",
  "romaji": "Ugo no takenoko",
  "english": "Bamboo shoots after rain",
  "meaning": "Things spring up rapidly"
}
```

Adding it again would create a duplicate, so instead of following the issue instructions literally I fixed the pre-existing JSON breakage that would have blocked CI anyway. I also commented on the issue so maintainers can mark backlog item 163 as completed.


### Validation

```
$ node -e "JSON.parse(require('fs').readFileSync('community/content/japanese-proverbs.json','utf8')); console.log('valid')"
valid
```

- ✅ Valid JSON
- ✅ Entry count unchanged: **57** (nothing added or removed)
- ✅ Only file touched: `community/content/japanese-proverbs.json`

Related to #28939