### PR TITLE
add new regional dialect entry

### DIFF
--- a/community/content/japanese-regional-dialects.json
+++ b/community/content/japanese-regional-dialects.json
@@ -222,5 +222,12 @@
   "english": "sentence ending",
   "region": "Nagoya",
   "note": "Strong Nagoya marker. (Set 5)"
-  }
+  },
+  {
+  "dialect": "〜だがや",
+  "standardJapanese": "〜だよ",
+  "english": "sentence ending",
+  "region": "Nagoya",
+  "note": "Strong Nagoya marker. (Set 1)"
+}
 ]


### PR DESCRIPTION
Changes Proposed
Added a new regional dialect entry for Nagoya (〜だがや) mapping to standard Japanese (〜だよ) in community/content/japanese-regional-dialects.json.

Included English explanation, region classification, and usage notes as part of the regional datasets expansion.

Related Issue
Closes #29941