### PR TITLE
fix(i18n): remove orphaned flat locale files

### DIFF
--- a/core/i18n/locales/en.json
+++ b/core/i18n/locales/en.json
@@ -1,7 +1,0 @@
-{
-  "MenuInfo": {
-    "greeting": "Welcome to KanaDojo!",
-    "description": "KanaDojo is an aesthetic, minimalist platform for learning Japanese inspired by Monkeytype.",
-    "instructions": "To begin, select a dojo and start training now!"
-  }
-}

--- a/core/i18n/locales/es.json
+++ b/core/i18n/locales/es.json
@@ -1,7 +1,0 @@
-{
-  "MenuInfo": {
-    "greeting": "¡Bienvenido a KanaDojo!",
-    "description": "KanaDojo es una plataforma divertida, estética y minimalista para aprender y practicar el idioma Japonés en linea.",
-    "instructions": "Para empezar, coge un dojo. ¡Y comienza a entrenar ahora!"
-  }
-}

--- a/core/i18n/locales/zh.json
+++ b/core/i18n/locales/zh.json
@@ -1,7 +1,0 @@
-{
-  "MenuInfo": {
-    "greeting": "欢迎使用 KanaDojo！",
-    "description": "KanaDojo 是一个美观、社区驱动的日语学习平台，灵感来自 Duolingo 和 Monkeytype。",
-    "instructions": "开始之前，请在下方选择一个道场，立即开始训练！"
-  }
-}


### PR DESCRIPTION
## Description

Removed three orphaned flat locale files from `core/i18n/locales/`:

- `en.json`
- `es.json`
- `zh.json`

These files are no longer used by the runtime i18n loader and contain stale `MenuInfo` namespace data. The current locale structure uses per-locale namespace files instead.

## Related Issue

Closes #28964

## Pre-Submission Checklist

- [x] I have starred the repo
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors
- [x] My commit messages follow the Conventional Commits format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## How Has This Been Tested?

**Test Steps:**

1. Verified that the three orphaned locale files were removed.
2. Ran `npm run lint`; it completed with 0 errors, with existing warnings remaining.
3. Ran the test suite; unrelated `localStorage`/`localforage` test-environment failures were observed.
4. Verified that only the three intended locale files are included in the commit.

## Screenshots/Videos (if applicable)

Not applicable — this is an i18n cleanup with no UI changes.

**Helpful links:** [Contributing](https://github.com/lingdojo/kana-dojo/blob/main/CONTRIBUTING.md) · [Troubleshooting](https://github.com/lingdojo/kana-dojo/blob/main/docs/TROUBLESHOOTING.md)

## Additional Context

The removed files contained the stale `MenuInfo` namespace and were not part of the current namespace-based locale loading structure.