### PR TITLE
Fix common Japanese language mistakes

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -128,5 +128,10 @@
   "wrong": "会議は三時からで始まります。",
   "correct": "会議は三時から始まります。",
   "explanation": "Remove unnecessary particle after から. (Pattern set 5)"
+},
+  {
+  "wrong": "私は日本語を話しますです。",
+  "correct": "私は日本語を話します。",
+  "explanation": "Do not stack ます and です in one predicate. (Pattern set 2)"
 }
 ]


### PR DESCRIPTION
Added the new learner mistake pair to the Japanese common mistakes list.

This helps learners avoid incorrectly combining ます and です in the same predicate.

Closes #29181

## 📝 Description

...

## 🔗 Related Issue

Closes #

## ✅ Pre-Submission Checklist

- [ ] I have starred the repo ⭐
- [ ] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [ ] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

<!--
**Manual Test Checklist:**

- [ ] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

...

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

...
