### PR TITLE
fix(vocab): correct there/over there glosses for そちら/そっち/あちら

### DIFF
--- a/public/data-vocab/n5.json
+++ b/public/data-vocab/n5.json
@@ -123,7 +123,7 @@
     "jmdict_seq": "1483185",
     "kana": "あちら",
     "kanji": "",
-    "waller_definition": "there"
+    "waller_definition": "over there"
   },
   {
     "jmdict_seq": "1343460",
@@ -2037,13 +2037,13 @@
     "jmdict_seq": "1006780",
     "kana": "そちら",
     "kanji": "",
-    "waller_definition": "over there"
+    "waller_definition": "there"
   },
   {
     "jmdict_seq": "1006780",
     "kana": "そっち",
     "kanji": "",
-    "waller_definition": "over there"
+    "waller_definition": "there"
   },
   {
     "jmdict_seq": "1203250",


### PR DESCRIPTION
Closes #28820
そちら/そっち (near-listener demonstrative) were glossed as 'over there' — corrected to 'there'.
あちら (far demonstrative) was glossed as 'there', inconsistent with its casual form あっち which was already 'over there' — corrected to 'over there' to match.