### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -352,5 +352,11 @@
     "romaji": "Kuchi wa wazawai no moto",
     "english": "The mouth is the source of misfortune",
     "meaning": "Careless words cause trouble"
+  },
+  {
+    "japanese": "三人寄れば文殊の知恵",
+    "romaji": "Sannin yoreba monju no chie",
+    "english": "Three people together have the wisdom of Monju",
+    "meaning": "Two heads are better than one"
   }
 ]


### PR DESCRIPTION
Root cause: The issue requested adding a new Japanese proverb (#15) to `community/content/japanese-proverbs.json` as a beginner-friendly contribution.
Fix: Appended the new proverb object ("三人寄れば文殊の知恵", "Sannin yoreba monju no chie", "Three people together have the wisdom of Monju", "Two heads are better than one") to the end of the JSON array in `community/content/japanese-proverbs.json`.
Validation: `npm ci`, `npm run check`, `npm run i18n:check` - all checks passed.

Fixes https://github.com/lingdojo/kana-dojo/issues/29433

Fixes #29433
