### PR TITLE
content: add japanese haiku

### DIFF
--- a/community/content/japanese-haiku.json
+++ b/community/content/japanese-haiku.json
@@ -124,5 +124,14 @@
     "season": "Spring",
     "kigo": "Frog (kawazu)",
     "notes": "A foundational haiku focused on stillness and sudden movement."
+  },
+  {
+    "japanese": "朝顔に\nつるべ取られて\nもらい水",
+    "romaji": "Asagao ni / tsurube torarete / morai mizu",
+    "english": "Morning glories took my well-bucket; I asked next door for water.",
+    "poet": "Kaga no Chiyo",
+    "season": "Summer",
+    "kigo": "Morning glory (asagao)",
+    "notes": "Famous for gentle empathy toward nature."
   }
 ]


### PR DESCRIPTION
## Summary
- Add Kaga no Chiyo’s classic summer haiku (朝顔に / つるべ取られて / もらい水) to `community/content/japanese-haiku.json`

## Test plan
- [ ] Confirm JSON is valid
- [ ] Confirm the new entry appears at the end of the haiku array with correct fields

Closes #29247