### PR TITLE
content: add new common mistake

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -143,5 +143,10 @@
     "wrong": "日本語が好きをです。",
     "correct": "日本語が好きです。",
     "explanation": "好き takes が, not を. (Pattern set 3)"
+  },
+  {
+    "wrong": "図書館に本を借りました。",
+    "correct": "図書館で本を借りました。",
+    "explanation": "で marks location of action. (Pattern set 4)"
   }
 ]


### PR DESCRIPTION
Root cause: The issue requested adding a new common Japanese learner mistake entry to the content JSON file.
Fix: Appended the specified learner mistake regarding the use of 'に' vs 'で' for location of action to `community/content/japanese-common-mistakes.json`.
Validation: Ran `npm ci`, `npm run check`, and `npm run i18n:check`. All commands passed successfully.
Fixes https://github.com/lingdojo/kana-dojo/issues/29407


Fixes #29407


