### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -91,5 +91,6 @@
   "Japan's National Apology Day falls on August 15th, when the nation reflects on World War II and its aftermath.",
   "There's a Japanese concept 'meisou' (瞑想) - meditation that focuses on emptying the mind rather than filling it.",
   "Japan has a festival where parents throw their babies to sumo wrestlers, who bounce them for good luck and health.",
-  "There's a Japanese word 'miryoku' (魅力) for charm or attractiveness that draws people in - the quality that makes things captivating."
+  "There's a Japanese word 'miryoku' (魅力) for charm or attractiveness that draws people in - the quality that makes things captivating.",
+  "Japan has 'anti-lonely death' services that check on elderly living alone and arrange their affairs if they pass away."
 ]


### PR DESCRIPTION
Root cause: This is a beginner-friendly community contribution issue asking to add a new Japan fact about 'anti-lonely death' services.
Fix: Added the requested fact to the end of `community/content/japan-facts.json`.
Validation: Ran `npm ci`, `npm run check`, and `npm run i18n:check` successfully. Checked via `tail -n 5 community/content/japan-facts.json` to ensure valid JSON syntax.
Fixes https://github.com/lingdojo/kana-dojo/issues/29432

Fixes #29432
