### PR TITLE
fix(kana): add alt romaji for ji and zu

### DIFF
--- a/features/Kana/data/kana.ts
+++ b/features/Kana/data/kana.ts
@@ -73,6 +73,7 @@ export const kana: KanaGroup[] = [
   {
     kana: ['だ', 'ぢ', 'づ', 'で', 'ど'],
     romanji: ['da', 'ji', 'zu', 'de', 'do'],
+    altRomanji: [[], ['di'], ['du'], [], []],
     groupName: 'h.d.d',
   },
   {


### PR DESCRIPTION
## 📝 Description

Adding alternative romaji ("Romanji") for ぢ and づ. These are standard romaji and IME inputs.

| Syllable | Existing Accepted Romaji | New Alt. Romaji |
|--------|--------|--------|
| ぢ | ji | di |
| づ | zu | du |

## 🔗 Related Issue

Closes #29312 

## ✅ Pre-Submission Checklist

- [X] I have starred the repo ⭐
- [X] My code follows the project's code style and uses `cn()` utility where needed
- [X] I have run `npm run check` locally and there are no _additional_ TypeScript/ESLint_ errors 🐞
- [X] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [X] I have updated the documentation (if applicable) 📖
- [X] This PR is against the `main` branch 

## 🎯 Type of Change

- [X] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Build locally
2. Start Hiragana game on type mode for だ (da) group
3. Type alternative & standard romaji and confirm answer is accepted

<!--
**Manual Test Checklist:**

- [X] Tested in **Kana** dojo
- [ ] Tested in **Kanji** dojo
- [ ] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

<img width="878" height="616" alt="Screenshot 2026-08-27 at 11 55 57 PM" src="https://github.com/user-attachments/assets/fbceb172-4ff6-4074-a63c-fbec8b585883" />

## 📦 Additional Notes

It is worth calling out the 'Nicely done!' game bar does not show the alternative romaji in the hint/helper text, only the standard. Maybe worth an enhancement to show "{romanji} or {altRomanji}, but I couldn't find this logic.
