### PR TITLE
fix(dojo): respect manual selections over auto-learning

### DIFF
--- a/features/Kana/components/Game/index.tsx
+++ b/features/Kana/components/Game/index.tsx
@@ -75,7 +75,11 @@ const Game = () => {
 
   useEffect(() => {
     const handoff = readAutoLearningHandoff('kana');
-    if (handoff) {
+    const manualSelection = useKanaStore.getState().kanaGroupIndices;
+    const hasManualSelection = manualSelection.length > 0;
+
+    // Only apply the auto-learning selection when there is no manual selection.
+    if (handoff && !hasManualSelection) {
       isAutoLearningSessionRef.current = true;
       replaceGroups(
         handoff.sets.flatMap(set =>
@@ -85,10 +89,13 @@ const Game = () => {
           ),
         ),
       );
+
       setGameMode(handoff.gameMode);
       setAutoSelectionActive('kana', true);
       clearAutoLearningHandoff();
     }
+
+    // Mark initialization as complete after preserving or applying the selection.
     setIsSelectionReady(true);
   }, [replaceGroups, setAutoSelectionActive, setGameMode]);
 

--- a/features/Kanji/components/Game/index.tsx
+++ b/features/Kanji/components/Game/index.tsx
@@ -91,7 +91,11 @@ const Game = () => {
 
     const resolveSelection = async () => {
       const handoff = readAutoLearningHandoff('kanji');
-      if (!handoff) {
+      const manualSelection = useKanjiStore.getState().selectedKanjiSets;
+      const hasManualSelection = manualSelection.length > 0;
+
+      // Only apply the auto-learning selection when there is no manual selection.
+      if (!handoff || hasManualSelection) {
         setIsSelectionReady(true);
         return;
       }

--- a/features/Vocabulary/components/Game/index.tsx
+++ b/features/Vocabulary/components/Game/index.tsx
@@ -92,7 +92,11 @@ const Game = () => {
 
     const resolveSelection = async () => {
       const handoff = readAutoLearningHandoff('vocabulary');
-      if (!handoff) {
+      const manualSelection = useVocabStore.getState().selectedVocabSets;
+      const hasManualSelection = manualSelection.length > 0;
+
+      // Only apply the auto-learning selection when there is no manual selection.
+      if (!handoff || hasManualSelection) {
         setIsSelectionReady(true);
         return;
       }


### PR DESCRIPTION
## 📝 Description

This PR will affect 3 dojos. Kana, Vocab, and Kanji. **Specifically during the group/set selection screen.** This prioritizes the selected groups/sets of the user over the auto-learning (recommended groups/sets) provided by the system.

There are side-effects to this fix, so please check the **Screenshots/Videos** sections because I can explain it better there with the gifs.

## 🔗 Related Issue

Closes #28365 

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Open [KanaDojo](https://kanadojo.com/)
2. Select either Kana, Vocab, or Kanji. (In this case, we will select Kana)
3. Select 1 or more groups other than the first two groups. (In this case, we may select the さ-group)
4. Press the Play button ▶️ (Not the Custom one or the continue learning)
5. Answer about 5 or 10 questions, and observe if no characters (other than the selected group/s) appeared.
6. If none appear, the fix was successful.
7. You may try it out to other dojos (Kana, Vocab, Kanji)! ^_^

<!--
**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [ ] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [x] Tested in Pick and Reverse-Pick mode
-->
## 📸 Screenshots/Videos (if applicable)

Before the fix, you will notice that the system is consistently choosing the first two groups in the Kana dojo, even if the selected group is in Katakana.

\
<img width="800" height="450" alt="problem" src="https://github.com/user-attachments/assets/abcb0db7-8463-4d5e-859f-edaf57a33aaf" />
<div align="center">problem.gif</div>

\
\
Next, here is the solutions applied. It is now respecting the selected groups/sets in all 3 dojos.

<img width="800" height="450" alt="solution" src="https://github.com/user-attachments/assets/4f56272c-b03c-45e4-ab01-aa985bc2f07e" />
<div align="center">solution.gif</div>

\
\
However, there are side-effects. After ending the session with the selected groups/sets, the said selection was preserved. I did not fix this because it is outside of the scope, and might cause some confusions if I did so.

Thankfully, the selections only remained within their own dojo. It was a nice feature as well because I can practice on specific groups (like one group in hiragana and another in katakana) which makes practices isolated to the chosen groups.

\
<img width="800" height="450" alt="side-effects" src="https://github.com/user-attachments/assets/ef91a852-f850-46c7-a7a7-4361d90cc7c9" />
<div align="center">side-effects.gif</div>

\
**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

I found this issue posted 2 weeks ago saying:

> The user reports that the app does not allow them to choose a specific set of hiragana to practice; instead, it forces them to practice all hiragana at once.

Reproducing the issue was fairly easy, however the symptom was a bit different. Instead of making the user _practice all hiragana at once_, it made them only practice the あ and か groups regardless what group/s they picked. At first this was confusing, but this was the result of the test.

Upon further observation, it is affecting all 3 dojos. The symptom became this:

> The system is consistently choosing the first two cards/groups in each dojos.

For example:

- Kana: It consistently choose the あ and か groups, whether it is Hiragana or Katakana.
- Vocabulary: It consistently choose Unit 1 - Level 1 and 2, regardless of what level you choose.
- Kanji: It consistently choose Unit 1 (N5) - Level 1 and 2, regardless of what level you choose.

At first, I thought it was a filtering bug, but upon studying the code. I found that it was an assignment/precedence bug where the system prioritize the auto-learning (which is giving the user what the system recommends to practice) over the selected groups/sets.

I then studied how to solve it, mainly checking how it was stored in `useKanaStore.ts`, `useVocabStore.ts`, and `useKanjiStore.ts`.

What I first found was the property `setKanaGroupIndices` that modifies the selected groups of kana. It then led me to `index.tsx` under the `@/features/Kana/components/Game/`.

Then I noticed the `handoff`, which I placed in a `console.log()` to see it's content, and there it was! I found that it is storing [0, 1] for the sets, which were the あ and か groups.

I then begun to add a logic where it asks if the user has any selected groups, then if yes, it should not apply the auto-learning. The same solution was then applied to the remaining 2 dojos.

This was such a fun challenge, I learned more about the codebase! **Thanks a lot for giving me a chance to work on this ^_^**

...
