### PR TITLE
content: add new japanese false friend

### DIFF
--- a/community/content/japanese-false-friends.json
+++ b/community/content/japanese-false-friends.json
@@ -160,5 +160,11 @@
   "termB": "revenge (English)",
   "explanation": "Often used as 'try again after failing'. (Set 4)",
   "example": "去年落ちた試験に今年リベンジする。"
+ },
+ {
+  "termA": "ドンマイ (donmai)",
+  "termB": "don't mind (English)",
+  "explanation": "Used to comfort someone: 'never mind'. (Set 4)",
+  "example": "ミスしてもドンマイ！"
 }
 ]


### PR DESCRIPTION
## Description

Adds the false friend pair **ドンマイ (donmai) / don't mind** to `community/content/japanese-false-friends.json`, as requested in #29031 (backlog id 73, Set 4 variant).

```json
{
  "termA": "ドンマイ (donmai)",
  "termB": "don't mind (English)",
  "explanation": "Used to comfort someone: 'never mind'. (Set 4)",
  "example": "ミスしてもドンマイ！"
}
```

### Note

Two sibling entries with the same pair (labelled `Set 2`) already exist in the file — this PR adds exactly the `Set 4` variant requested by the issue so backlog item 73 can be marked completed. If maintainers would rather consolidate the duplicates, happy to adjust.

### Validation

```
$ node -e "JSON.parse(require('fs').readFileSync('community/content/japanese-false-friends.json','utf8')); console.log('valid')"
valid
```

- ✅ Valid JSON
- ✅ Pair count: **28** (27 → 28, appended at the end, matching local formatting)
- ✅ Only file touched: `community/content/japanese-false-friends.json`

Closes #29031
