### PR TITLE
content: add new common mistake

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -143,5 +143,10 @@
     "wrong": "日本語が好きをです。",
     "correct": "日本語が好きです。",
     "explanation": "好き takes が, not を. (Pattern set 3)"
+  },
+  {
+    "wrong": "先生は私を日本語を教えました。",
+    "correct": "先生は私に日本語を教えました。",
+    "explanation": "Recipient takes に with 教える. (Pattern set 4)"
   }
 ]


### PR DESCRIPTION
Root cause: The open-source community issue requested adding a specific beginner mistake entry to `community/content/japanese-common-mistakes.json`.
Fix: Appended the new entry to the end of the JSON array correctly.
Validation: Ran `npm ci`, `npm run check`, and `npm run i18n:check` successfully without any errors.

Fixes https://github.com/lingdojo/kana-dojo/issues/29428

Fixes #29428
