### PR TITLE
feat(theme): add Taiko Thunder theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -238,6 +238,12 @@
     "backgroundColor": "oklch(14.0% 0.060 300.0 / 1)",
     "mainColor": "oklch(78.0% 0.220 330.0 / 1)",
     "secondaryColor": "oklch(85.0% 0.175 190.0 / 1)"
+  },
+  {
+    "id": "taiko-thunder",
+    "backgroundColor": "oklch(17.0% 0.035 280.0 / 1)",
+    "mainColor": "oklch(68.0% 0.175 30.0 / 1)",
+    "secondaryColor": "oklch(78.0% 0.125 45.0 / 1)"
   }
 ]
 


### PR DESCRIPTION
## Why

Issue #29186 asks for the community theme `taiko-thunder` in `community/content/community-themes.json`. This PR adds that entry so the assigned good-first-issue can close.

## Scope

- Appends one object to `community/content/community-themes.json` with `id` `taiko-thunder` and the issue's OKLCH colors.
- Does not change `features/Preferences/data/themes/themeDefinitions.ts` (that file already defines the same id).
- Does not touch backlog or automation state files.

Closes #29186

## Blast Radius

Learners and maintainers see one new community theme registry row. Runtime theme selection still comes from `themeDefinitions.ts`, so app behavior stays the same. Vercel already ignores this content path for deploys.

## Verification

- `python3` JSON parse of `community/content/community-themes.json` succeeded.
- Asserted `taiko-thunder` appears exactly once with the issue's three color fields.
- Diff is +6 lines on that file only.


Made with [Cursor](https://cursor.com)