### PR TITLE
feat(kana): add "Select All / Deselect All" button for Kana vocabulary groups (#29295)

### DIFF
--- a/features/Kana/components/KanaCards/Subset.tsx
+++ b/features/Kana/components/KanaCards/Subset.tsx
@@ -76,6 +76,13 @@ const Subset = ({ sliceRange, subgroup }: SubsetProps) => {
       </span>
     ));
 
+  const isAllSubsetSelected =
+    !hasAutoLearningSelection &&
+    Array.from(
+      { length: sliceRange[1] - sliceRange[0] },
+      (_, i) => sliceRange[0] + i,
+    ).every(idx => kanaGroupIndices.includes(idx));
+
   return (
     <fieldset className='flex flex-col items-start gap-1'>
       {kanaGroups.map((group, i) => {
@@ -151,7 +158,10 @@ const Subset = ({ sliceRange, subgroup }: SubsetProps) => {
           borderBottomThickness={12}
         >
           <MousePointer size={22} className={cn('fill-current')} />
-          <span>select all {subgroup.slice(1).toLowerCase()}</span>
+          <span>
+            {isAllSubsetSelected ? 'deselect' : 'select'} all{' '}
+            {subgroup.slice(1).toLowerCase()}
+          </span>
         </ActionButton>
       </div>
     </fieldset>

--- a/features/Kana/components/KanaCards/SubsetNew.tsx
+++ b/features/Kana/components/KanaCards/SubsetNew.tsx
@@ -77,6 +77,13 @@ const SubsetNew = ({ sliceRange, subgroup }: SubsetProps) => {
       </span>
     ));
 
+  const isAllSubsetSelected =
+    !hasAutoLearningSelection &&
+    Array.from(
+      { length: sliceRange[1] - sliceRange[0] },
+      (_, i) => sliceRange[0] + i,
+    ).every(idx => kanaGroupIndices.includes(idx));
+
   return (
     <fieldset className='flex w-full flex-col items-stretch gap-0'>
       {kanaGroups.map((group, i) => {
@@ -164,7 +171,10 @@ const SubsetNew = ({ sliceRange, subgroup }: SubsetProps) => {
           className='justify-start'
         >
           <MousePointer size={22} className={cn('fill-current')} />
-          <span>select all {subgroup.slice(1).toLowerCase()}</span>
+          <span>
+            {isAllSubsetSelected ? 'deselect' : 'select'} all{' '}
+            {subgroup.slice(1).toLowerCase()}
+          </span>
         </ActionButton>
       </div>
     </fieldset>

--- a/features/Kana/facade/useKanaSelection.ts
+++ b/features/Kana/facade/useKanaSelection.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { useMemo } from 'react';
-import useKanaStore from '../store/useKanaStore';
+import { useCallback, useMemo } from 'react';
+import useKanaStore from '@/features/Kana/store/useKanaStore';
 
 /**
  * Kana Selection Facade - Public API for selection state
@@ -34,6 +34,20 @@ export function useKanaSelection(): KanaSelection & KanaSelectionActions {
   const setGameMode = useKanaStore(state => state.setSelectedGameModeKana);
   const replaceGroups = useKanaStore(state => state.setKanaGroupIndices);
 
+  const clearSelection = useCallback(() => {
+    replaceGroups([]);
+  }, [replaceGroups]);
+
+  const selectAll = useCallback(() => {
+    const allIndices = Array.from({ length: 60 }, (_, i) => i);
+    replaceGroups(allIndices);
+  }, [replaceGroups]);
+
+  const isGroupSelected = useCallback(
+    (index: number) => selectedGroupIndices.includes(index),
+    [selectedGroupIndices],
+  );
+
   return useMemo(
     () => ({
       // State
@@ -46,16 +60,9 @@ export function useKanaSelection(): KanaSelection & KanaSelectionActions {
       addGroup,
       addGroups,
       replaceGroups,
-      clearSelection: () => {
-        // Toggle all currently selected groups to clear them
-        addGroups(selectedGroupIndices);
-      },
-      selectAll: () => {
-        // Select all 69 kana groups (based on kana.ts data)
-        const allIndices = Array.from({ length: 69 }, (_, i) => i);
-        addGroups(allIndices);
-      },
-      isGroupSelected: (index: number) => selectedGroupIndices.includes(index),
+      clearSelection,
+      selectAll,
+      isGroupSelected,
       setGameMode,
     }),
     [
@@ -64,6 +71,9 @@ export function useKanaSelection(): KanaSelection & KanaSelectionActions {
       addGroup,
       addGroups,
       replaceGroups,
+      clearSelection,
+      selectAll,
+      isGroupSelected,
       setGameMode,
     ],
   );

--- a/widgets/menu/KanaMenu.tsx
+++ b/widgets/menu/KanaMenu.tsx
@@ -53,7 +53,11 @@ const SUBSET_LABELS: Record<KanaType, Record<string, string>> = {
 
 const KanaMenu = ({ filter = 'all' }: { filter?: KanaMenuFilter }) => {
   const { playClick } = useClick();
-  const { addGroups: addKanaGroupIndices, replaceGroups } = useKanaSelection();
+  const {
+    selectedGroupIndices,
+    addGroups: addKanaGroupIndices,
+    replaceGroups,
+  } = useKanaSelection();
   const { allGroups: kana } = useKanaContent();
   const router = useRouter();
   const characterMastery = useStatsStore(
@@ -95,9 +99,50 @@ const KanaMenu = ({ filter = 'all' }: { filter?: KanaMenuFilter }) => {
     ? persistedKanaSelection.selectedSubset
     : fallbackSelectedSubset;
 
+  const activeSubsetIndices = useMemo(() => {
+    const key = `${filterOverride}-${selectedSubset}`;
+    const sliceRange = SUBSET_SLICE_RANGES[key];
+    if (!sliceRange) return [];
+    return Array.from(
+      { length: sliceRange[1] - sliceRange[0] },
+      (_, i) => sliceRange[0] + i,
+    );
+  }, [filterOverride, selectedSubset]);
+
+  const compactIndices = useMemo(
+    () =>
+      kana
+        .map((k, i) => ({ k, i }))
+        .filter(({ k }) => {
+          if (k.groupName.startsWith('challenge.')) return false;
+          if (filter === 'hiragana') return k.groupName.startsWith('h.');
+          if (filter === 'katakana') return k.groupName.startsWith('k.');
+          return true;
+        })
+        .map(({ i }) => i),
+    [filter, kana],
+  );
+
+  const isAllSubsetSelected =
+    activeSubsetIndices.length > 0 &&
+    activeSubsetIndices.every(idx => selectedGroupIndices.includes(idx));
+
+  const isAllCompactSelected =
+    compactIndices.length > 0 &&
+    compactIndices.every(idx => selectedGroupIndices.includes(idx));
+
   const kanaTypeLabel = KANA_TYPE_LABELS[filterOverride];
   const subsetLabel = SUBSET_LABELS[filterOverride]?.[selectedSubset];
-  const selectAllLabel = `Select  ${kanaTypeLabel} ${subsetLabel}`;
+  const subsetActionPrefix = isAllSubsetSelected ? 'Deselect' : 'Select';
+  const selectAllLabel = `${subsetActionPrefix} ${kanaTypeLabel} ${subsetLabel}`;
+
+  const compactActionPrefix = isAllCompactSelected ? 'Deselect' : 'Select';
+  const compactSelectAllLabel =
+    filter === 'hiragana'
+      ? `${compactActionPrefix} All Hiragana`
+      : filter === 'katakana'
+        ? `${compactActionPrefix} All Katakana`
+        : `${compactActionPrefix} All Kana`;
 
   const hasKanaProgress = useMemo(
     () =>
@@ -185,90 +230,36 @@ const KanaMenu = ({ filter = 'all' }: { filter?: KanaMenuFilter }) => {
             }}
           />
         )}
+        {filter === 'all' && (
+          <AutoLearningButton
+            hasProgress={hasKanaProgress}
+            isLoading={isAutoLearning}
+            error={autoLearningError}
+            onClick={() => void handleAutoLearning()}
+          />
+        )}
         <div className='flex w-full flex-row items-center gap-2'>
-          {filter === 'all' ? (
-            <AutoLearningButton
-              hasProgress={hasKanaProgress}
-              isLoading={isAutoLearning}
-              error={autoLearningError}
-              onClick={() => void handleAutoLearning()}
-              className='flex-1'
-            />
-          ) : (
-            <ActionButton
-              onClick={e => {
-                e.currentTarget.blur();
-                playClick();
-                if (viewMode === 'full') {
-                  const key = `${filterOverride}-${selectedSubset}`;
-                  const sliceRange = SUBSET_SLICE_RANGES[key];
-                  if (sliceRange) {
-                    const indices = Array.from(
-                      { length: sliceRange[1] - sliceRange[0] },
-                      (_, i) => sliceRange[0] + i,
-                    );
-                    addKanaGroupIndices(indices);
-                  }
-                } else {
-                  const indices = kana
-                    .map((k, i) => ({ k, i }))
-                    .filter(({ k }) => {
-                      if (k.groupName.startsWith('challenge.')) return false;
-                      if (filter === 'hiragana')
-                        return k.groupName.startsWith('h.');
-                      if (filter === 'katakana')
-                        return k.groupName.startsWith('k.');
-                      return true;
-                    })
-                    .map(({ i }) => i);
-                  addKanaGroupIndices(indices);
+          <ActionButton
+            onClick={e => {
+              e.currentTarget.blur();
+              playClick();
+              if (viewMode === 'full') {
+                if (activeSubsetIndices.length > 0) {
+                  addKanaGroupIndices(activeSubsetIndices);
                 }
-              }}
-              className='flex-1 px-2 py-2 sm:py-3'
-              borderBottomThickness={14}
-              borderRadius='3xl'
-            >
-              <MousePointer className={cn('fill-current')} />
-              {viewMode === 'full' ? selectAllLabel : 'Select All Kana'}
-            </ActionButton>
-          )}
-          {/*
-            Previous root Kana selection button retained for easy restoration:
-            <ActionButton
-              onClick={e => {
-                e.currentTarget.blur();
-                playClick();
-                if (viewMode === 'full') {
-                  const key = `${filterOverride}-${selectedSubset}`;
-                  const sliceRange = SUBSET_SLICE_RANGES[key];
-                  if (sliceRange) {
-                    const indices = Array.from(
-                      { length: sliceRange[1] - sliceRange[0] },
-                      (_, i) => sliceRange[0] + i,
-                    );
-                    addKanaGroupIndices(indices);
-                  }
-                } else {
-                  const indices = kana
-                    .map((k, i) => ({ k, i }))
-                    .filter(({ k }) => {
-                      if (k.groupName.startsWith('challenge.')) return false;
-                      if (filter === 'hiragana') return k.groupName.startsWith('h.');
-                      if (filter === 'katakana') return k.groupName.startsWith('k.');
-                      return true;
-                    })
-                    .map(({ i }) => i);
-                  addKanaGroupIndices(indices);
+              } else {
+                if (compactIndices.length > 0) {
+                  addKanaGroupIndices(compactIndices);
                 }
-              }}
-              className='flex-1 px-2 py-2 sm:py-3'
-              borderBottomThickness={14}
-              borderRadius='3xl'
-            >
-              <MousePointer className={cn('fill-current')} />
-              {viewMode === 'full' ? selectAllLabel : 'Select All Kana'}
-            </ActionButton>
-          */}
+              }
+            }}
+            className='flex-1 px-2 py-2 sm:py-3'
+            borderBottomThickness={14}
+            borderRadius='3xl'
+          >
+            <MousePointer className={cn('fill-current')} />
+            {viewMode === 'full' ? selectAllLabel : compactSelectAllLabel}
+          </ActionButton>
           <ActionButton
             onClick={() => {
               playClick();


### PR DESCRIPTION
📝 Description
Adds a dynamic "Select All / Deselect All" button on the Kana selection screen for both Hiragana and Katakana. This allows users to select or deselect all character groups for the active subset or view with a single click, eliminating the need to manually click through each card one by one.

Summary of Changes:
widgets/menu/KanaMenu.tsx:
Restored and enabled the ActionButton with MousePointer icon in the action bar across all filter views (all, hiragana, katakana).
Placed AutoLearningButton on its own dedicated row above the action bar when filter === 'all'.
Subscribed to selectedGroupIndices via the useKanaSelection() facade hook.
Dynamically switches label between Select [Type] [Subset] and Deselect [Type] [Subset] (e.g., Select Hiragana Base ↔ Deselect Hiragana Base, Select Katakana Foreign ↔ Deselect Katakana Foreign) based on whether all visible groups are currently selected.
In compact view, dynamically switches between Select All Kana (or Hiragana / Katakana) and Deselect All Kana.
features/Kana/components/KanaCards/Subset.tsx & SubsetNew.tsx:
Updated the button label to dynamically toggle between select all [subset] and deselect all [subset] based on the active selection state.
features/Kana/facade/useKanaSelection.ts:
Updated clearSelection to directly call replaceGroups([]) and selectAll to replace groups with all 60 standard group indices.
Wrapped facade actions in useCallback for stable reference identity.
🔗 Related Issue
Closes #29295

✅ Pre-Submission Checklist
 I have starred the repo ⭐
 My code follows the project's code style and uses cn() utility where needed
 I have run npm run check locally and there are no TypeScript/ESLint errors 🐞
 My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
 I have updated the documentation (if applicable) 📖
 This PR is against the main branch
🎯 Type of Change
 fix: Bug fix (non-breaking change which fixes an issue)
 feat: New feature (non-breaking change which adds functionality)
 docs: Documentation update (e.g., this file, README)
 content: Content update (e.g., new kanji, vocab, or fonts in /static/)
 style: UI/Theme changes (e.g., Tailwind, CSS, new themes)
 refactor: Code refactor (no functional changes)
 test: Test update (adding missing tests or correcting existing tests)
 chore: Build, CI/CD, or dependency updates
🧪 How Has This Been Tested?
Test Steps:

Navigate to /kana:
With Hiragana and Base active, verify the action button shows "Select Hiragana Base".
Click the button: verify all 10 base Hiragana groups are selected with checkmarks and the button label updates to "Deselect Hiragana Base".
Click the button again: verify all 10 base Hiragana groups are deselected and the label updates back to "Select Hiragana Base".
Switch tabs to Katakana → Foreign:
Verify the button dynamically updates to "Select Katakana Foreign" / "Deselect Katakana Foreign".
Toggle to Compact view (list mode):
Verify the top button displays "Select All Kana" / "Deselect All Kana", and each individual subset card displays select all [subset] / deselect all [subset].
Navigate to /kana/learn-hiragana and /kana/learn-katakana:
Verify that the select/deselect button functions identically and respects the specific script filter.
Manual Test Checklist:

 Tested in Kana dojo
 Tested all filter views (/kana, /kana/learn-hiragana, /kana/learn-katakana)
 Tested both Grid (full) and List (compact) view modes
📸 Screenshots/Videos (if applicable)
N/A

Helpful links: 

Contributing
 · 

Troubleshooting

📦 Additional Context
Improves the user onboarding and study flow by allowing one-click selection of entire character sets and subsets without manual card-by-card clicking.
...
