### PR TITLE
fix(kanji): normalize Classic Input meaning answers

### DIFF
--- a/features/Kanji/__tests__/isKanjiClassicInputAnswerCorrect.test.ts
+++ b/features/Kanji/__tests__/isKanjiClassicInputAnswerCorrect.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { isKanjiClassicInputAnswerCorrect } from '@/features/Kanji/lib/isKanjiClassicInputAnswerCorrect';
+
+describe('isKanjiClassicInputAnswerCorrect', () => {
+  it.each(['present', 'the present', '  PRESENT  '])(
+    'accepts an optional article in a meaning answer: %s',
+    inputValue => {
+      expect(
+        isKanjiClassicInputAnswerCorrect({
+          inputValue,
+          target: ['the present', 'いま'],
+          isReverse: false,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it('preserves Classic Input reading answers', () => {
+    expect(
+      isKanjiClassicInputAnswerCorrect({
+        inputValue: 'いま',
+        target: ['the present', 'いま'],
+        isReverse: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves compound meaning prefixes', () => {
+    expect(
+      isKanjiClassicInputAnswerCorrect({
+        inputValue: 'point',
+        target: ['to the point'],
+        isReverse: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps reverse answers exact', () => {
+    expect(
+      isKanjiClassicInputAnswerCorrect({
+        inputValue: 'emperor',
+        target: 'the emperor',
+        isReverse: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/features/Kanji/components/Game/Input.tsx
+++ b/features/Kanji/components/Game/Input.tsx
@@ -21,6 +21,7 @@ import { cn } from '@/shared/utils/utils';
 import { useSetProgressStore } from '@/features/Progress';
 import { shouldSuppressContinueKeyboardShortcut } from '@/shared/utils/game/continueShortcutGuard';
 import { useMenuSelectorStore } from '@/shared/ui-composite/Menu/store/useMenuSelectorStore';
+import { isKanjiClassicInputAnswerCorrect } from '@/features/Kanji/lib/isKanjiClassicInputAnswerCorrect';
 
 // Get the global adaptive selector for weighted character selection
 const adaptiveSelector = getGlobalAdaptiveSelector();
@@ -210,20 +211,12 @@ const KanjiInputGame = ({
     }
   };
 
-  const normalizeAnswer = (value: string): string => value.trim().toLowerCase();
-
   const isInputCorrect = (input: string): boolean => {
-    const normalizedInput = normalizeAnswer(input);
-
-    if (!isReverse) {
-      return (
-        Array.isArray(targetChar) &&
-        targetChar.some(answer => normalizeAnswer(answer) === normalizedInput)
-      );
-    } else {
-      const reverseTargetChar = typeof targetChar === 'string' ? targetChar : '';
-      return normalizedInput === normalizeAnswer(reverseTargetChar);
-    }
+    return isKanjiClassicInputAnswerCorrect({
+      inputValue: input,
+      target: targetChar,
+      isReverse,
+    });
   };
 
   const handleCheck = () => {

--- a/features/Kanji/lib/isKanjiAnswerCorrect.ts
+++ b/features/Kanji/lib/isKanjiAnswerCorrect.ts
@@ -11,7 +11,7 @@ const normalize = (value: string): string =>
 const OPTIONAL_MEANING_PREFIX =
   /^(?:to(?!\s+(?:the|an|a)\s+)\s+|(?:the|an|a)\s+)/;
 
-const normalizeMeaning = (value: string): string =>
+export const normalizeKanjiMeaningAnswer = (value: string): string =>
   normalize(value).replace(OPTIONAL_MEANING_PREFIX, '');
 
 const normalizeReading = (value: string): string =>
@@ -24,12 +24,12 @@ export const isKanjiAnswerCorrect = (
 ): boolean => {
   const normalizedAnswer = isReverse
     ? normalize(answer)
-    : normalizeMeaning(answer);
+    : normalizeKanjiMeaningAnswer(answer);
   if (!normalizedAnswer) return false;
 
   if (!isReverse) {
     return kanji.meanings.some(
-      meaning => normalizeMeaning(meaning) === normalizedAnswer,
+      meaning => normalizeKanjiMeaningAnswer(meaning) === normalizedAnswer,
     );
   }
 

--- a/features/Kanji/lib/isKanjiClassicInputAnswerCorrect.ts
+++ b/features/Kanji/lib/isKanjiClassicInputAnswerCorrect.ts
@@ -1,0 +1,30 @@
+import { normalizeKanjiMeaningAnswer } from './isKanjiAnswerCorrect';
+
+interface KanjiClassicInputAnswerOptions {
+  inputValue: string;
+  target: string | string[] | undefined;
+  isReverse: boolean;
+}
+
+const normalizeExactAnswer = (value: string): string =>
+  value.trim().normalize('NFC').toLowerCase();
+
+export const isKanjiClassicInputAnswerCorrect = ({
+  inputValue,
+  target,
+  isReverse,
+}: KanjiClassicInputAnswerOptions): boolean => {
+  if (isReverse) {
+    return (
+      typeof target === 'string' &&
+      normalizeExactAnswer(target) === normalizeExactAnswer(inputValue)
+    );
+  }
+
+  if (!Array.isArray(target)) return false;
+
+  const normalizedInput = normalizeKanjiMeaningAnswer(inputValue);
+  return target.some(
+    answer => normalizeKanjiMeaningAnswer(answer) === normalizedInput,
+  );
+};


### PR DESCRIPTION
## What changed
- apply the shared optional-prefix normalizer in Kanji Classic Input
- preserve reading answers and exact reverse-mode behavior
- add focused regression tests

Fixes #29403

## Tests
- `npx tsc --noEmit --incremental --pretty false`
- changed-file ESLint
- 30 focused validator tests
- mutation check: the former exact match fails the new regression

`npm test` retains the existing `main` baseline of 21 failing files, primarily storage/jsdom and stale property assertions.
