### PR TITLE
fix(session): trigger donation modal on finalized session instead of streak

### DIFF
--- a/app/ClientLayout.tsx
+++ b/app/ClientLayout.tsx
@@ -31,7 +31,7 @@ import VisualEffectsRenderer from '@/features/Preferences/components/renderers/V
 import TransitionAdvertisementOverlay, {
   isTransitionAdvertisementEnabled,
 } from '@/shared/ui-composite/Game/TransitionAdvertisementOverlay';
-import { STREAK_MILESTONE_DONATION_EVENT } from '@/shared/ui-composite/Game/StreakMilestoneOverlay';
+import { SESSION_END_DONATION_EVENT } from '@/shared/utils/sessionHistory';
 
 // Initialize adaptive selector early to load persisted weights from IndexedDB
 // This runs once at module load time, ensuring weights are ready before games start
@@ -119,16 +119,10 @@ export default function ClientLayout({
   useEffect(() => {
     const showDonationModal = () => setIsDonationModalOpen(true);
 
-    window.addEventListener(
-      STREAK_MILESTONE_DONATION_EVENT,
-      showDonationModal,
-    );
+    window.addEventListener(SESSION_END_DONATION_EVENT, showDonationModal);
 
     return () => {
-      window.removeEventListener(
-        STREAK_MILESTONE_DONATION_EVENT,
-        showDonationModal,
-      );
+      window.removeEventListener(SESSION_END_DONATION_EVENT, showDonationModal);
     };
   }, []);
 
@@ -160,10 +154,14 @@ export default function ClientLayout({
   }, [pathname]);
 
   useEffect(() => {
-    const isDev = process.env.NODE_ENV === 'development';
-    const isPreviewDeployment =
-      process.env.NODE_ENV === 'production' &&
-      process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production';
+    // TEMPORARILY COMMENTED OUT: Causes warning in ESLint checks
+    // const isDev = process.env.NODE_ENV === 'development';
+    // const isPreviewDeployment =
+    //   process.env.NODE_ENV === 'production' &&
+    //   process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production';
+
+    const hideDonationModal = () => setIsDonationModalOpen(false);
+
     const isTargetRoute = /\/(kana|kanji|vocabulary)(\/|$)/.test(pathname);
     const isPreferencesRoute = /\/preferences(\/|$)/.test(pathname);
     const isProgressRoute = /\/progress(\/|$)/.test(pathname);
@@ -180,7 +178,7 @@ export default function ClientLayout({
       if (typeof window !== 'undefined') {
         sessionStorage.setItem(donationLastPathKey, pathname);
       }
-      setIsDonationModalOpen(false);
+      hideDonationModal();
       return;
     }
 

--- a/shared/ui-composite/Game/StreakMilestoneOverlay.test.tsx
+++ b/shared/ui-composite/Game/StreakMilestoneOverlay.test.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import StreakMilestoneOverlay, {
-  STREAK_MILESTONE_DONATION_EVENT,
-} from '@/shared/ui-composite/Game/StreakMilestoneOverlay';
+import StreakMilestoneOverlay from '@/shared/ui-composite/Game/StreakMilestoneOverlay';
 
 const playClick = vi.fn();
 
@@ -43,25 +41,6 @@ afterEach(() => {
 });
 
 describe('StreakMilestoneOverlay keyboard handling', () => {
-  it('requests the donation modal whenever a milestone opens', () => {
-    const showDonationModal = vi.fn();
-    window.addEventListener(
-      STREAK_MILESTONE_DONATION_EVENT,
-      showDonationModal,
-    );
-
-    const { rerender } = render(
-      <StreakMilestoneOverlay milestone={10} onDismiss={vi.fn()} />,
-    );
-    rerender(<StreakMilestoneOverlay milestone={25} onDismiss={vi.fn()} />);
-
-    expect(showDonationModal).toHaveBeenCalledTimes(2);
-    window.removeEventListener(
-      STREAK_MILESTONE_DONATION_EVENT,
-      showDonationModal,
-    );
-  });
-
   it('focuses Skip when the milestone opens', () => {
     render(<StreakMilestoneOverlay milestone={10} onDismiss={vi.fn()} />);
 
@@ -79,7 +58,10 @@ describe('StreakMilestoneOverlay keyboard handling', () => {
     window.addEventListener('keydown', gameKeyDown);
 
     render(<StreakMilestoneOverlay milestone={10} onDismiss={onDismiss} />);
-    fireEvent.keyDown(document.body, { key, code: key === ' ' ? 'Space' : key });
+    fireEvent.keyDown(document.body, {
+      key,
+      code: key === ' ' ? 'Space' : key,
+    });
 
     expect(onDismiss).toHaveBeenCalledOnce();
     expect(playClick).toHaveBeenCalledOnce();

--- a/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
+++ b/shared/ui-composite/Game/StreakMilestoneOverlay.tsx
@@ -14,8 +14,6 @@ import { suppressContinueKeyboardShortcuts } from '@/shared/utils/game/continueS
 import { ENABLE_EVERY_QUESTION_AD_OVERLAY } from '@/shared/utils/game/streakMilestones';
 
 const STREAK_MILESTONE_AD_SLOT = '2642983933';
-export const STREAK_MILESTONE_DONATION_EVENT =
-  'kana-dojo:streak-milestone-donation';
 const ENABLE_STREAK_MILESTONE_DECORATIONS = true;
 // Let Enter/Space dismiss the overlay so type-mode keyboard users don't
 // accidentally trigger the underlying "next" control (#27829).
@@ -91,8 +89,6 @@ export default function StreakMilestoneOverlay({
 
   useEffect(() => {
     if (!milestone) return;
-
-    window.dispatchEvent(new Event(STREAK_MILESTONE_DONATION_EVENT));
 
     // Move keyboard focus to Skip so Enter targets this dialog, not the
     // type-mode "next" button still mounted underneath.

--- a/shared/utils/sessionHistory.ts
+++ b/shared/utils/sessionHistory.ts
@@ -77,6 +77,7 @@ interface SessionHistoryStore {
   activeSessionsById: Record<string, SessionDraft>;
 }
 
+export const SESSION_END_DONATION_EVENT = 'kana-dojo:session-end-donation';
 const STORAGE_KEY = 'kanadojo-session-history-v1';
 
 const getDefaultStore = (): SessionHistoryStore => {
@@ -198,6 +199,8 @@ export async function finalizeSession(params: {
   store.totalSessions += 1;
   store.updatedAt = Date.now();
   await saveStore(store);
+
+  window.dispatchEvent(new Event(SESSION_END_DONATION_EVENT));
+
   return record;
 }
-


### PR DESCRIPTION
## 📝 Description

Donation modal "A small favor, If you can" only shows when session is finalized and saved through `sessionHistory.ts` instead of streak-based trigger that cause users' quiz flow to be interrupted every streak.

## 🔗 Related Issue

Closes #29489 

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch 

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Start a practice session.
2. Proceed through questions.
3. Achieve a streak.
4. Notice no donation popup shows.
5. End session.
6. Notice donation popup now shows.

<!--
**Manual Test Checklist:**

- [x] Tested in **Kana** dojo
- [x] Tested in **Kanji** dojo
- [x] Tested in **Vocabulary** dojo
- [x] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

<img width="1080" height="608" alt="fix" src="https://github.com/user-attachments/assets/c505a67d-211c-4c63-ba80-e8d1c757777d" />

\
**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

## 📦 Additional Context

ESLint triggered warnings on `ClientLayout.tsx` lines `158-159` because `isDev` and `isPreviewDeployment` is unused. Solution I did was commenting it out as I have seen in line `185` with the same context of said constants.

Additionally, ESLint also warned about line `181` saying around the lines of `Avoid using set state in useEffect()`. Solution I did was on line `163` where I declared an arrow function assigned to `hideDonationModal` as I have seen in line `120` with `showDonationModal`.

That's all! Thanks for reviewing my PR, I would like to know what's your thoughts on this or if there's any adjustment I could do.
