### PR TITLE
fix(content): repair invalid JSON in japan-trivia-hard.json

### DIFF
--- a/community/content/japan-trivia-hard.json
+++ b/community/content/japan-trivia-hard.json
@@ -605,7 +605,7 @@
   "correctIndex": 0
 },
   {
-  "question": "Which Japanese castle is known for its black exterior and nickname "Crow Castle"?",
+  "question": "Which Japanese castle is known for its black exterior and nickname \"Crow Castle\"?",
   "difficulty": "hard",
   "answers": [
     "Matsumoto Castle",


### PR DESCRIPTION
## Problem

`community/content/japan-trivia-hard.json` contains a trivia entry whose `question` string has unescaped double quotes around "Crow Castle", which breaks JSON parsing:

```json
"question": "Which Japanese castle is known for its black exterior and nickname "Crow Castle"?",
```

This file is read at runtime via `fs.readFileSync` + `JSON.parse` in `app/api/trivia/route.ts` with no error handling, so `/api/trivia` fails for `difficulty=hard` (and `difficulty=all`, since it aggregates all difficulty files).

## Solution

Escaped the two double quotes around "Crow Castle" (`\"Crow Castle\"`), matching the same phrase already correctly escaped elsewhere in the same file (e.g. line 366). No wording was changed — only the JSON escaping.

## Verification

- Parsed the file with both Python's `json.load()` and Node's `JSON.parse()` after the fix — both succeed, with the same 59 entries as before.
- Confirmed the diff is a single-line change to a single file (`git diff main..fix/invalid-json-trivia-hard`).