### PR TITLE
fix: repair invalid JSON in japanese-idioms.json (missing comma)

### DIFF
--- a/community/content/japanese-idioms.json
+++ b/community/content/japanese-idioms.json
@@ -160,7 +160,7 @@
     "romaji": "Koshi ga omoi",
     "english": "Heavy hips",
     "meaning": "Slow to start doing something. (Set 6)"
-  }
+  },
   {
     "japanese": "鼻が高い",
     "romaji": "Hana ga takai",


### PR DESCRIPTION
## Summary

`community/content/japanese-idioms.json` is currently **invalid JSON** — a comma is missing between two adjacent entries (`腰が重い` and `頭が上がらない`). This breaks parsing of the idioms content and would fail the `check` workflow.

## Fix

Add the missing comma. Verified: the file now parses as valid JSON (28 entries).

- Diff is `+1 / -1` (only the comma) — no behavior change.
- Content-only change: no TypeScript/UI impacted.

## Notes

The two adjacent entries came in via a recent change (see #29460); this PR restores valid JSON so the content is parseable again.
