### PR TITLE
content: repair invalid JSON in japanese-haiku.json

### DIFF
--- a/community/content/japanese-haiku.json
+++ b/community/content/japanese-haiku.json
@@ -105,48 +105,24 @@
   "poet": "Masaoka Shiki",
   "season": "Autumn",
   "kigo": "Persimmon (kaki)",
-  "notes": "A quintessential autumn haiku contrasting the everyday act of eating fruit with the timeless ringing of a temple bell."
-},
+    "notes": "A quintessential autumn haiku contrasting the everyday act of eating fruit with the timeless ringing of a temple bell."
+  },
   {
-  "japanese": "秋深き
-隣は何を
-する人ぞ",
-  "romaji": "Aki fukaki / tonari wa nani o / suru hito zo",
-  "english": "In deep autumn, what kind of person lives next door?",
-  "poet": "Matsuo Basho",
-  "season": "Autumn",
-  "kigo": "Deep autumn (aki fukaki)",
-  "notes": "Evokes solitude and curiosity."
-},
-{
-  "japanese": "雀の子
-そこのけそこのけ
-お馬が通る",
-  "romaji": "Suzume no ko / soko noke soko noke / ouma ga toru",
-  "english": "Little sparrows, move aside, the horse is coming through.",
-  "poet": "Kobayashi Issa",
-  "season": "Spring",
-  "kigo": "Sparrow chicks (suzume no ko)",
-  "notes": "Playful and warm, characteristic of Issa's tone."
-},
+    "japanese": "雀の子\nそこのけそこのけ\nお馬が通る",
+    "romaji": "Suzume no ko / soko noke soko noke / ouma ga toru",
+    "english": "Little sparrows, move aside, the horse is coming through.",
+    "poet": "Kobayashi Issa",
+    "season": "Spring",
+    "kigo": "Sparrow chicks (suzume no ko)",
+    "notes": "Playful and warm, characteristic of Issa's tone."
+  },
   {
-  "japanese": "春の海
-ひねもすのたり
-のたりかな",
-  "romaji": "Haru no umi / hinemosu notari / notari kana",
-  "english": "The spring sea stretches lazily all day, rising and falling.",
-  "poet": "Yosa Buson",
-  "season": "Spring",
-  "kigo": "Spring sea (haru no umi)",
-  "notes": "Known for musical phrasing and calm motion."
-},
-  {
-  "japanese": "古池や\n蛙飛びこむ\n水の音",
-  "romaji": "Furu ike ya / kawazu tobikomu / mizu no oto",
-  "english": "An old pond; a frog jumps in; the sound of water.",
-  "poet": "Matsuo Basho",
-  "season": "Spring",
-  "kigo": "Frog (kawazu)",
-  "notes": "A foundational haiku focused on stillness and sudden movement."
-}
+    "japanese": "古池や\n蛙飛びこむ\n水の音",
+    "romaji": "Furu ike ya / kawazu tobikomu / mizu no oto",
+    "english": "An old pond; a frog jumps in; the sound of water.",
+    "poet": "Matsuo Basho",
+    "season": "Spring",
+    "kigo": "Frog (kawazu)",
+    "notes": "A foundational haiku focused on stillness and sudden movement."
+  }
 ]


### PR DESCRIPTION
Three entries contained literal newlines inside string values (秋深き, 雀の子, 春の海), which made the whole file fail JSON.parse. Replace them with escaped \\n sequences and restore 4-space indentation on the tail entries.

Also remove two exact duplicate objects (秋深き and 春の海 existed both mid-file and at the tail) - same result as running scripts/deduplicate-content.js.

Unique haiku count unchanged in substance: 16 entries -> 14 unique.

