### PR TITLE
fix(group-selection): fixing group selection bug

### DIFF
--- a/shared/ui-composite/Menu/TrainingActionBar.tsx
+++ b/shared/ui-composite/Menu/TrainingActionBar.tsx
@@ -69,12 +69,6 @@ const TrainingActionBar: React.FC<ITopBarProps> = ({
 
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-  const startAutoLearning = () => {
-    document
-      .querySelector<HTMLButtonElement>('[data-auto-learning-dojo]')
-      ?.click();
-  };
-
   useEffect(() => {
     if (!hotkeysOn) return;
 
@@ -88,11 +82,8 @@ const TrainingActionBar: React.FC<ITopBarProps> = ({
 
       if (event.key === 'Enter' && isFilled) {
         event.preventDefault();
-        if (showExperimentalModes) {
-          setShowGameModesModal(true);
-        } else {
-          startAutoLearning();
-        }
+        setGameModesMode('train');
+        setShowGameModesModal(true);
       }
     };
     window.addEventListener('keydown', handleKeyDown);
@@ -349,13 +340,8 @@ const TrainingActionBar: React.FC<ITopBarProps> = ({
               show: true,
               colorScheme: 'primary' as const,
               onClick: () => {
-                if (showExperimentalModes) {
-                  setGameModesMode('train');
-                  setShowGameModesModal(true);
-                  return;
-                }
-
-                startAutoLearning();
+                setGameModesMode('train');
+                setShowGameModesModal(true);
               },
               ref: buttonRef,
             },
@@ -407,7 +393,7 @@ const TrainingActionBar: React.FC<ITopBarProps> = ({
                 >
                   <Icon size={36} className={cn(iconClassName)} />
                   {id === 'custom' && (
-                    <span className='whitespace-nowrap text-lg font-medium sm:text-xl'>
+                    <span className='text-lg font-medium whitespace-nowrap sm:text-xl'>
                       {label}
                     </span>
                   )}


### PR DESCRIPTION
## 📝 Description

Attempting to train manually selected groups would mistakenly trigger Auto Learning instead of starting a training session.
Removed startAutoLearning(): Deleted the synthetic button click helper.

## 🔗 Related Issue

Closes #29555

## ✅ Pre-Submission Checklist

- [ ] I have starred the repo ⭐
- [ ] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [ ] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [ ] This PR is against the `main` branch 

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [ ] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1.  ...
2.  ...

<!--
**Manual Test Checklist:**

- [*] Tested in **Kana** dojo
- [*] Tested in **Kanji** dojo
- [*] Tested in **Vocabulary** dojo
- [] Tested all 4 game modes (Pick, Reverse-Pick, Input, Reverse-Input)
- [ ] ... (add any other specific tests)
-->
## 📸 Screenshots/Videos (if applicable)

<img width="1020" height="647" alt="image" src="https://github.com/user-attachments/assets/04b30793-50e3-413c-8eb5-89101b36e251" />

**Helpful links:** [Contributing](../blob/main/CONTRIBUTING.md) · [Troubleshooting](../blob/main/docs/TROUBLESHOOTING.md)

