### PR TITLE
content: add new japanese proverb

### DIFF
--- a/community/content/japanese-proverbs.json
+++ b/community/content/japanese-proverbs.json
@@ -394,5 +394,11 @@
     "romaji": "Kaeru no ko wa kaeru",
     "english": "A frog's child is a frog",
     "meaning": "Children resemble their parents"
+  },
+  {
+    "japanese": "口は禍の元",
+    "romaji": "Kuchi wa wazawai no moto",
+    "english": "The mouth is the source of misfortune",
+    "meaning": "Careless words cause trouble"
   }
 ]


### PR DESCRIPTION
Closes #30041

## What does this PR do?
Adds Japanese Proverb #169 to \community/content/japanese-proverbs.json\.

## The Proverb Added
| Japanese | Reading | English |
|----------|---------|---------|
| **口は禍の元** | Kuchi wa wazawai no moto | The mouth is the source of misfortune |

> 💡 **Meaning:** Careless words cause trouble

## Checklist
- [x] Forked the repo
- [x] Added the proverb object before the closing \]\
- [x] Ensured valid JSON (no trailing comma)
- [x] PR title follows the format: \content: add new japanese proverb\
