### PR TITLE
content: add anime quote

### DIFF
--- a/community/content/anime-quotes.json
+++ b/community/content/anime-quotes.json
@@ -397,5 +397,12 @@
   "english": "Lend me your energy!",
   "anime": "Dragon Ball Z",
   "character": "Son Goku"
+ },
+ {
+  "japanese": "レロレロレロレロ",
+  "romaji": "Rero rero rero rero",
+  "english": "Lero lero lero lero. (alt wording 27) (alt wording 79)",
+  "anime": "JoJo's Bizarre Adventure: Stardust Crusaders",
+  "character": "Noriaki Kakyoin"
 }
 ]


### PR DESCRIPTION
## Description

Adds anime quote **レロレロレロレロ** (Rero rero rero rero — Noriaki Kakyoin, *JoJo's Bizarre Adventure: Stardust Crusaders*) to `community/content/anime-quotes.json`, as requested in #29023 (backlog id 131, alt wording 79 variant).

```json
{
  "japanese": "レロレロレロレロ",
  "romaji": "Rero rero rero rero",
  "english": "Lero lero lero lero. (alt wording 27) (alt wording 79)",
  "anime": "JoJo's Bizarre Adventure: Stardust Crusaders",
  "character": "Noriaki Kakyoin"
}
```

### Note

A sibling entry with the same quote already exists in the file (english ending with `(alt wording 27)`). This PR adds the exact variant requested by the issue so backlog item 131 can be marked completed; if maintainers prefer to keep only one copy, I'm happy to drop this or update the existing entry instead.

### Validation

```
$ node -e "JSON.parse(require('fs').readFileSync('community/content/anime-quotes.json','utf8')); console.log('valid')"
valid
```

- ✅ Valid JSON
- ✅ Quote count: **58** (57 → 58, one entry appended at the end)
- ✅ Only file touched: `community/content/anime-quotes.json`

Closes #29023