### PR TITLE
feat(ux): auto-advance after skipping streak milestone overlay (#29270)

### DIFF
--- a/shared/store/useContinueRequestStore.ts
+++ b/shared/store/useContinueRequestStore.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { create } from 'zustand';
+
+interface ContinueRequestState {
+  requestCount: number;
+  requestContinue: () => void;
+}
+
+const useContinueRequestStore = create<ContinueRequestState>(set => ({
+  requestCount: 0,
+  requestContinue: () =>
+    set(state => ({ requestCount: state.requestCount + 1 })),
+}));
+
+export default useContinueRequestStore;

--- a/shared/ui-composite/Game/GameBottomBar.test.tsx
+++ b/shared/ui-composite/Game/GameBottomBar.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GameBottomBar } from '@/shared/ui-composite/Game/GameBottomBar';
+import useContinueRequestStore from '@/shared/store/useContinueRequestStore';
 
 describe('GameBottomBar feedback freezing', () => {
   it('keeps last checked feedback while transitioning through check state', () => {
@@ -84,3 +85,80 @@ describe('GameBottomBar feedback freezing', () => {
   });
 });
 
+describe('GameBottomBar milestone-skip auto-continue', () => {
+  beforeEach(() => {
+    useContinueRequestStore.setState({ requestCount: 0 });
+  });
+
+  it('triggers onAction when a continue request arrives in correct state', () => {
+    const onAction = vi.fn();
+    const buttonRef = React.createRef<HTMLButtonElement>();
+    render(
+      <GameBottomBar
+        state='correct'
+        onAction={onAction}
+        canCheck
+        feedbackContent='answer-a'
+        buttonRef={buttonRef}
+      />,
+    );
+
+    act(() => {
+      useContinueRequestStore.getState().requestContinue();
+    });
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger onAction for continue requests in check state', () => {
+    const onAction = vi.fn();
+    render(
+      <GameBottomBar
+        state='check'
+        onAction={onAction}
+        canCheck={false}
+        feedbackContent={null}
+      />,
+    );
+
+    act(() => {
+      useContinueRequestStore.getState().requestContinue();
+    });
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger onAction for continue requests in wrong state', () => {
+    const onAction = vi.fn();
+    render(
+      <GameBottomBar
+        state='wrong'
+        onAction={onAction}
+        canCheck
+        feedbackContent='answer-a'
+      />,
+    );
+
+    act(() => {
+      useContinueRequestStore.getState().requestContinue();
+    });
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-continue on mount when previous requests exist', () => {
+    const onAction = vi.fn();
+    useContinueRequestStore.setState({ requestCount: 3 });
+
+    render(
+      <GameBottomBar
+        state='correct'
+        onAction={onAction}
+        canCheck
+        feedbackContent='answer-a'
+      />,
+    );
+
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});

--- a/shared/ui-composite/Game/GameBottomBar.tsx
+++ b/shared/ui-composite/Game/GameBottomBar.tsx
@@ -4,6 +4,7 @@ import { CircleCheck, RotateCcw, Flag } from 'lucide-react';
 import clsx from 'clsx';
 import { ActionButton } from '@/shared/ui/components/ActionButton';
 import { useClick } from '@/shared/hooks/generic/useAudio';
+import useContinueRequestStore from '@/shared/store/useContinueRequestStore';
 
 // Toggle between new SVG check icon (true) and old CircleCheck icon (false)
 const USE_NEW_CHECK_ICON = true;
@@ -47,9 +48,24 @@ export const GameBottomBar = ({
   const isCorrect = state === 'correct';
   const isWrong = state === 'wrong';
   const [hideWrongFeedback, setHideWrongFeedback] = useState(false);
-  const lastClearSignalRef = useRef<number | undefined>(clearWrongFeedbackSignal);
+  const lastClearSignalRef = useRef<number | undefined>(
+    clearWrongFeedbackSignal,
+  );
   const showFeedback = state !== 'check' && !(isWrong && hideWrongFeedback);
   const showContinue = isCorrect;
+
+  // Skipping the streak milestone overlay advances to the next question by
+  // reusing the "next" button's handler (#29270).
+  const requestCount = useContinueRequestStore(state => state.requestCount);
+  const lastSeenRequestCountRef = useRef(requestCount);
+
+  useEffect(() => {
+    if (requestCount === lastSeenRequestCountRef.current) return;
+    lastSeenRequestCountRef.current = requestCount;
+    if (!isCorrect) return;
+    buttonRef?.current?.click();
+  }, [requestCount, isCorrect, buttonRef]);
+
   // When hideRetry is true, treat wrong state like check state for button display
   const showRetryButton = isWrong && !hideRetry;
   const showNextButton =

--- a/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
+++ b/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
@@ -11,6 +11,7 @@ import AdSenseDisplay from '@/shared/ui-composite/Ads/AdSenseDisplay';
 import { GameBottomBar } from '@/shared/ui-composite/Game/GameBottomBar';
 import BottomBar from '@/shared/ui-composite/layout/BottomBar';
 import { suppressContinueKeyboardShortcuts } from '@/shared/utils/game/continueShortcutGuard';
+import useContinueRequestStore from '@/shared/store/useContinueRequestStore';
 import { ENABLE_EVERY_QUESTION_AD_OVERLAY } from '@/shared/utils/game/streakMilestones';
 
 const STREAK_MILESTONE_AD_SLOT = '2642983933';
@@ -85,6 +86,9 @@ export default function StreakMilestoneOverlay({
 }: StreakMilestoneOverlayProps) {
   const { isGlassMode } = useThemePreferences();
   const { playClick } = useClick();
+  const requestContinue = useContinueRequestStore(
+    state => state.requestContinue,
+  );
   const skipButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
@@ -131,6 +135,7 @@ export default function StreakMilestoneOverlay({
 
   const handleDismiss = () => {
     playClick();
+    requestContinue();
     onDismiss();
   };
 


### PR DESCRIPTION
## 📝 Description

When the user hits a streak milestone (10, 25, 50, …), the StreakMilestoneOverlay appears over the question that was just answered. Pressing Skip previously only closed the overlay, leaving the already-completed question on screen with a "next/continue" button — forcing an extra click (and some confusion).
This PR makes Skip auto-advance to the next question by reusing the exact handler the "next" button already uses, so the game flow stays smooth with no extra interaction.
How it works (minimal change):
- Added a tiny shared Zustand signal store — shared/store/useContinueRequestStore.ts — with requestContinue() (increments requestCount).
- StreakMilestoneOverlay.handleDismiss now fires requestContinue() alongside onDismiss (covers both the button click and the Enter/Space shortcut).
- GameBottomBar (shared by every game mode) reacts to the request only when state === 'correct' and clicks its own action button (buttonRef.current?.click()) — i.e. it invokes the same handleContinue/onAction behind the "next" button. No game-mode components (Input/TilesMode) were touched, and MCQ is unaffected (it already auto-advances and renders no bottom bar in correct state).
Safeguards: only advances from the correct state (nothing happens on check/wrong, e.g. after an incorrect answer in the ad-overlay path), and a lastSeenRequestCountRef guard prevents phantom advances on remount or repeated triggers.

## 🔗 Related Issue

Closes #29270

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [x] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Open Kana → choose Pick or Type → Start
2. Answer correctly until reaching a streak of 10
3. The Streak Milestone overlay appears over the just-answered question
4. Press Skip → the game auto-advances to the next question (no second click needed)

<!--
**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

...

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

Files changed:
- 📄 shared/store/useContinueRequestStore.ts (new) — Zustand signal store (requestCount / requestContinue).
- 📝 shared/ui-composite/Game/StreakMilestoneOverlay.tsx — handleDismiss fires requestContinue().
- 📝 shared/ui-composite/Game/GameBottomBar.tsx — auto-clicks its action button on a continue request while in correct state.
- 🧪 shared/ui-composite/Game/GameBottomBar.test.tsx — new tests for the auto-advance behavior.
Notes: skipping will also play the continue click sound right after the skip click (same sound asset, cosmetic). The fix applies to Kana/Kanji/Vocabulary classic training via the shared GameBottomBar, with no changes to any feature game logic.