### PR TITLE
feat(theme): add Vaporwave Shrine theme

### DIFF
--- a/community/content/community-themes.json
+++ b/community/content/community-themes.json
@@ -298,5 +298,11 @@
   "backgroundColor": "oklch(21.0% 0.042 235.0 / 1)",
   "mainColor": "oklch(92.0% 0.025 240.0 / 1)",
   "secondaryColor": "oklch(70.0% 0.135 225.0 / 1)"
+  },
+  {
+    "id": "vaporwave-shrine",
+    "backgroundColor": "oklch(17.0% 0.072 305.0 / 1)",
+    "mainColor": "oklch(75.0% 0.175 195.0 / 1)",
+    "secondaryColor": "oklch(80.0% 0.195 330.0 / 1)"
   }
 ]


### PR DESCRIPTION
## 📝 Description

Adds the `vaporwave-shrine` community theme to `community/content/community-themes.json`, using the exact values from the issue (which match the entry already staged in `community/backlog/theme-backlog.json`):

| Property | Value |
|---|---|
| `id` | `vaporwave-shrine` |
| `backgroundColor` | `oklch(17.0% 0.072 305.0 / 1)` |
| `mainColor` | `oklch(75.0% 0.175 195.0 / 1)` |
| `secondaryColor` | `oklch(80.0% 0.195 330.0 / 1)` |

## 🔗 Related Issue

Closes #29998

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞 (content-only change — `npm run check` is skipped by `pr-check.yml` for `community/content/`-only PRs; validated JSON syntax and schema instead)
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change

- [x] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. `JSON.parse` / `json.load` on the modified file — parses cleanly (51 entries, was 50).
2. Verified `vaporwave-shrine` was not already present and that the new id is unique.
3. Verified the new object's keys match every other entry exactly (`id`, `backgroundColor`, `mainColor`, `secondaryColor`) — no extra or missing fields.

Diff is 6 added lines, no other files touched, so `pr-check.yml` treats it as a community-content-only PR.

## 📸 Screenshots/Videos (if applicable)

n/a — data-only entry, no rendering code changed.

## 📦 Additional Context

The two entries directly above the new one (`kyoto-kimono`, `ocean-tofu`) are indented with 2 spaces instead of 4. I left them alone to keep the diff minimal; happy to fix the formatting in a separate PR if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
