### PR TITLE
content: add new regional dialect entry

### DIFF
--- a/community/content/japanese-regional-dialects.json
+++ b/community/content/japanese-regional-dialects.json
@@ -229,5 +229,12 @@
   "english": "sentence ending",
   "region": "Nagoya",
   "note": "Strong Nagoya marker. (Set 1)"
+},
+  {
+  "dialect": "〜やねん",
+  "standardJapanese": "〜なんだ",
+  "english": "it is that...",
+  "region": "Kansai",
+  "note": "Explanatory ending in conversation. (Set 1)"
 }
 ]


### PR DESCRIPTION
## 📝 Description

Added a new regional Japanese dialect entry for the Kansai dialect.

The contribution adds the phrase **〜やねん**, along with its standard Japanese equivalent, English meaning, region, and usage note to the regional dialect dataset.

### ✨ Changes Made

* Added **〜やねん** as a new Kansai dialect entry.
* Added the standard Japanese equivalent: **〜なんだ**
* Added the English meaning: **it is that...**
* Added the region: **Kansai**
* Added the usage note: **Explanatory ending in conversation. (Set 1)**
* Maintained valid JSON formatting.

### 📁 File Changed

`community/content/japanese-regional-dialects.json`

### 🔗 Related Issue

Closes #30049 

### ✅ Checklist

* [x] Added the requested dialect entry
* [x] Maintained valid JSON syntax
* [x] Followed the contribution instructions
* [x] No unrelated changes were made

Thank you for reviewing this contribution! 🙌
