### PR TITLE
content: add grammar point 72

### DIFF
--- a/community/content/japanese-grammar.json
+++ b/community/content/japanese-grammar.json
@@ -34,5 +34,6 @@
   "\"〜なら\" means \"if\" or \"in the case of\" and often gives advice. (practice variation 19)",
   "\"〜ていく/〜てくる\" shows direction or change over time, like \"will start\" or \"have been\". (practice variation 33)",
   "\"〜ことになる\" indicates something was decided (by others or circumstances).",
-  "\"〜にとって\" means \"for / to (someone)\"."
+  "\"〜にとって\" means \"for / to (someone)\".",
+  "\"〜て以来\" means \"since (doing)\"."
 ]


### PR DESCRIPTION
## 📝 Description

Added Grammar Point 72 to the Japanese grammar content:

`〜て以来` means `since (doing)`.

## 🔗 Related Issue

Closes #30159

## ✅ Pre-Submission Checklist

* [x] I have starred the repo ⭐
* [x] My code follows the project's code style and uses `cn()` utility where needed
* [ ] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
* [x] My commit messages follow the [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) format
* [ ] I have updated the documentation (if applicable) 📖
* [x] This PR is against the `main` branch

## 🎯 Type of Change

* [ ] `fix`: Bug fix (non-breaking change which fixes an issue)
* [ ] `feat`: New feature (non-breaking change which adds functionality)
* [ ] `docs`: Documentation update (e.g., this file, README)
* [x] `content`: Content update (e.g., new kanji, vocab, or fonts in `/static/`)
* [ ] `style`: UI/Theme changes (e.g., Tailwind, CSS, new themes)
* [ ] `refactor`: Code refactor (no functional changes)
* [ ] `test`: Test update (adding missing tests or correcting existing tests)
* [ ] `chore`: Build, CI/CD, or dependency updates

## 🧪 How Has This Been Tested?

**Test Steps:**

1. Validated `community/content/japanese-grammar.json` with Python's JSON validator.
2. Ran `git diff --check` to verify there are no whitespace errors.

## 📸 Screenshots/Videos (if applicable)

Not applicable — this is a content-only change.

## 📦 Additional Context

This change addresses Grammar Point 72 from issue #30159.