### PR TITLE
content: add video game quote from Yakuza Like a Dragon

### DIFF
--- a/community/content/japanese-videogame-quotes.json
+++ b/community/content/japanese-videogame-quotes.json
@@ -397,6 +397,12 @@
   "english": "Our story starts here.",
   "game": "Tales series",
   "character": "Various endings"
+},
+{
+  "japanese": "生きるってのは、戦うってことだ",
+  "romaji": "Ikiru tte no wa, tatakau tte koto da",
+  "english": "To live is to fight.",
+  "game": "Yakuza: Like a Dragon",
+  "character": "Ichiban Kasuga"
 }
 ]
-


### PR DESCRIPTION
## Problem
Issue #29818 requested adding Video Game Quote 54 to the community dataset so Japanese learners can study language through video game culture. The quote from Yakuza: Like a Dragon (Ichiban Kasuga) was missing from the quotes catalog.

## Solution
- Added the Japanese text, Romaji transliteration, and English translation for Ichiban Kasuga's quote: '生きるってのは、戦うってことだ' ('To live is to fight.').
- Preserved JSON schema integrity and formatting.

Closes #29818