### PR TITLE
content: add new common mistake

### DIFF
--- a/community/content/japanese-common-mistakes.json
+++ b/community/content/japanese-common-mistakes.json
@@ -183,5 +183,10 @@
     "wrong": "これはおいしいだ。",
     "correct": "これはおいしい。",
     "explanation": "い-adjectives do not take だ in plain present. (Pattern set 5)"
+  },
+  {
+    "wrong": "日本語をわかります。",
+    "correct": "日本語がわかります。",
+    "explanation": "わかる takes が. (Pattern set 4)"
   }
 ]


### PR DESCRIPTION
## 📝 Description

Adds the learner mistake pair requested in #30167 to `community/content/japanese-common-mistakes.json`:

```json
{
  "wrong": "日本語をわかります。",
  "correct": "日本語がわかります。",
  "explanation": "わかる takes が. (Pattern set 4)"
}
```

わかる marks its object with が rather than を, which is one of the particle mix-ups beginners hit early on. The entry is appended at the end of the array, using the same three keys and indentation as the surrounding entries, and nothing else in the file is touched.

## 🔗 Related Issue

Closes #30167

## ✅ Pre-Submission Checklist

- [ ] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change

- [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] `feat`: New feature (non-breaking change which adds functionality)
- [ ] `docs`: Documentation update (e.g., this file, README)
- [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
- [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
- [ ] `refactor`: Code refactor (no functional changes)
- [ ] `test`: Test update (adding missing tests or correcting existing tests)
- [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Ran the same JSON syntax validation the community-content PR check runs (`JSON.parse` on the changed file) — it parses cleanly.
2. Confirmed the array now holds 38 entries and the new one has the expected `wrong` / `correct` / `explanation` keys.

## 📸 Screenshots/Videos (if applicable)

Not applicable — data-only change.

## 📦 Additional Context

Content-only change; no application code touched.
