### PR TITLE
content: add new regional dialect entry

### DIFF
--- a/community/content/japanese-regional-dialects.json
+++ b/community/content/japanese-regional-dialects.json
@@ -201,5 +201,12 @@
   "english": "well then/see you",
   "region": "Hokkaido",
   "note": "Transition/goodbye phrase. (Set 2)"
+  },
+  {
+    "dialect": "なんくるないさ",
+    "standardJapanese": "なんとかなる",
+    "english": "it'll work out",
+    "region": "Okinawa",
+    "note": "Famous Okinawan resilience phrase. (Set 3)"
   }
 ]


### PR DESCRIPTION
Root cause: Issue #29401 requested adding a new beginner-friendly open-source contribution dialect entry for Okinawa.
Fix: Appended the "なんくるないさ" entry to `community/content/japanese-regional-dialects.json` following the required schema.
Validation:
npm ci
npm run check
npm run i18n:check
All passed.
Fixes https://github.com/lingdojo/kana-dojo/issues/29401


Fixes #29401


