### PR TITLE
fix(tts): speak even when the browser reports no voices (#30123)

### DIFF
--- a/features/Preferences/__tests__/useJapaneseTTS.test.tsx
+++ b/features/Preferences/__tests__/useJapaneseTTS.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor, cleanup } from '@testing-library/react';
+import { useJapaneseTTS } from '@/features/Preferences/hooks/useJapaneseTTS';
+
+vi.mock('@/features/Preferences', () => ({
+  useAudioPreferences: () => ({
+    pronunciationEnabled: true,
+    pronunciationVoiceName: null,
+    setPronunciationVoiceName: vi.fn(),
+  }),
+}));
+
+/**
+ * Brave with fingerprint blocking on, and some other engines, never populate
+ * getVoices() but still speak a plain utterance. This stands in for that.
+ */
+const stubSpeechSynthesis = (voices: SpeechSynthesisVoice[]) => {
+  const spoken: SpeechSynthesisUtterance[] = [];
+
+  vi.stubGlobal(
+    'SpeechSynthesisUtterance',
+    class {
+      text: string;
+      lang = '';
+      rate = 1;
+      pitch = 1;
+      volume = 1;
+      voice: SpeechSynthesisVoice | null = null;
+      onstart: (() => void) | null = null;
+      onend: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      constructor(text: string) {
+        this.text = text;
+      }
+    },
+  );
+
+  vi.stubGlobal('speechSynthesis', {
+    speaking: false,
+    pending: false,
+    cancel: vi.fn(),
+    getVoices: () => voices,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    speak: (utterance: SpeechSynthesisUtterance) => {
+      spoken.push(utterance);
+      utterance.onstart?.(new Event('start') as SpeechSynthesisEvent);
+      utterance.onend?.(new Event('end') as SpeechSynthesisEvent);
+    },
+  });
+
+  return spoken;
+};
+
+describe('useJapaneseTTS speak', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    // Unmount before the globals go away, or the cleanup effect that removes
+    // the voiceschanged listener throws.
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('still speaks when the browser reports no voices', async () => {
+    const spoken = stubSpeechSynthesis([]);
+    const { result } = renderHook(() => useJapaneseTTS());
+
+    await act(async () => {
+      const speaking = result.current.speak('しゅ');
+      // The hook retries getVoices ten times before giving up on the list.
+      await vi.advanceTimersByTimeAsync(3000);
+      await speaking;
+    });
+
+    await waitFor(() => expect(spoken).toHaveLength(1));
+    expect(spoken[0].text).toBe('しゅ');
+    expect(spoken[0].lang).toBe('ja-JP');
+    // No voice to choose from, so the engine picks its own.
+    expect(spoken[0].voice).toBeNull();
+  });
+  it('still prefers a Japanese voice when the browser reports one', async () => {
+    const jaVoice = { name: 'Kyoko', lang: 'ja-JP' } as SpeechSynthesisVoice;
+    const enVoice = { name: 'Daniel', lang: 'en-GB' } as SpeechSynthesisVoice;
+    const spoken = stubSpeechSynthesis([enVoice, jaVoice]);
+    const { result } = renderHook(() => useJapaneseTTS());
+
+    await act(async () => {
+      const speaking = result.current.speak('しゅ');
+      await vi.advanceTimersByTimeAsync(3000);
+      await speaking;
+    });
+
+    await waitFor(() => expect(spoken).toHaveLength(1));
+    expect(spoken[0].voice).toBe(jaVoice);
+  });
+});

--- a/features/Preferences/hooks/useJapaneseTTS.ts
+++ b/features/Preferences/hooks/useJapaneseTTS.ts
@@ -209,10 +209,14 @@ export const useJapaneseTTS = () => {
                 );
                 return;
               } else {
-                console.warn('No voices available after retries');
-                setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
-                resolve();
-                return;
+                // Some browsers never populate getVoices(), notably Brave with
+                // fingerprint blocking on, but still speak when given an
+                // utterance. Bailing out here left the click silent with no
+                // explanation, so fall through and let the engine pick a voice
+                // for ja-JP itself.
+                console.warn(
+                  'No voices reported, speaking with the browser default',
+                );
               }
             }
 
@@ -275,8 +279,9 @@ export const useJapaneseTTS = () => {
                   return 0;
                 });
                 utterance.voice = sortedJapanese[0];
-              } else {
-                // Fallback to matched voice or any voice
+              } else if (matchedVoice || voices[0]) {
+                // Fallback to matched voice or any voice. With no voices at
+                // all, leave it unset so the engine picks one.
                 utterance.voice = matchedVoice || voices[0];
               }
             } else {
@@ -328,22 +333,18 @@ export const useJapaneseTTS = () => {
               resolve();
             };
 
-            // Speak only if we have a voice set
-            if (utterance.voice) {
-              stopCurrentSpeech();
-              setTimeout(() => {
-                if (requestId !== speakRequestIdRef.current) {
-                  resolve();
-                  return;
-                }
+            // An unset voice is still worth speaking: the engine falls back to
+            // its own default for utterance.lang. Requiring one here meant a
+            // browser that hides its voice list stayed silent on every click.
+            stopCurrentSpeech();
+            setTimeout(() => {
+              if (requestId !== speakRequestIdRef.current) {
+                resolve();
+                return;
+              }
 
-                speechSynthesis.speak(utterance);
-              }, 50);
-            } else {
-              console.warn('Could not set voice for speech synthesis');
-              setState((prev: TTSState) => ({ ...prev, isPlaying: false }));
-              resolve();
-            }
+              speechSynthesis.speak(utterance);
+            }, 50);
           } catch (error) {
             console.warn('Speech synthesis error:', error);
             setState((prev: TTSState) => ({ ...prev, isPlaying: false }));


### PR DESCRIPTION
## 📝 Description

Pronunciation audio never plays in browsers that hide their speech synthesis voice list, which is what #30123 reports from Brave.

`speak()` in `features/Preferences/hooks/useJapaneseTTS.ts` only reached `speechSynthesis.speak()` once it had selected a specific voice:

```js
// Speak only if we have a voice set
if (utterance.voice) {
  ...
} else {
  console.warn('Could not set voice for speech synthesis');
  setState(prev => ({ ...prev, isPlaying: false }));
  resolve();
}
```

There was an earlier bail too, when `getVoices()` was still empty after the retries. Brave with fingerprint blocking on returns an empty list, so no voice was ever selected and every click resolved silently. UI click sounds kept working because those are plain `Audio` objects and never go through this path, which is exactly the asymmetry in the report.

An utterance does not need an explicit voice. With `lang` set to `ja-JP` the engine falls back to its own default, so both bail-outs can go and the voice is simply left unset when there is nothing to pick from.

Japanese voice selection is unchanged whenever the browser does report voices.

Worth noting the triage notes on the issue point elsewhere. Pronunciation does not use audio files, so there are no broken URLs or third party audio host involved.

## 🔗 Related Issue

Closes #30123

## ✅ Pre-Submission Checklist

- [x] I have starred the repo ⭐
- [x] My code follows the project's code style and uses `cn()` utility where needed
- [x] I have run `npm run check` locally and there are no TypeScript/ESLint errors 🐞
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have updated the documentation (if applicable) 📖
- [x] This PR is against the `main` branch

## 🎯 Type of Change

- [x] `fix`: Bug fix (non-breaking change which fixes an issue)

## 🧪 How Has This Been Tested?

**Test Steps:**

1. In a browser, stubbed `speechSynthesis.getVoices()` to return an empty array to stand in for Brave with fingerprint blocking, then spoke an utterance with `lang = 'ja-JP'` and no explicit voice. `onstart` fires, so the engine does speak without an enumerated voice. That is the basis for the fix.
2. Added two tests. One asserts that `speak()` still reaches `speechSynthesis.speak()` when the browser reports no voices, and it fails on `main` and passes with this change. The other asserts a Japanese voice is still preferred when one is reported, so the existing selection is not regressed.

`npx vitest run features/Preferences/__tests__/useJapaneseTTS.test.tsx` passes. `tsc --noEmit` is clean, and `eslint` reports no new problems in the touched files.

One limit I want to be upfront about: I cannot verify that Brave then produces audible sound on the reporter's machine, only that the app no longer refuses to try. The change also covers any other engine that hides its voice list.

## 📦 Additional Context

The `check` failure on this PR is not from this change. `npm run check` currently fails on `main` with two `react-hooks/refs` errors in `shared/hooks/generic/useSessionScrollRestoration.ts`, which #30045 fixes. Every code PR since 31 Aug has been red for that reason.
