### PR TITLE
content: add new japan fact

### DIFF
--- a/community/content/japan-facts.json
+++ b/community/content/japan-facts.json
@@ -95,6 +95,6 @@
   "The Japanese word 'nomunication' combines 'nomu' (drink) and 'communication' - bonding with colleagues over after-work drinks.",
   "There's a Japanese concept called 'ikigai' (生き甲斐) - your reason for being - found at the intersection of what you love, need, and can be paid for.",
   "There's a Japanese word 'kenkyo' (謙虚) for humility so deep it rejects praise - considered one of the highest virtues.",
-  "The term 'shinnen' (信念) means conviction or strongly held belief, often tied to personal principles."
+  "The term 'shinnen' (信念) means conviction or strongly held belief, often tied to personal principles.",
+  "Japan has an island dedicated entirely to art museums - Naoshima, where Tadao Ando's architecture blends with nature."
 ]
-


### PR DESCRIPTION
## What

Adds one new fact to `community/content/japan-facts.json` as requested in the linked good-first-issue.

> Japan has an island dedicated entirely to art museums - Naoshima, where Tadao Ando's architecture blends with nature.

## Notes
- Single entry appended to the existing array; JSON validated (parses cleanly, 96 → 97 entries).
- No code or behavior changes.

Closes #29622